### PR TITLE
feat: 管理画面一覧ページにカラム表示切り替え機能を追加

### DIFF
--- a/apps/web/src/components/admin/column-visibility-toggle.tsx
+++ b/apps/web/src/components/admin/column-visibility-toggle.tsx
@@ -1,0 +1,55 @@
+import { Settings2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { ColumnConfig } from "@/hooks/use-column-visibility";
+
+interface ColumnVisibilityToggleProps {
+	columns: ColumnConfig[];
+	visibleColumns: Set<string>;
+	onToggle: (key: string) => void;
+}
+
+function ColumnVisibilityToggle({
+	columns,
+	visibleColumns,
+	onToggle,
+}: ColumnVisibilityToggleProps) {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button variant="outline" size="md" className="gap-1.5">
+					<Settings2 className="h-4 w-4" />
+					表示列
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-48">
+				<DropdownMenuLabel>表示する列</DropdownMenuLabel>
+				<DropdownMenuSeparator />
+				<div className="max-h-64 overflow-y-auto">
+					{columns.map((column) => (
+						<label
+							key={column.key}
+							className="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-base-200"
+						>
+							<Checkbox
+								checked={visibleColumns.has(column.key)}
+								onCheckedChange={() => onToggle(column.key)}
+							/>
+							<span className="text-sm">{column.label}</span>
+						</label>
+					))}
+				</div>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+export { ColumnVisibilityToggle };
+export type { ColumnVisibilityToggleProps };

--- a/apps/web/src/components/admin/data-table-action-bar.tsx
+++ b/apps/web/src/components/admin/data-table-action-bar.tsx
@@ -1,5 +1,6 @@
 import { EllipsisVertical, Plus } from "lucide-react";
 import type * as React from "react";
+import { ColumnVisibilityToggle } from "@/components/admin/column-visibility-toggle";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -9,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SearchInput } from "@/components/ui/search-input";
 import { Select } from "@/components/ui/select";
+import type { ColumnConfig } from "@/hooks/use-column-visibility";
 import { cn } from "@/lib/utils";
 
 interface FilterOption {
@@ -20,6 +22,12 @@ interface SecondaryAction {
 	label: string;
 	icon?: React.ReactNode;
 	onClick: () => void;
+}
+
+interface ColumnVisibilityConfig {
+	columns: ColumnConfig[];
+	visibleColumns: Set<string>;
+	onToggle: (key: string) => void;
 }
 
 interface DataTableActionBarProps extends React.ComponentProps<"div"> {
@@ -35,6 +43,7 @@ interface DataTableActionBarProps extends React.ComponentProps<"div"> {
 		onClick: () => void;
 	};
 	secondaryActions?: SecondaryAction[];
+	columnVisibility?: ColumnVisibilityConfig;
 }
 
 function DataTableActionBar({
@@ -47,6 +56,7 @@ function DataTableActionBar({
 	onFilterChange,
 	primaryAction,
 	secondaryActions,
+	columnVisibility,
 	className,
 	children,
 	...props
@@ -88,6 +98,13 @@ function DataTableActionBar({
 				{children}
 			</div>
 			<div className="flex items-center gap-2">
+				{columnVisibility && (
+					<ColumnVisibilityToggle
+						columns={columnVisibility.columns}
+						visibleColumns={columnVisibility.visibleColumns}
+						onToggle={columnVisibility.onToggle}
+					/>
+				)}
 				{primaryAction && (
 					<Button
 						variant="primary"
@@ -122,4 +139,9 @@ function DataTableActionBar({
 }
 
 export { DataTableActionBar };
-export type { DataTableActionBarProps, FilterOption, SecondaryAction };
+export type {
+	ColumnVisibilityConfig,
+	DataTableActionBarProps,
+	FilterOption,
+	SecondaryAction,
+};

--- a/apps/web/src/hooks/use-column-visibility.ts
+++ b/apps/web/src/hooks/use-column-visibility.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from "react";
+
+export interface ColumnConfig {
+	key: string;
+	label: string;
+	defaultVisible?: boolean; // デフォルトtrue、falseでデフォルト非表示
+}
+
+export interface UseColumnVisibilityReturn {
+	visibleColumns: Set<string>;
+	toggleColumn: (key: string) => void;
+	isVisible: (key: string) => boolean;
+	columnConfigs: ColumnConfig[];
+}
+
+function getStorageKey(key: string): string {
+	return `column-visibility:${key}`;
+}
+
+function loadVisibility(
+	storageKey: string,
+	columns: ColumnConfig[],
+): Set<string> {
+	if (typeof window === "undefined") {
+		// SSR時はデフォルト値を返す
+		return new Set(
+			columns
+				.filter((col) => col.defaultVisible !== false)
+				.map((col) => col.key),
+		);
+	}
+
+	try {
+		const stored = localStorage.getItem(getStorageKey(storageKey));
+		if (stored) {
+			const parsed = JSON.parse(stored) as string[];
+			return new Set(parsed);
+		}
+	} catch {
+		// パースエラー時はデフォルト値を使用
+	}
+
+	// デフォルト値: defaultVisible !== false のカラムを表示
+	return new Set(
+		columns.filter((col) => col.defaultVisible !== false).map((col) => col.key),
+	);
+}
+
+function saveVisibility(storageKey: string, visibleColumns: Set<string>): void {
+	if (typeof window === "undefined") return;
+
+	try {
+		localStorage.setItem(
+			getStorageKey(storageKey),
+			JSON.stringify([...visibleColumns]),
+		);
+	} catch {
+		// ストレージエラーは無視
+	}
+}
+
+export function useColumnVisibility(
+	storageKey: string,
+	columns: ColumnConfig[],
+): UseColumnVisibilityReturn {
+	const [visibleColumns, setVisibleColumns] = useState<Set<string>>(() =>
+		loadVisibility(storageKey, columns),
+	);
+
+	// マウント時にlocalStorageから読み込み（SSR対応）
+	useEffect(() => {
+		setVisibleColumns(loadVisibility(storageKey, columns));
+	}, [storageKey, columns]);
+
+	// 変更時に保存
+	useEffect(() => {
+		saveVisibility(storageKey, visibleColumns);
+	}, [storageKey, visibleColumns]);
+
+	const toggleColumn = useCallback((key: string) => {
+		setVisibleColumns((prev) => {
+			const next = new Set(prev);
+			if (next.has(key)) {
+				next.delete(key);
+			} else {
+				next.add(key);
+			}
+			return next;
+		});
+	}, []);
+
+	const isVisible = useCallback(
+		(key: string) => visibleColumns.has(key),
+		[visibleColumns],
+	);
+
+	return {
+		visibleColumns,
+		toggleColumn,
+		isVisible,
+		columnConfigs: columns,
+	};
+}

--- a/apps/web/src/routes/admin/_admin/official/works.tsx
+++ b/apps/web/src/routes/admin/_admin/official/works.tsx
@@ -1,7 +1,9 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
 import { Pencil, Trash2, Upload } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { DataTableActionBar } from "@/components/admin/data-table-action-bar";
 import { DataTablePagination } from "@/components/admin/data-table-pagination";
@@ -27,6 +29,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
 import {
 	importApi,
@@ -39,6 +42,17 @@ export const Route = createFileRoute("/admin/_admin/official/works")({
 	component: OfficialWorksPage,
 });
 
+// カラム定義
+const COLUMN_CONFIGS = [
+	{ key: "id", label: "ID", defaultVisible: false },
+	{ key: "nameJa", label: "作品名" },
+	{ key: "categoryCode", label: "カテゴリ" },
+	{ key: "seriesCode", label: "シリーズ" },
+	{ key: "releaseDate", label: "発売日" },
+	{ key: "createdAt", label: "作成日時", defaultVisible: false },
+	{ key: "updatedAt", label: "更新日時", defaultVisible: false },
+] as const;
+
 function OfficialWorksPage() {
 	const queryClient = useQueryClient();
 
@@ -50,6 +64,13 @@ function OfficialWorksPage() {
 
 	// API呼び出し用にデバウンス（300ms）
 	const debouncedSearch = useDebounce(search, 300);
+
+	// カラム表示設定
+	const columnConfigs = useMemo(() => [...COLUMN_CONFIGS], []);
+	const { visibleColumns, toggleColumn, isVisible } = useColumnVisibility(
+		"admin:official:works",
+		columnConfigs,
+	);
 
 	const [editingWork, setEditingWork] = useState<OfficialWork | null>(null);
 	const [editForm, setEditForm] = useState<Partial<OfficialWork>>({});
@@ -188,6 +209,11 @@ function OfficialWorksPage() {
 					filterValue={category}
 					filterPlaceholder="カテゴリを選択"
 					onFilterChange={handleCategoryChange}
+					columnVisibility={{
+						columns: columnConfigs,
+						visibleColumns,
+						onToggle: toggleColumn,
+					}}
 					primaryAction={{
 						label: "新規作成",
 						onClick: () => setIsCreateDialogOpen(true),
@@ -219,11 +245,25 @@ function OfficialWorksPage() {
 						<Table zebra>
 							<TableHeader>
 								<TableRow className="hover:bg-transparent">
-									<TableHead className="w-[150px]">ID</TableHead>
-									<TableHead>作品名</TableHead>
-									<TableHead className="w-[120px]">カテゴリ</TableHead>
-									<TableHead className="w-[100px]">シリーズ</TableHead>
-									<TableHead className="w-[100px]">発売日</TableHead>
+									{isVisible("id") && (
+										<TableHead className="w-[150px]">ID</TableHead>
+									)}
+									{isVisible("nameJa") && <TableHead>作品名</TableHead>}
+									{isVisible("categoryCode") && (
+										<TableHead className="w-[120px]">カテゴリ</TableHead>
+									)}
+									{isVisible("seriesCode") && (
+										<TableHead className="w-[100px]">シリーズ</TableHead>
+									)}
+									{isVisible("releaseDate") && (
+										<TableHead className="w-[100px]">発売日</TableHead>
+									)}
+									{isVisible("createdAt") && (
+										<TableHead className="w-[160px]">作成日時</TableHead>
+									)}
+									{isVisible("updatedAt") && (
+										<TableHead className="w-[160px]">更新日時</TableHead>
+									)}
 									<TableHead className="w-[70px]" />
 								</TableRow>
 							</TableHeader>
@@ -231,7 +271,7 @@ function OfficialWorksPage() {
 								{works.length === 0 ? (
 									<TableRow>
 										<TableCell
-											colSpan={6}
+											colSpan={visibleColumns.size + 1}
 											className="h-24 text-center text-base-content/50"
 										>
 											データがありません
@@ -240,21 +280,55 @@ function OfficialWorksPage() {
 								) : (
 									works.map((w) => (
 										<TableRow key={w.id}>
-											<TableCell className="font-mono text-sm">
-												{w.id}
-											</TableCell>
-											<TableCell className="font-medium">{w.nameJa}</TableCell>
-											<TableCell>
-												<Badge variant="secondary">
-													{getCategoryName(w.categoryCode)}
-												</Badge>
-											</TableCell>
-											<TableCell className="font-mono text-sm">
-												{w.seriesCode || "-"}
-											</TableCell>
-											<TableCell className="text-sm">
-												{w.releaseDate || "-"}
-											</TableCell>
+											{isVisible("id") && (
+												<TableCell className="font-mono text-sm">
+													{w.id}
+												</TableCell>
+											)}
+											{isVisible("nameJa") && (
+												<TableCell className="font-medium">
+													{w.nameJa}
+												</TableCell>
+											)}
+											{isVisible("categoryCode") && (
+												<TableCell>
+													<Badge variant="secondary">
+														{getCategoryName(w.categoryCode)}
+													</Badge>
+												</TableCell>
+											)}
+											{isVisible("seriesCode") && (
+												<TableCell className="font-mono text-sm">
+													{w.seriesCode || "-"}
+												</TableCell>
+											)}
+											{isVisible("releaseDate") && (
+												<TableCell className="text-sm">
+													{w.releaseDate || "-"}
+												</TableCell>
+											)}
+											{isVisible("createdAt") && (
+												<TableCell className="whitespace-nowrap text-base-content/70 text-sm">
+													{format(
+														new Date(w.createdAt),
+														"yyyy/MM/dd HH:mm:ss",
+														{
+															locale: ja,
+														},
+													)}
+												</TableCell>
+											)}
+											{isVisible("updatedAt") && (
+												<TableCell className="whitespace-nowrap text-base-content/70 text-sm">
+													{format(
+														new Date(w.updatedAt),
+														"yyyy/MM/dd HH:mm:ss",
+														{
+															locale: ja,
+														},
+													)}
+												</TableCell>
+											)}
 											<TableCell>
 												<div className="flex items-center gap-1">
 													<Button


### PR DESCRIPTION
## 概要

管理画面の一覧ページにカラム表示切り替え機能を追加

## 変更内容

* `useColumnVisibility`フックを作成（localStorage永続化対応）
* `ColumnVisibilityToggle`コンポーネントを作成
* `DataTableActionBar`にカラム可視性設定を追加
* 全11ページにカラム表示切り替え機能を実装
  * ID列: デフォルト非表示（トグル可能）
  * createdAt/updatedAt列: デフォルト非表示（トグル可能）
  * 日時表示: 秒まで表示（yyyy/MM/dd HH:mm:ss形式）

## 影響範囲

* 管理画面の全一覧ページ（11ページ）
  * artists, artist-aliases, circles, events, event-series
  * songs, works, platforms
  * alias-types, credit-roles, official-work-categories

## 補足事項

* 設定はlocalStorageに保存され、ページ再読み込み後も維持される
* エンティティにフィールドが存在しない場合はカラム設定に含めない（例: platformsにはidがない）