### PR TITLE
docs: cc-sdd開発ワークフローをREADMEに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,98 @@ thac/
 - `bun run db:studio`: データベーススタジオUIを開く
 - `cd packages/db && bun run db:local`: ローカルSQLiteデータベースを起動
 - `bun run check`: Biomeによるフォーマットとlintを実行
+
+## 開発ワークフロー（cc-sdd）
+
+本プロジェクトはSpec-Driven Development（仕様駆動開発）を採用しています。
+Claude Codeのスラッシュコマンドを使用して、仕様策定から実装まで一貫したワークフローで開発を行います。
+
+### ワークフロー概要
+
+```
+Phase 0: Steering（プロジェクト設定）
+    ↓
+Phase 1: Specification（仕様策定）
+    spec-init → spec-requirements → spec-design → spec-tasks
+    ↓
+Phase 2: Implementation（実装）
+    spec-impl
+```
+
+### スラッシュコマンド一覧
+
+#### Phase 0: プロジェクト設定（オプション）
+
+| コマンド | 説明 |
+|---------|------|
+| `/kiro:steering` | ステアリングドキュメントの管理 |
+| `/kiro:steering-custom` | カスタムステアリングの作成 |
+
+#### Phase 1: 仕様策定
+
+| コマンド | 説明 |
+|---------|------|
+| `/kiro:spec-init "機能の説明"` | 新規仕様の初期化 |
+| `/kiro:spec-requirements {feature}` | 要件定義の生成 |
+| `/kiro:spec-design {feature} [-y]` | 技術設計の作成 |
+| `/kiro:spec-tasks {feature} [-y]` | 実装タスクの生成 |
+
+#### Phase 2: 実装
+
+| コマンド | 説明 |
+|---------|------|
+| `/kiro:spec-impl {feature} [task-numbers]` | TDD方式で実装 |
+
+#### バリデーション（オプション）
+
+| コマンド | 説明 |
+|---------|------|
+| `/kiro:validate-gap {feature}` | 既存コードベースとのギャップ分析 |
+| `/kiro:validate-design {feature}` | 技術設計のレビュー |
+| `/kiro:validate-impl {feature}` | 実装の検証 |
+
+#### 進捗確認
+
+| コマンド | 説明 |
+|---------|------|
+| `/kiro:spec-status {feature}` | 仕様のステータスと進捗を表示 |
+
+### ディレクトリ構成
+
+```
+.kiro/
+├── steering/           # プロジェクト共通の方針
+│   ├── product.md      # プロダクト概要
+│   ├── tech.md         # 技術スタック
+│   └── structure.md    # プロジェクト構造
+└── specs/              # 機能ごとの仕様書
+    └── {feature}/
+        ├── spec.json       # メタデータ
+        ├── requirements.md # 要件定義
+        ├── design.md       # 技術設計
+        └── tasks.md        # 実装タスク
+```
+
+### 開発フローの例
+
+新機能「ユーザープロフィール」を追加する場合：
+
+```bash
+# 1. 仕様の初期化
+/kiro:spec-init "ユーザープロフィール機能"
+
+# 2. 要件定義（レビュー後に承認）
+/kiro:spec-requirements user-profile
+
+# 3. 技術設計（-y で自動承認、または対話式でレビュー）
+/kiro:spec-design user-profile
+
+# 4. 実装タスクの生成
+/kiro:spec-tasks user-profile
+
+# 5. 実装（TDD方式）
+/kiro:spec-impl user-profile
+
+# 進捗確認（いつでも実行可能）
+/kiro:spec-status user-profile
+```


### PR DESCRIPTION
## 概要

READMEにcc-sdd（Claude Code Spec-Driven Development）を使用した開発ワークフローを追加しました。

## 変更内容

* 開発ワークフロー（cc-sdd）セクションを追加
  * ワークフロー概要（Phase 0〜2の流れ図）
  * スラッシュコマンド一覧（テーブル形式）
  * バリデーションコマンド（オプション）
  * ディレクトリ構成
  * 具体的な開発フローの例

## 影響範囲

ドキュメントのみの変更のため、アプリケーションへの影響はありません。