### PR TITLE
ci: ドキュメント変更時のCI実行をスキップ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.kiro/**'
+      - 'LICENSE'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.kiro/**'
+      - 'LICENSE'
 
 jobs:
   ci:


### PR DESCRIPTION
## 概要

ドキュメントのみの変更時にCIを実行しないよう最適化。

## 変更内容

* `.github/workflows/ci.yml` に `paths-ignore` を追加
* 以下のファイル変更時はCIをスキップ:
  - `**.md` (Markdownファイル)
  - `docs/**` (ドキュメントディレクトリ)
  - `.kiro/**` (Kiro仕様ファイル)
  - `LICENSE` (ライセンスファイル)

## 影響範囲

* ドキュメントのみの変更でCIが実行されなくなる
* コード変更時のCIは従来通り実行される