### PR TITLE
feat: サークル詳細画面に参加形態別作品一覧を追加

### DIFF
--- a/apps/server/src/routes/admin/circles/index.ts
+++ b/apps/server/src/routes/admin/circles/index.ts
@@ -16,8 +16,12 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { circleReleasesRouter } from "./releases";
 
 const circlesRouter = new Hono<AdminContext>();
+
+// サブルーターをマウント
+circlesRouter.route("/", circleReleasesRouter);
 
 // サークル一覧取得（ページネーション、検索、頭文字フィルタ対応）
 circlesRouter.get("/", async (c) => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1469,6 +1469,28 @@ export const releaseCirclesApi = {
 		),
 };
 
+// ===== サークルのリリース一覧 =====
+
+export interface CircleReleaseItem {
+	id: string;
+	name: string;
+	releaseDate: string | null;
+	releaseType: string | null;
+	catalogNumber: string | null;
+}
+
+export interface CircleReleasesByType {
+	participationType: ParticipationType;
+	releases: CircleReleaseItem[];
+}
+
+export const circleReleasesApi = {
+	list: (circleId: string) =>
+		fetchWithAuth<CircleReleasesByType[]>(
+			`/api/admin/circles/${circleId}/releases`,
+		),
+};
+
 // ===== トラック管理 =====
 
 export interface Track {


### PR DESCRIPTION
## 概要

サークル詳細画面に、そのサークルが参加しているリリース一覧を参加形態別にグループ化して表示する機能を追加。

## 変更内容

- 新規API作成: `GET /api/admin/circles/:circleId/releases`
  - 参加形態（主催/共同主催/参加/ゲスト/スプリット）別にグループ化してリリースを返却
- APIクライアント更新: `circleReleasesApi`を追加
- フロントエンド更新: サークル詳細画面に「参加作品一覧」セクションを追加
  - 参加形態別のバッジ表示（既存の`PARTICIPATION_TYPE_COLORS`を使用）
  - リリースタイプのバッジ表示
  - 各リリースから詳細画面へのリンク

## 影響範囲

- サークル詳細画面（`/admin/circles/:id`）

Closes #48