### PR TITLE
fix: Docker環境でのSSR認証エラーを修正

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,7 +1,17 @@
 import { adminClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
+// SSR時はSERVER_URL（Docker内部通信用）、クライアント側はVITE_SERVER_URL（ブラウザ用）を使用
+const getBaseURL = () => {
+	if (typeof window === "undefined") {
+		// サーバーサイド（SSR）
+		return process.env.SERVER_URL || import.meta.env.VITE_SERVER_URL;
+	}
+	// クライアントサイド
+	return import.meta.env.VITE_SERVER_URL;
+};
+
 export const authClient = createAuthClient({
-	baseURL: import.meta.env.VITE_SERVER_URL,
+	baseURL: getBaseURL(),
 	plugins: [adminClient()],
 });

--- a/apps/web/src/middleware/auth.ts
+++ b/apps/web/src/middleware/auth.ts
@@ -3,14 +3,13 @@ import { authClient } from "@/lib/auth-client";
 
 export const authMiddleware = createMiddleware().server(
 	async ({ next, request }) => {
-		const session = await authClient.getSession({
+		const { data: session } = await authClient.getSession({
 			fetchOptions: {
 				headers: request.headers,
-				throw: true,
 			},
 		});
 		return next({
-			context: { session },
+			context: { session: session ?? null },
 		});
 	},
 );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - node_modules:/app/node_modules
     environment:
       - VITE_SERVER_URL=http://localhost:3000
+      - SERVER_URL=http://server:3000
     healthcheck:
       test: ["CMD", "bun", "-e", "await fetch('http://localhost:3001').catch(() => process.exit(1))"]
       interval: 30s


### PR DESCRIPTION
## 概要

Docker環境で `/dashboard` にアクセスすると500エラーが発生する問題を修正

## 問題の原因

1. `authMiddleware`で`throw: true`を設定していたため、未認証時にエラーがスローされ、`loader`でのリダイレクト処理に到達しなかった
2. Docker環境のSSR時、`localhost:3000`へのアクセスがコンテナ内で解決できず`ConnectionRefused`エラーが発生していた

## 変更内容

* `apps/web/src/middleware/auth.ts`: `throw: true`を削除し、未認証時もエラーをスローしないように変更
* `apps/web/src/lib/auth-client.ts`: SSR時は`SERVER_URL`（Docker内部通信用）、クライアント側は`VITE_SERVER_URL`（ブラウザ用）を使い分けるように修正
* `docker-compose.yml`: webサービスに`SERVER_URL=http://server:3000`環境変数を追加

## 影響範囲

* 認証関連のミドルウェア処理
* Docker環境でのSSR動作