### PR TITLE
feat: ページタイトルを動的に設定

### DIFF
--- a/apps/web/src/lib/head.ts
+++ b/apps/web/src/lib/head.ts
@@ -1,0 +1,25 @@
+export const APP_NAME = "東方編曲録";
+
+export function createPageHead(pageTitle?: string) {
+	return {
+		meta: [{ title: pageTitle ? `${pageTitle} | ${APP_NAME}` : APP_NAME }],
+	};
+}
+
+export function createTrackDetailHead(
+	trackName?: string,
+	releaseName?: string,
+) {
+	const subtitle =
+		trackName && releaseName ? `${trackName} - ${releaseName}` : "読み込み中";
+	return {
+		meta: [{ title: `トラック詳細：${subtitle} | ${APP_NAME}` }],
+	};
+}
+
+export function createReleaseDetailHead(releaseName?: string) {
+	const subtitle = releaseName || "読み込み中";
+	return {
+		meta: [{ title: `作品詳細：${subtitle} | ${APP_NAME}` }],
+	};
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { Toaster } from "@/components/ui/sonner";
+import { APP_NAME } from "@/lib/head";
 import { ThemeProvider } from "@/lib/theme";
 import Header from "../components/header";
 import appCss from "../index.css?url";
@@ -45,7 +46,7 @@ export const Route = createRootRouteWithContext<RouterAppContext>()({
 				content: "width=device-width, initial-scale=1",
 			},
 			{
-				title: "My App",
+				title: APP_NAME,
 			},
 		],
 		links: [

--- a/apps/web/src/routes/admin/_admin/artist-aliases.tsx
+++ b/apps/web/src/routes/admin/_admin/artist-aliases.tsx
@@ -42,8 +42,10 @@ import {
 	INITIAL_SCRIPT_LABELS,
 	type InitialScript,
 } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/artist-aliases")({
+	head: () => createPageHead("アーティスト名義"),
 	component: ArtistAliasesPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/artists.tsx
+++ b/apps/web/src/routes/admin/_admin/artists.tsx
@@ -40,8 +40,10 @@ import {
 	INITIAL_SCRIPT_LABELS,
 	type InitialScript,
 } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/artists")({
+	head: () => createPageHead("アーティスト"),
 	component: ArtistsPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/circles.tsx
+++ b/apps/web/src/routes/admin/_admin/circles.tsx
@@ -46,9 +46,11 @@ import {
 	type InitialScript,
 	platformsApi,
 } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 import { getExternalLinkUrl } from "@/lib/utils";
 
 export const Route = createFileRoute("/admin/_admin/circles")({
+	head: () => createPageHead("サークル"),
 	component: CirclesPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/event-series.tsx
+++ b/apps/web/src/routes/admin/_admin/event-series.tsx
@@ -35,8 +35,10 @@ import {
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
 import { type EventSeries, eventSeriesApi } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/event-series")({
+	head: () => createPageHead("イベントシリーズ"),
 	component: EventSeriesPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/events.tsx
+++ b/apps/web/src/routes/admin/_admin/events.tsx
@@ -40,8 +40,10 @@ import {
 	eventsApi,
 } from "@/lib/api-client";
 import { suggestFromEventName } from "@/lib/event-name-parser";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/events")({
+	head: () => createPageHead("イベント"),
 	component: EventsPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/index.tsx
+++ b/apps/web/src/routes/admin/_admin/index.tsx
@@ -15,8 +15,10 @@ import {
 } from "lucide-react";
 import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { statsApi } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/")({
+	head: () => createPageHead("管理ダッシュボード"),
 	component: AdminDashboard,
 });
 

--- a/apps/web/src/routes/admin/_admin/master/alias-types.tsx
+++ b/apps/web/src/routes/admin/_admin/master/alias-types.tsx
@@ -29,8 +29,10 @@ import {
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
 import { type AliasType, aliasTypesApi, importApi } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/master/alias-types")({
+	head: () => createPageHead("名義種別"),
 	component: AliasTypesPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/master/credit-roles.tsx
+++ b/apps/web/src/routes/admin/_admin/master/credit-roles.tsx
@@ -29,8 +29,10 @@ import {
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
 import { type CreditRole, creditRolesApi, importApi } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/master/credit-roles")({
+	head: () => createPageHead("クレジット役割"),
 	component: CreditRolesPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/master/official-work-categories.tsx
+++ b/apps/web/src/routes/admin/_admin/master/official-work-categories.tsx
@@ -33,10 +33,12 @@ import {
 	type OfficialWorkCategory,
 	officialWorkCategoriesApi,
 } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute(
 	"/admin/_admin/master/official-work-categories",
 )({
+	head: () => createPageHead("公式作品カテゴリ"),
 	component: OfficialWorkCategoriesPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/master/platforms.tsx
+++ b/apps/web/src/routes/admin/_admin/master/platforms.tsx
@@ -39,8 +39,10 @@ import {
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
 import { importApi, type Platform, platformsApi } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/master/platforms")({
+	head: () => createPageHead("プラットフォーム"),
 	component: PlatformsPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/official/songs.tsx
+++ b/apps/web/src/routes/admin/_admin/official/songs.tsx
@@ -37,8 +37,10 @@ import {
 	officialSongsApi,
 	officialWorksApi,
 } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/official/songs")({
+	head: () => createPageHead("公式楽曲"),
 	component: OfficialSongsPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/official/works.tsx
+++ b/apps/web/src/routes/admin/_admin/official/works.tsx
@@ -37,8 +37,10 @@ import {
 	officialWorkCategoriesApi,
 	officialWorksApi,
 } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/official/works")({
+	head: () => createPageHead("公式作品"),
 	component: OfficialWorksPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/releases.tsx
+++ b/apps/web/src/routes/admin/_admin/releases.tsx
@@ -42,8 +42,10 @@ import {
 	type ReleaseWithDiscs,
 	releasesApi,
 } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/releases")({
+	head: () => createPageHead("作品"),
 	component: ReleasesPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/releases_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/releases_.$id.tsx
@@ -53,8 +53,11 @@ import {
 	trackCreditsApi,
 	tracksApi,
 } from "@/lib/api-client";
+import { createReleaseDetailHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/releases_/$id")({
+	loader: ({ params }) => releasesApi.get(params.id),
+	head: ({ loaderData }) => createReleaseDetailHead(loaderData?.name),
 	component: ReleaseDetailPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/tracks.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks.tsx
@@ -37,8 +37,10 @@ import {
 	type TrackWithCreditCount,
 	tracksApi,
 } from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/tracks")({
+	head: () => createPageHead("トラック"),
 	component: TracksPage,
 });
 

--- a/apps/web/src/routes/admin/_admin/tracks_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks_.$id.tsx
@@ -43,8 +43,12 @@ import {
 	trackCreditsApi,
 	tracksApi,
 } from "@/lib/api-client";
+import { createTrackDetailHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/_admin/tracks_/$id")({
+	loader: ({ params }) => tracksApi.get(params.id),
+	head: ({ loaderData }) =>
+		createTrackDetailHead(loaderData?.name, loaderData?.release?.name),
 	component: TrackDetailPage,
 });
 

--- a/apps/web/src/routes/admin/login.tsx
+++ b/apps/web/src/routes/admin/login.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 import AdminLoginForm from "@/components/admin-login-form";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/admin/login")({
+	head: () => createPageHead("管理者ログイン"),
 	component: AdminLoginPage,
 });
 

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { getUser } from "@/functions/get-user";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/dashboard")({
+	head: () => createPageHead("ダッシュボード"),
 	component: RouteComponent,
 	beforeLoad: async () => {
 		const session = await getUser();

--- a/apps/web/src/routes/go.tsx
+++ b/apps/web/src/routes/go.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { AlertTriangle, ArrowLeft, ExternalLink } from "lucide-react";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/go")({
+	head: () => createPageHead("外部リンク"),
 	validateSearch: (search: Record<string, unknown>) => ({
 		url: (search.url as string) || "",
 	}),

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -2,8 +2,10 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 import SignInForm from "@/components/sign-in-form";
 import SignUpForm from "@/components/sign-up-form";
+import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/login")({
+	head: () => createPageHead("ログイン"),
 	component: RouteComponent,
 });
 


### PR DESCRIPTION
## 概要

HTMLタイトルを「My App」から「ページ名 | 東方編曲録」形式に変更し、各ページで適切なタイトルを表示するようにした。

## 変更内容

* `apps/web/src/lib/head.ts` - タイトル生成ユーティリティを新規作成
* `apps/web/src/routes/__root.tsx` - デフォルトタイトルを「東方編曲録」に変更
* 各ルートファイル（21ファイル）- head()関数を追加してページ固有のタイトルを設定
* 作品詳細・トラック詳細ページ - loaderを使用して動的タイトルを設定

### タイトル形式

| ページ | タイトル例 |
|--------|-----------|
| トップページ | 東方編曲録 |
| 一般ページ | ダッシュボード \| 東方編曲録 |
| 作品詳細 | 作品詳細：作品名 \| 東方編曲録 |
| トラック詳細 | トラック詳細：トラック名 - 作品名 \| 東方編曲録 |

## 影響範囲

* Webアプリの全ページのHTMLタイトル

## 補足事項

* TanStack Startのhead()関数を使用してSSR対応
* 詳細ページはloaderでデータを取得し、動的にタイトルを生成