### PR TITLE
fix: Turso接続のECONNRESETエラーに対応するリトライ機能を追加

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,9 +2,37 @@ import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import * as schema from "./schema";
 
+// リトライ機能付きfetch
+const fetchWithRetry = async (
+	input: string | URL | Request,
+	init?: RequestInit,
+): Promise<Response> => {
+	const maxRetries = 3;
+	const baseDelay = 1000; // 1秒
+
+	for (let attempt = 0; attempt < maxRetries; attempt++) {
+		try {
+			return await fetch(input, init);
+		} catch (error) {
+			const isLastAttempt = attempt === maxRetries - 1;
+			if (isLastAttempt) {
+				throw error;
+			}
+
+			// 指数バックオフで待機
+			const delay = baseDelay * 2 ** attempt;
+			await new Promise((resolve) => setTimeout(resolve, delay));
+		}
+	}
+
+	// TypeScript用（到達しない）
+	throw new Error("Unexpected: all retries exhausted");
+};
+
 const client = createClient({
 	url: process.env.DATABASE_URL || "",
 	authToken: process.env.DATABASE_AUTH_TOKEN,
+	fetch: fetchWithRetry,
 });
 
 export const db = drizzle({ client, schema });


### PR DESCRIPTION
## 概要

Docker環境でTurso接続時に発生する一時的なネットワークエラー（ECONNRESET）に対応するリトライ機能を追加

## 問題の原因

Docker環境でサーバー起動直後にTursoへの接続が一時的に失敗し、`ECONNRESET`エラーが発生していた。数秒後にリトライすると成功するため、一時的なネットワーク不安定が原因と判断。

## 変更内容

* libsqlクライアントに指数バックオフ付きリトライ機能を追加
  * 最大3回リトライ
  * 待機時間: 1秒 → 2秒 → 4秒

## 影響範囲

* `packages/db/src/index.ts` - データベースクライアントの初期化処理