### PR TITLE
fix: ページ更新時のレイアウト崩れ（FOUC）を修正

### DIFF
--- a/apps/web/src/components/theme-switcher.tsx
+++ b/apps/web/src/components/theme-switcher.tsx
@@ -8,16 +8,18 @@ const themes: { value: Theme; label: string; icon: React.ReactNode }[] = [
 ];
 
 export function ThemeSwitcher() {
-	const { theme, setTheme, resolvedTheme } = useTheme();
+	const { theme, setTheme, resolvedTheme, mounted } = useTheme();
 
-	const currentIcon =
-		theme === "system" ? (
-			<Monitor className="size-5" />
-		) : resolvedTheme === "dark" ? (
-			<Moon className="size-5" />
-		) : (
-			<Sun className="size-5" />
-		);
+	// Show placeholder before mount to match SSR output and prevent hydration mismatch
+	const currentIcon = !mounted ? (
+		<div className="size-5" />
+	) : theme === "system" ? (
+		<Monitor className="size-5" />
+	) : resolvedTheme === "dark" ? (
+		<Moon className="size-5" />
+	) : (
+		<Sun className="size-5" />
+	);
 
 	return (
 		<div className="dropdown dropdown-end">
@@ -29,23 +31,26 @@ export function ThemeSwitcher() {
 			>
 				{currentIcon}
 			</div>
-			<ul
-				role="menu"
-				className="dropdown-content menu z-50 w-40 rounded-box bg-base-100 p-2 shadow-lg"
-			>
-				{themes.map((t) => (
-					<li key={t.value}>
-						<button
-							type="button"
-							onClick={() => setTheme(t.value)}
-							className={theme === t.value ? "active" : ""}
-						>
-							{t.icon}
-							{t.label}
-						</button>
-					</li>
-				))}
-			</ul>
+			{/* Only render dropdown after mount to prevent hydration issues */}
+			{mounted && (
+				<ul
+					role="menu"
+					className="dropdown-content menu z-50 w-40 rounded-box bg-base-100 p-2 shadow-lg"
+				>
+					{themes.map((t) => (
+						<li key={t.value}>
+							<button
+								type="button"
+								onClick={() => setTheme(t.value)}
+								className={theme === t.value ? "active" : ""}
+							>
+								{t.icon}
+								{t.label}
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,6 +1,5 @@
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import Loader from "./components/loader";
-import "./index.css";
 import { routeTree } from "./routeTree.gen";
 
 export const getRouter = () => {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -11,7 +11,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { APP_NAME } from "@/lib/head";
 import { ThemeProvider } from "@/lib/theme";
 import Header from "../components/header";
-import "../index.css";
+import appCss from "../index.css?url";
 
 const queryClient = new QueryClient({
 	defaultOptions: {
@@ -32,6 +32,8 @@ const themeInitScript = `
     resolvedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
   document.documentElement.setAttribute('data-theme', resolvedTheme);
+  // Pass initial values to React for hydration sync
+  window.__THEME_DATA__ = { theme: theme, resolvedTheme: resolvedTheme };
 })();
 `;
 
@@ -49,7 +51,7 @@ export const Route = createRootRouteWithContext<RouterAppContext>()({
 				title: APP_NAME,
 			},
 		],
-		links: [],
+		links: [{ rel: "stylesheet", href: appCss }],
 	}),
 
 	component: RootDocument,


### PR DESCRIPTION
## 概要

ページを更新した際に一瞬レイアウトが崩れる問題（FOUC）を修正

## 問題の原因

SSR時にCSSがHTMLの`<head>`に含まれていなかったため、HTMLが先に表示されてからCSSが遅延読み込みされていた

## 変更内容

* CSSを`?url`サフィックスでインポートし、`head()`の`links`に追加
* テーマ初期化をグローバル変数`window.__THEME_DATA__`でSSR/Hydration間で同期
* ThemeSwitcherでmount前はプレースホルダーを表示
* router.tsxの重複CSSインポートを削除

## 影響範囲

全ページのSSR初期表示

## 補足事項

TanStack StartのSSRでCSSを正しく適用するには、`?url`でインポートして`head()`の`links`に含める必要がある