### PR TITLE
feat: 文字種と頭文字の列順序を入れ替え

### DIFF
--- a/apps/web/src/routes/admin/_admin/artists.tsx
+++ b/apps/web/src/routes/admin/_admin/artists.tsx
@@ -218,8 +218,8 @@ function ArtistsPage() {
 									<TableHead>名前</TableHead>
 									<TableHead className="w-[150px]">日本語名</TableHead>
 									<TableHead className="w-[150px]">英語名</TableHead>
-									<TableHead className="w-[120px]">頭文字</TableHead>
 									<TableHead className="w-[120px]">文字種</TableHead>
+									<TableHead className="w-[120px]">頭文字</TableHead>
 									<TableHead className="w-[70px]" />
 								</TableRow>
 							</TableHeader>
@@ -245,9 +245,6 @@ function ArtistsPage() {
 											<TableCell className="text-base-content/70">
 												{artist.nameEn || "-"}
 											</TableCell>
-											<TableCell className="font-mono">
-												{artist.nameInitial || "-"}
-											</TableCell>
 											<TableCell>
 												<Badge
 													variant={
@@ -257,6 +254,10 @@ function ArtistsPage() {
 													{INITIAL_SCRIPT_LABELS[artist.initialScript]}
 												</Badge>
 											</TableCell>
+											<TableCell className="font-mono">
+												{artist.nameInitial || "-"}
+											</TableCell>
+
 											<TableCell>
 												<div className="flex items-center gap-1">
 													<Button

--- a/apps/web/src/routes/admin/_admin/circles.tsx
+++ b/apps/web/src/routes/admin/_admin/circles.tsx
@@ -413,8 +413,8 @@ function CirclesPage() {
 									<TableHead>名前</TableHead>
 									<TableHead className="w-[150px]">日本語名</TableHead>
 									<TableHead className="w-[150px]">英語名</TableHead>
-									<TableHead className="w-[100px]">頭文字</TableHead>
-									<TableHead className="w-[120px]">文字種</TableHead>
+									<TableHead className="w-[100px]">文字種</TableHead>
+									<TableHead className="w-[120px]">頭文字</TableHead>
 									<TableHead className="w-[70px]" />
 								</TableRow>
 							</TableHeader>
@@ -440,9 +440,6 @@ function CirclesPage() {
 											<TableCell className="text-base-content/70">
 												{circle.nameEn || "-"}
 											</TableCell>
-											<TableCell className="font-mono">
-												{circle.nameInitial || "-"}
-											</TableCell>
 											<TableCell>
 												<Badge
 													variant={
@@ -452,6 +449,10 @@ function CirclesPage() {
 													{INITIAL_SCRIPT_LABELS[circle.initialScript]}
 												</Badge>
 											</TableCell>
+											<TableCell className="font-mono">
+												{circle.nameInitial || "-"}
+											</TableCell>
+
 											<TableCell>
 												<div className="flex items-center gap-1">
 													<Button


### PR DESCRIPTION
## 概要

アーティスト管理とサークル管理の一覧画面で、テーブルの「文字種」と「頭文字」の列順序を入れ替え

## 変更内容

* アーティスト管理一覧: 文字種 → 頭文字 の順に変更
* サークル管理一覧: 文字種 → 頭文字 の順に変更

## 影響範囲

* `apps/web/src/routes/admin/_admin/artists.tsx`
* `apps/web/src/routes/admin/_admin/circles.tsx`