### PR TITLE
fix: 外部リンク編集ダイアログの修正

### DIFF
--- a/apps/web/src/components/admin/official-link-dialog.tsx
+++ b/apps/web/src/components/admin/official-link-dialog.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -42,6 +42,15 @@ export function OfficialLinkDialog({
 	const [url, setUrl] = useState(link?.url ?? "");
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+
+	// ダイアログが開いた時にlinkプロップの値でフォーム状態を同期
+	useEffect(() => {
+		if (open) {
+			setPlatformCode(link?.platformCode ?? "");
+			setUrl(link?.url ?? "");
+			setError(null);
+		}
+	}, [open, link]);
 
 	// プラットフォーム一覧取得
 	const { data: platformsData } = useQuery({
@@ -142,7 +151,7 @@ export function OfficialLinkDialog({
 							searchPlaceholder="プラットフォームを検索..."
 							emptyMessage="プラットフォームが見つかりません"
 							ungroupedLabel="その他"
-							disabled={isSubmitting || mode === "edit"}
+							disabled={isSubmitting}
 						/>
 					</div>
 


### PR DESCRIPTION
## 概要

公式作品・公式楽曲の外部リンク編集ダイアログで、既存データがフォームに表示されない問題を修正

## 問題の原因

`OfficialLinkDialog`コンポーネントで`useState`の初期値はコンポーネントの初回マウント時のみ設定されるため、編集ダイアログを開いても`link`プロップの値がフォームに反映されなかった

## 変更内容

* `useEffect`を追加してダイアログが開いた時に`link`プロップの値でフォーム状態を同期
* 編集時もプラットフォームを変更可能に変更（`disabled`条件から`mode === "edit"`を削除）

## 影響範囲

* 公式作品の外部リンク編集（`/admin/official/works/:id`）
* 公式楽曲の外部リンク編集（`/admin/official/songs/:id`）