### PR TITLE
refactor: 公開リンクの不要フィールドを削除

### DIFF
--- a/apps/server/src/routes/admin/releases/publications.ts
+++ b/apps/server/src/routes/admin/releases/publications.ts
@@ -110,25 +110,6 @@ releasePublicationsRouter.post("/:releaseId/publications", async (c) => {
 		return c.json({ error: "URL already exists" }, 409);
 	}
 
-	// 一意性チェック（リリース × プラットフォーム × プラットフォーム内ID）
-	if (parsed.data.platformItemId) {
-		const duplicateCheck = await db
-			.select()
-			.from(releasePublications)
-			.where(
-				and(
-					eq(releasePublications.releaseId, releaseId),
-					eq(releasePublications.platformCode, parsed.data.platformCode),
-					eq(releasePublications.platformItemId, parsed.data.platformItemId),
-				),
-			)
-			.limit(1);
-
-		if (duplicateCheck.length > 0) {
-			return c.json({ error: "This publication link already exists" }, 409);
-		}
-	}
-
 	// 作成
 	const result = await db
 		.insert(releasePublications)

--- a/apps/server/src/routes/admin/tracks/publications.ts
+++ b/apps/server/src/routes/admin/tracks/publications.ts
@@ -110,25 +110,6 @@ trackPublicationsRouter.post("/:trackId/publications", async (c) => {
 		return c.json({ error: "URL already exists" }, 409);
 	}
 
-	// 一意性チェック（トラック × プラットフォーム × プラットフォーム内ID）
-	if (parsed.data.platformItemId) {
-		const duplicateCheck = await db
-			.select()
-			.from(trackPublications)
-			.where(
-				and(
-					eq(trackPublications.trackId, trackId),
-					eq(trackPublications.platformCode, parsed.data.platformCode),
-					eq(trackPublications.platformItemId, parsed.data.platformItemId),
-				),
-			)
-			.limit(1);
-
-		if (duplicateCheck.length > 0) {
-			return c.json({ error: "This publication link already exists" }, 409);
-		}
-	}
-
 	// 作成
 	const result = await db
 		.insert(trackPublications)

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1508,13 +1508,7 @@ export interface TrackPublication {
 	id: string;
 	trackId: string;
 	platformCode: string;
-	platformItemId: string | null;
 	url: string;
-	visibility: "public" | "unlisted" | "private" | null;
-	publishedAt: Date | null;
-	removedAt: Date | null;
-	isOfficial: boolean;
-	countryCode: string | null;
 	createdAt: Date | null;
 	updatedAt: Date | null;
 	platform?: Platform | null;
@@ -1531,12 +1525,6 @@ export const trackPublicationsApi = {
 			id: string;
 			platformCode: string;
 			url: string;
-			platformItemId?: string | null;
-			visibility?: "public" | "unlisted" | "private" | null;
-			publishedAt?: string | null;
-			removedAt?: string | null;
-			isOfficial?: boolean;
-			countryCode?: string | null;
 		},
 	) =>
 		fetchWithAuth<TrackPublication>(
@@ -1550,13 +1538,7 @@ export const trackPublicationsApi = {
 		trackId: string,
 		id: string,
 		data: {
-			platformItemId?: string | null;
 			url?: string;
-			visibility?: "public" | "unlisted" | "private" | null;
-			publishedAt?: string | null;
-			removedAt?: string | null;
-			isOfficial?: boolean;
-			countryCode?: string | null;
 		},
 	) =>
 		fetchWithAuth<TrackPublication>(
@@ -1625,13 +1607,7 @@ export interface ReleasePublication {
 	id: string;
 	releaseId: string;
 	platformCode: string;
-	platformItemId: string | null;
 	url: string;
-	visibility: "public" | "unlisted" | "private" | null;
-	publishedAt: Date | null;
-	removedAt: Date | null;
-	isOfficial: boolean;
-	countryCode: string | null;
 	createdAt: Date | null;
 	updatedAt: Date | null;
 	platform?: Platform | null;
@@ -1648,12 +1624,6 @@ export const releasePublicationsApi = {
 			id: string;
 			platformCode: string;
 			url: string;
-			platformItemId?: string | null;
-			visibility?: "public" | "unlisted" | "private" | null;
-			publishedAt?: string | null;
-			removedAt?: string | null;
-			isOfficial?: boolean;
-			countryCode?: string | null;
 		},
 	) =>
 		fetchWithAuth<ReleasePublication>(
@@ -1667,13 +1637,7 @@ export const releasePublicationsApi = {
 		releaseId: string,
 		id: string,
 		data: {
-			platformItemId?: string | null;
 			url?: string;
-			visibility?: "public" | "unlisted" | "private" | null;
-			publishedAt?: string | null;
-			removedAt?: string | null;
-			isOfficial?: boolean;
-			countryCode?: string | null;
 		},
 	) =>
 		fetchWithAuth<ReleasePublication>(

--- a/apps/web/src/routes/admin/_admin/releases_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/releases_.$id.tsx
@@ -161,21 +161,9 @@ function ReleaseDetailPage() {
 	const [publicationForm, setPublicationForm] = useState<{
 		platformCode: string;
 		url: string;
-		platformItemId: string;
-		countryCode: string;
-		visibility: string;
-		publishedAt: string;
-		removedAt: string;
-		isOfficial: boolean;
 	}>({
 		platformCode: "",
 		url: "",
-		platformItemId: "",
-		countryCode: "",
-		visibility: "public",
-		publishedAt: "",
-		removedAt: "",
-		isOfficial: false,
 	});
 
 	// JANコード管理用
@@ -833,24 +821,12 @@ function ReleaseDetailPage() {
 			setPublicationForm({
 				platformCode: publication.platformCode,
 				url: publication.url,
-				platformItemId: publication.platformItemId || "",
-				countryCode: publication.countryCode || "",
-				visibility: publication.visibility || "public",
-				publishedAt: publication.publishedAt || "",
-				removedAt: publication.removedAt || "",
-				isOfficial: publication.isOfficial || false,
 			});
 		} else {
 			setEditingPublication(null);
 			setPublicationForm({
 				platformCode: "",
 				url: "",
-				platformItemId: "",
-				countryCode: "JP",
-				visibility: "public",
-				publishedAt: "",
-				removedAt: "",
-				isOfficial: false,
 			});
 		}
 		setIsPublicationDialogOpen(true);
@@ -862,27 +838,13 @@ function ReleaseDetailPage() {
 		try {
 			if (editingPublication) {
 				await releasePublicationsApi.update(id, editingPublication.id, {
-					platformCode: publicationForm.platformCode,
 					url: publicationForm.url,
-					platformItemId: publicationForm.platformItemId || null,
-					countryCode: publicationForm.countryCode || null,
-					visibility: publicationForm.visibility || null,
-					publishedAt: publicationForm.publishedAt || null,
-					removedAt: publicationForm.removedAt || null,
-					isOfficial: publicationForm.isOfficial,
 				});
 			} else {
 				await releasePublicationsApi.create(id, {
 					id: createId.releasePublication(),
-					releaseId: id,
 					platformCode: publicationForm.platformCode,
 					url: publicationForm.url,
-					platformItemId: publicationForm.platformItemId || null,
-					countryCode: publicationForm.countryCode || null,
-					visibility: publicationForm.visibility || null,
-					publishedAt: publicationForm.publishedAt || null,
-					removedAt: publicationForm.removedAt || null,
-					isOfficial: publicationForm.isOfficial,
 				});
 			}
 			invalidateQuery();
@@ -1371,8 +1333,6 @@ function ReleaseDetailPage() {
 									<tr>
 										<th>プラットフォーム</th>
 										<th>URL</th>
-										<th>状態</th>
-										<th>公式</th>
 										<th className="w-24">操作</th>
 									</tr>
 								</thead>
@@ -1395,18 +1355,6 @@ function ReleaseDetailPage() {
 														? `${pub.url.substring(0, 50)}...`
 														: pub.url}
 												</a>
-											</td>
-											<td>
-												<Badge
-													variant={
-														pub.visibility === "public" ? "success" : "ghost"
-													}
-												>
-													{pub.visibility === "public" ? "公開" : "非公開"}
-												</Badge>
-											</td>
-											<td>
-												{pub.isOfficial && <Badge variant="info">公式</Badge>}
 											</td>
 											<td>
 												<div className="flex items-center gap-1">
@@ -2335,107 +2283,6 @@ function ReleaseDetailPage() {
 								}
 								placeholder="https://..."
 							/>
-						</div>
-
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label>プラットフォーム内ID</Label>
-								<Input
-									value={publicationForm.platformItemId}
-									onChange={(e) =>
-										setPublicationForm({
-											...publicationForm,
-											platformItemId: e.target.value,
-										})
-									}
-									placeholder="プラットフォーム固有のID"
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label>国コード</Label>
-								<select
-									value={publicationForm.countryCode}
-									onChange={(e) =>
-										setPublicationForm({
-											...publicationForm,
-											countryCode: e.target.value,
-										})
-									}
-									className="select select-bordered w-full"
-								>
-									<option value="">選択してください</option>
-									{COUNTRY_CODE_OPTIONS.map((opt) => (
-										<option key={opt.value} value={opt.value}>
-											{opt.label}
-										</option>
-									))}
-								</select>
-							</div>
-						</div>
-
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label>公開状態</Label>
-								<Select
-									value={publicationForm.visibility}
-									onChange={(e) =>
-										setPublicationForm({
-											...publicationForm,
-											visibility: e.target.value,
-										})
-									}
-								>
-									<option value="public">公開</option>
-									<option value="unlisted">限定公開</option>
-									<option value="private">非公開</option>
-								</Select>
-							</div>
-							<div className="grid gap-2">
-								<Label>公式アップロード</Label>
-								<div className="flex items-center gap-2">
-									<input
-										type="checkbox"
-										className="checkbox"
-										checked={publicationForm.isOfficial}
-										onChange={(e) =>
-											setPublicationForm({
-												...publicationForm,
-												isOfficial: e.target.checked,
-											})
-										}
-									/>
-									<span className="text-sm">公式</span>
-								</div>
-							</div>
-						</div>
-
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label>公開日</Label>
-								<Input
-									type="date"
-									value={publicationForm.publishedAt}
-									onChange={(e) =>
-										setPublicationForm({
-											...publicationForm,
-											publishedAt: e.target.value,
-										})
-									}
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label>取り下げ日</Label>
-								<Input
-									type="date"
-									value={publicationForm.removedAt}
-									onChange={(e) =>
-										setPublicationForm({
-											...publicationForm,
-											removedAt: e.target.value,
-										})
-									}
-								/>
-							</div>
 						</div>
 					</div>
 					<DialogFooter>

--- a/apps/web/src/routes/admin/_admin/tracks_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks_.$id.tsx
@@ -29,7 +29,6 @@ import { GroupedSearchableSelect } from "@/components/ui/grouped-searchable-sele
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SearchableSelect } from "@/components/ui/searchable-select";
-import { Select } from "@/components/ui/select";
 import {
 	Table,
 	TableBody,
@@ -58,7 +57,6 @@ import {
 	tracksApi,
 } from "@/lib/api-client";
 import {
-	COUNTRY_CODE_OPTIONS,
 	PLATFORM_CATEGORY_LABELS,
 	PLATFORM_CATEGORY_ORDER,
 } from "@/lib/constants";
@@ -156,13 +154,7 @@ function TrackDetailPage() {
 	const [publicationForm, setPublicationForm] = useState({
 		id: "",
 		platformCode: "",
-		platformItemId: "",
 		url: "",
-		visibility: "public" as "public" | "unlisted" | "private",
-		publishedAt: "",
-		removedAt: "",
-		isOfficial: false,
-		countryCode: "",
 	});
 	const [editingPublication, setEditingPublication] =
 		useState<TrackPublication | null>(null);
@@ -780,13 +772,7 @@ function TrackDetailPage() {
 		setPublicationForm({
 			id: createId.trackPublication(),
 			platformCode: "",
-			platformItemId: "",
 			url: "",
-			visibility: "public",
-			publishedAt: "",
-			removedAt: "",
-			isOfficial: false,
-			countryCode: "JP",
 		});
 		setEditingPublication(null);
 		setIsPublicationDialogOpen(true);
@@ -797,17 +783,7 @@ function TrackDetailPage() {
 		setPublicationForm({
 			id: publication.id,
 			platformCode: publication.platformCode,
-			platformItemId: publication.platformItemId ?? "",
 			url: publication.url,
-			visibility: publication.visibility ?? "public",
-			publishedAt: publication.publishedAt
-				? format(new Date(publication.publishedAt), "yyyy-MM-dd")
-				: "",
-			removedAt: publication.removedAt
-				? format(new Date(publication.removedAt), "yyyy-MM-dd")
-				: "",
-			isOfficial: publication.isOfficial,
-			countryCode: publication.countryCode ?? "",
 		});
 		setEditingPublication(publication);
 		setIsPublicationDialogOpen(true);
@@ -826,25 +802,13 @@ function TrackDetailPage() {
 		try {
 			if (editingPublication) {
 				await trackPublicationsApi.update(trackId, editingPublication.id, {
-					platformItemId: publicationForm.platformItemId || null,
 					url: publicationForm.url,
-					visibility: publicationForm.visibility,
-					publishedAt: publicationForm.publishedAt || null,
-					removedAt: publicationForm.removedAt || null,
-					isOfficial: publicationForm.isOfficial,
-					countryCode: publicationForm.countryCode || null,
 				});
 			} else {
 				await trackPublicationsApi.create(trackId, {
 					id: publicationForm.id,
 					platformCode: publicationForm.platformCode,
 					url: publicationForm.url,
-					platformItemId: publicationForm.platformItemId || null,
-					visibility: publicationForm.visibility,
-					publishedAt: publicationForm.publishedAt || null,
-					removedAt: publicationForm.removedAt || null,
-					isOfficial: publicationForm.isOfficial,
-					countryCode: publicationForm.countryCode || null,
 				});
 			}
 			await queryClient.invalidateQueries({
@@ -1496,8 +1460,6 @@ function TrackDetailPage() {
 								<TableRow className="hover:bg-transparent">
 									<TableHead>プラットフォーム</TableHead>
 									<TableHead>URL</TableHead>
-									<TableHead className="w-[80px]">状態</TableHead>
-									<TableHead className="w-[80px]">公式</TableHead>
 									<TableHead className="w-[100px]" />
 								</TableRow>
 							</TableHeader>
@@ -1516,30 +1478,6 @@ function TrackDetailPage() {
 											>
 												{pub.url}
 											</a>
-										</TableCell>
-										<TableCell>
-											<Badge
-												variant={
-													pub.visibility === "public"
-														? "success"
-														: pub.visibility === "unlisted"
-															? "warning"
-															: "ghost"
-												}
-											>
-												{pub.visibility === "public"
-													? "公開"
-													: pub.visibility === "unlisted"
-														? "限定"
-														: "非公開"}
-											</Badge>
-										</TableCell>
-										<TableCell>
-											{pub.isOfficial ? (
-												<Badge variant="primary">公式</Badge>
-											) : (
-												"-"
-											)}
 										</TableCell>
 										<TableCell>
 											<div className="flex items-center gap-1">
@@ -2113,110 +2051,6 @@ function TrackDetailPage() {
 								}
 								placeholder="https://..."
 							/>
-						</div>
-
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label>プラットフォーム内ID</Label>
-								<Input
-									value={publicationForm.platformItemId}
-									onChange={(e) =>
-										setPublicationForm({
-											...publicationForm,
-											platformItemId: e.target.value,
-										})
-									}
-									placeholder="プラットフォーム固有のID"
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label>国コード</Label>
-								<select
-									value={publicationForm.countryCode}
-									onChange={(e) =>
-										setPublicationForm({
-											...publicationForm,
-											countryCode: e.target.value,
-										})
-									}
-									className="select select-bordered w-full"
-								>
-									<option value="">選択してください</option>
-									{COUNTRY_CODE_OPTIONS.map((opt) => (
-										<option key={opt.value} value={opt.value}>
-											{opt.label}
-										</option>
-									))}
-								</select>
-							</div>
-						</div>
-
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label>公開状態</Label>
-								<Select
-									value={publicationForm.visibility}
-									onChange={(e) =>
-										setPublicationForm({
-											...publicationForm,
-											visibility: e.target.value as
-												| "public"
-												| "unlisted"
-												| "private",
-										})
-									}
-								>
-									<option value="public">公開</option>
-									<option value="unlisted">限定公開</option>
-									<option value="private">非公開</option>
-								</Select>
-							</div>
-							<div className="grid gap-2">
-								<Label>公式アップロード</Label>
-								<div className="flex h-12 items-center gap-2">
-									<input
-										type="checkbox"
-										className="checkbox"
-										checked={publicationForm.isOfficial}
-										onChange={(e) =>
-											setPublicationForm({
-												...publicationForm,
-												isOfficial: e.target.checked,
-											})
-										}
-									/>
-									<span className="text-sm">公式</span>
-								</div>
-							</div>
-						</div>
-
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label>公開日</Label>
-								<Input
-									type="date"
-									value={publicationForm.publishedAt}
-									onChange={(e) =>
-										setPublicationForm({
-											...publicationForm,
-											publishedAt: e.target.value,
-										})
-									}
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label>取り下げ日</Label>
-								<Input
-									type="date"
-									value={publicationForm.removedAt}
-									onChange={(e) =>
-										setPublicationForm({
-											...publicationForm,
-											removedAt: e.target.value,
-										})
-									}
-								/>
-							</div>
 						</div>
 					</div>
 					<DialogFooter>

--- a/packages/db/src/__tests__/publication.validation.test.ts
+++ b/packages/db/src/__tests__/publication.validation.test.ts
@@ -4,21 +4,11 @@ import {
 	insertTrackPublicationSchema,
 	updateReleasePublicationSchema,
 	updateTrackPublicationSchema,
-	VISIBILITY_TYPES,
 } from "../schema/publication.validation";
 
 describe("releasePublications validation schemas", () => {
-	describe("VISIBILITY_TYPES", () => {
-		test("should have all expected visibility types", () => {
-			expect(VISIBILITY_TYPES).toContain("public");
-			expect(VISIBILITY_TYPES).toContain("unlisted");
-			expect(VISIBILITY_TYPES).toContain("private");
-			expect(VISIBILITY_TYPES).toHaveLength(3);
-		});
-	});
-
 	describe("insertReleasePublicationSchema", () => {
-		test("should accept valid data with required fields only", () => {
+		test("should accept valid data with required fields", () => {
 			const result = insertReleasePublicationSchema.safeParse({
 				id: "rp_12345",
 				releaseId: "re_12345",
@@ -26,28 +16,6 @@ describe("releasePublications validation schemas", () => {
 				url: "https://www.youtube.com/watch?v=abc123",
 			});
 			expect(result.success).toBe(true);
-		});
-
-		test("should accept valid data with all optional fields", () => {
-			const result = insertReleasePublicationSchema.safeParse({
-				id: "rp_12345",
-				releaseId: "re_12345",
-				platformCode: "spotify",
-				url: "https://open.spotify.com/album/abc123",
-				platformItemId: "abc123",
-				countryCode: "JP",
-				visibility: "public",
-				publishedAt: new Date("2024-01-01"),
-				removedAt: null,
-				isOfficial: true,
-			});
-			expect(result.success).toBe(true);
-			if (result.success) {
-				expect(result.data.platformItemId).toBe("abc123");
-				expect(result.data.countryCode).toBe("JP");
-				expect(result.data.visibility).toBe("public");
-				expect(result.data.isOfficial).toBe(true);
-			}
 		});
 
 		test("should reject empty id", () => {
@@ -99,76 +67,6 @@ describe("releasePublications validation schemas", () => {
 			});
 			expect(result.success).toBe(false);
 		});
-
-		test("should reject invalid countryCode format (not 2 letters)", () => {
-			const result = insertReleasePublicationSchema.safeParse({
-				id: "rp_12345",
-				releaseId: "re_12345",
-				platformCode: "youtube",
-				url: "https://www.youtube.com/watch?v=abc123",
-				countryCode: "JPN",
-			});
-			expect(result.success).toBe(false);
-		});
-
-		test("should reject lowercase countryCode", () => {
-			const result = insertReleasePublicationSchema.safeParse({
-				id: "rp_12345",
-				releaseId: "re_12345",
-				platformCode: "youtube",
-				url: "https://www.youtube.com/watch?v=abc123",
-				countryCode: "jp",
-			});
-			expect(result.success).toBe(false);
-		});
-
-		test("should accept valid countryCode", () => {
-			const result = insertReleasePublicationSchema.safeParse({
-				id: "rp_12345",
-				releaseId: "re_12345",
-				platformCode: "youtube",
-				url: "https://www.youtube.com/watch?v=abc123",
-				countryCode: "US",
-			});
-			expect(result.success).toBe(true);
-		});
-
-		test("should reject invalid visibility type", () => {
-			const result = insertReleasePublicationSchema.safeParse({
-				id: "rp_12345",
-				releaseId: "re_12345",
-				platformCode: "youtube",
-				url: "https://www.youtube.com/watch?v=abc123",
-				visibility: "hidden",
-			});
-			expect(result.success).toBe(false);
-		});
-
-		test("should accept all valid visibility types", () => {
-			for (const visibility of VISIBILITY_TYPES) {
-				const result = insertReleasePublicationSchema.safeParse({
-					id: "rp_12345",
-					releaseId: "re_12345",
-					platformCode: "youtube",
-					url: "https://www.youtube.com/watch?v=abc123",
-					visibility,
-				});
-				expect(result.success).toBe(true);
-			}
-		});
-
-		test("should default isOfficial to true", () => {
-			const result = insertReleasePublicationSchema.safeParse({
-				id: "rp_12345",
-				releaseId: "re_12345",
-				platformCode: "youtube",
-				url: "https://www.youtube.com/watch?v=abc123",
-			});
-			expect(result.success).toBe(true);
-			if (result.success) {
-				expect(result.data.isOfficial).toBe(true);
-			}
-		});
 	});
 
 	describe("updateReleasePublicationSchema", () => {
@@ -184,23 +82,9 @@ describe("releasePublications validation schemas", () => {
 			expect(result.success).toBe(true);
 		});
 
-		test("should accept partial update with visibility only", () => {
-			const result = updateReleasePublicationSchema.safeParse({
-				visibility: "unlisted",
-			});
-			expect(result.success).toBe(true);
-		});
-
 		test("should reject invalid url in update", () => {
 			const result = updateReleasePublicationSchema.safeParse({
 				url: "not-a-url",
-			});
-			expect(result.success).toBe(false);
-		});
-
-		test("should reject invalid countryCode in update", () => {
-			const result = updateReleasePublicationSchema.safeParse({
-				countryCode: "JAPAN",
 			});
 			expect(result.success).toBe(false);
 		});
@@ -209,7 +93,7 @@ describe("releasePublications validation schemas", () => {
 
 describe("trackPublications validation schemas", () => {
 	describe("insertTrackPublicationSchema", () => {
-		test("should accept valid data with required fields only", () => {
+		test("should accept valid data with required fields", () => {
 			const result = insertTrackPublicationSchema.safeParse({
 				id: "tp_12345",
 				trackId: "tr_12345",
@@ -217,26 +101,6 @@ describe("trackPublications validation schemas", () => {
 				url: "https://www.youtube.com/watch?v=abc123",
 			});
 			expect(result.success).toBe(true);
-		});
-
-		test("should accept valid data with all optional fields", () => {
-			const result = insertTrackPublicationSchema.safeParse({
-				id: "tp_12345",
-				trackId: "tr_12345",
-				platformCode: "nicovideo",
-				url: "https://www.nicovideo.jp/watch/sm12345",
-				platformItemId: "sm12345",
-				countryCode: "JP",
-				visibility: "public",
-				publishedAt: new Date("2024-01-01"),
-				removedAt: null,
-				isOfficial: false,
-			});
-			expect(result.success).toBe(true);
-			if (result.success) {
-				expect(result.data.platformItemId).toBe("sm12345");
-				expect(result.data.isOfficial).toBe(false);
-			}
 		});
 
 		test("should reject empty id", () => {
@@ -288,19 +152,6 @@ describe("trackPublications validation schemas", () => {
 			});
 			expect(result.success).toBe(false);
 		});
-
-		test("should default isOfficial to true", () => {
-			const result = insertTrackPublicationSchema.safeParse({
-				id: "tp_12345",
-				trackId: "tr_12345",
-				platformCode: "youtube",
-				url: "https://www.youtube.com/watch?v=abc123",
-			});
-			expect(result.success).toBe(true);
-			if (result.success) {
-				expect(result.data.isOfficial).toBe(true);
-			}
-		});
 	});
 
 	describe("updateTrackPublicationSchema", () => {
@@ -309,10 +160,9 @@ describe("trackPublications validation schemas", () => {
 			expect(result.success).toBe(true);
 		});
 
-		test("should accept partial update", () => {
+		test("should accept partial update with url", () => {
 			const result = updateTrackPublicationSchema.safeParse({
-				visibility: "private",
-				isOfficial: false,
+				url: "https://new-url.com/video",
 			});
 			expect(result.success).toBe(true);
 		});

--- a/packages/db/src/schema/publication.ts
+++ b/packages/db/src/schema/publication.ts
@@ -10,10 +10,6 @@ import { platforms } from "./master";
 import { releases } from "./release";
 import { tracks } from "./track";
 
-// Visibility types
-export const VISIBILITY_TYPES = ["public", "unlisted", "private"] as const;
-export type VisibilityType = (typeof VISIBILITY_TYPES)[number];
-
 /**
  * ReleasePublications table - stores publication/distribution links for releases
  */
@@ -28,14 +24,6 @@ export const releasePublications = sqliteTable(
 			.notNull()
 			.references(() => platforms.code, { onDelete: "restrict" }),
 		url: text("url").notNull(),
-		platformItemId: text("platform_item_id"),
-		countryCode: text("country_code"),
-		visibility: text("visibility"),
-		publishedAt: integer("published_at", { mode: "timestamp_ms" }),
-		removedAt: integer("removed_at", { mode: "timestamp_ms" }),
-		isOfficial: integer("is_official", { mode: "boolean" })
-			.default(true)
-			.notNull(),
 		createdAt: integer("created_at", { mode: "timestamp_ms" })
 			.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
 			.notNull(),
@@ -47,11 +35,6 @@ export const releasePublications = sqliteTable(
 	(table) => [
 		index("idx_release_publications_release").on(table.releaseId),
 		index("idx_release_publications_platform").on(table.platformCode),
-		uniqueIndex("uq_release_publications_source").on(
-			table.releaseId,
-			table.platformCode,
-			table.platformItemId,
-		),
 		uniqueIndex("uq_release_publications_url").on(table.releaseId, table.url),
 	],
 );
@@ -70,14 +53,6 @@ export const trackPublications = sqliteTable(
 			.notNull()
 			.references(() => platforms.code, { onDelete: "restrict" }),
 		url: text("url").notNull(),
-		platformItemId: text("platform_item_id"),
-		countryCode: text("country_code"),
-		visibility: text("visibility"),
-		publishedAt: integer("published_at", { mode: "timestamp_ms" }),
-		removedAt: integer("removed_at", { mode: "timestamp_ms" }),
-		isOfficial: integer("is_official", { mode: "boolean" })
-			.default(true)
-			.notNull(),
 		createdAt: integer("created_at", { mode: "timestamp_ms" })
 			.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
 			.notNull(),
@@ -89,11 +64,6 @@ export const trackPublications = sqliteTable(
 	(table) => [
 		index("idx_track_publications_track").on(table.trackId),
 		index("idx_track_publications_platform").on(table.platformCode),
-		uniqueIndex("uq_track_publications_source").on(
-			table.trackId,
-			table.platformCode,
-			table.platformItemId,
-		),
 		uniqueIndex("uq_track_publications_url").on(table.trackId, table.url),
 	],
 );

--- a/packages/db/src/schema/publication.validation.ts
+++ b/packages/db/src/schema/publication.validation.ts
@@ -1,24 +1,9 @@
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { z } from "zod";
-import {
-	releasePublications,
-	trackPublications,
-	VISIBILITY_TYPES,
-} from "./publication";
-
-// Re-export for use in tests and other modules
-export { VISIBILITY_TYPES };
+import { releasePublications, trackPublications } from "./publication";
 
 // Helper: 空文字列を拒否するスキーマ
 const nonEmptyString = z.string().trim().min(1, "必須項目です");
-const optionalString = z.string().trim().optional().nullable();
-
-// Country code validation (ISO 3166-1 alpha-2)
-const countryCodeSchema = z
-	.string()
-	.regex(/^[A-Z]{2}$/, "ISO 3166-1 alpha-2形式で入力してください")
-	.optional()
-	.nullable();
 
 // URL validation
 const urlSchema = z.string().url("有効なURLを入力してください");
@@ -26,9 +11,6 @@ const optionalUrlSchema = z
 	.string()
 	.url("有効なURLを入力してください")
 	.optional();
-
-// Visibility type validation
-const visibilitySchema = z.enum(VISIBILITY_TYPES).optional().nullable();
 
 // ReleasePublication
 export const insertReleasePublicationSchema = createInsertSchema(
@@ -38,23 +20,11 @@ export const insertReleasePublicationSchema = createInsertSchema(
 		releaseId: nonEmptyString,
 		platformCode: nonEmptyString,
 		url: urlSchema,
-		platformItemId: optionalString,
-		countryCode: countryCodeSchema,
-		visibility: visibilitySchema,
-		publishedAt: z.date().optional().nullable(),
-		removedAt: z.date().optional().nullable(),
-		isOfficial: z.boolean().default(true),
 	},
 ).omit({ createdAt: true, updatedAt: true });
 
 export const updateReleasePublicationSchema = z.object({
 	url: optionalUrlSchema,
-	platformItemId: optionalString,
-	countryCode: countryCodeSchema,
-	visibility: visibilitySchema,
-	publishedAt: z.date().optional().nullable(),
-	removedAt: z.date().optional().nullable(),
-	isOfficial: z.boolean().optional(),
 });
 
 export const selectReleasePublicationSchema =
@@ -68,23 +38,11 @@ export const insertTrackPublicationSchema = createInsertSchema(
 		trackId: nonEmptyString,
 		platformCode: nonEmptyString,
 		url: urlSchema,
-		platformItemId: optionalString,
-		countryCode: countryCodeSchema,
-		visibility: visibilitySchema,
-		publishedAt: z.date().optional().nullable(),
-		removedAt: z.date().optional().nullable(),
-		isOfficial: z.boolean().default(true),
 	},
 ).omit({ createdAt: true, updatedAt: true });
 
 export const updateTrackPublicationSchema = z.object({
 	url: optionalUrlSchema,
-	platformItemId: optionalString,
-	countryCode: countryCodeSchema,
-	visibility: visibilitySchema,
-	publishedAt: z.date().optional().nullable(),
-	removedAt: z.date().optional().nullable(),
-	isOfficial: z.boolean().optional(),
 });
 
 export const selectTrackPublicationSchema =


### PR DESCRIPTION
## 概要

作品管理・トラック管理の公開リンクから不要なフィールドを削除し、シンプルな構成に変更

## 変更内容

* DBスキーマから以下のフィールドを削除:
  - `platformItemId`（プラットフォーム内ID）
  - `countryCode`（国コード）
  - `visibility`（公開状態）
  - `isOfficial`（公式アップロード）
  - `publishedAt`（公開日）
  - `removedAt`（取り下げ日）
* バリデーションスキーマを更新
* APIサーバーの重複チェックロジックを簡略化（URL重複チェックのみに）
* APIクライアントの型定義を更新
* フロントエンドUIからフォームフィールドとテーブルカラムを削除

## 影響範囲

* 作品管理画面の公開リンク機能
* トラック管理画面の公開リンク機能
* DBマイグレーションが必要