### PR TITLE
feat: スキーマ拡張とアーティスト関連楽曲表示機能を追加

### DIFF
--- a/apps/server/src/routes/admin/artist-aliases/index.ts
+++ b/apps/server/src/routes/admin/artist-aliases/index.ts
@@ -12,8 +12,12 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { aliasTracksRouter } from "./tracks";
 
 const artistAliasesRouter = new Hono<AdminContext>();
+
+// サブルーターをマウント
+artistAliasesRouter.route("/", aliasTracksRouter);
 
 // 一覧取得（ページネーション、検索、アーティストIDフィルタ対応）
 artistAliasesRouter.get("/", async (c) => {

--- a/apps/server/src/routes/admin/artist-aliases/tracks.ts
+++ b/apps/server/src/routes/admin/artist-aliases/tracks.ts
@@ -1,0 +1,124 @@
+import {
+	db,
+	eq,
+	inArray,
+	releases,
+	trackCreditRoles,
+	trackCredits,
+	tracks,
+} from "@thac/db";
+import { Hono } from "hono";
+import type { AdminContext } from "../../../middleware/admin-auth";
+
+const aliasTracksRouter = new Hono<AdminContext>();
+
+// アーティスト名義の関連楽曲取得（role別）
+aliasTracksRouter.get("/:aliasId/tracks", async (c) => {
+	const aliasId = c.req.param("aliasId");
+
+	// アーティスト名義のクレジット一覧を取得
+	const credits = await db
+		.select({
+			creditId: trackCredits.id,
+			trackId: trackCredits.trackId,
+			creditName: trackCredits.creditName,
+		})
+		.from(trackCredits)
+		.where(eq(trackCredits.artistAliasId, aliasId));
+
+	if (credits.length === 0) {
+		return c.json({
+			totalUniqueTrackCount: 0,
+			byRole: {},
+			tracks: [],
+		});
+	}
+
+	const creditIds = credits.map((c) => c.creditId);
+	const trackIds = [...new Set(credits.map((c) => c.trackId))];
+
+	// クレジットの役割を取得
+	const creditRoles = await db
+		.select({
+			trackCreditId: trackCreditRoles.trackCreditId,
+			roleCode: trackCreditRoles.roleCode,
+		})
+		.from(trackCreditRoles)
+		.where(inArray(trackCreditRoles.trackCreditId, creditIds));
+
+	// トラック情報を取得
+	const trackList = await db
+		.select({
+			id: tracks.id,
+			name: tracks.name,
+			nameJa: tracks.nameJa,
+			releaseId: tracks.releaseId,
+			trackNumber: tracks.trackNumber,
+		})
+		.from(tracks)
+		.where(inArray(tracks.id, trackIds))
+		.orderBy(tracks.name);
+
+	// リリース情報を取得
+	const releaseIds = [...new Set(trackList.map((t) => t.releaseId))];
+	const releaseList = await db
+		.select({
+			id: releases.id,
+			name: releases.name,
+			releaseDate: releases.releaseDate,
+		})
+		.from(releases)
+		.where(inArray(releases.id, releaseIds));
+
+	const releaseMap = new Map(releaseList.map((r) => [r.id, r]));
+
+	// クレジットIDからトラックIDへのマップ
+	const creditToTrack = new Map(credits.map((c) => [c.creditId, c.trackId]));
+
+	// 役割別に楽曲をグループ化
+	const byRole: Record<string, Set<string>> = {};
+	for (const cr of creditRoles) {
+		const trackId = creditToTrack.get(cr.trackCreditId);
+		if (trackId) {
+			if (!byRole[cr.roleCode]) {
+				byRole[cr.roleCode] = new Set();
+			}
+			const roleSet = byRole[cr.roleCode];
+			if (roleSet) {
+				roleSet.add(trackId);
+			}
+		}
+	}
+
+	// 役割別カウント
+	const roleCount: Record<string, number> = {};
+	for (const [roleCode, trackSet] of Object.entries(byRole)) {
+		roleCount[roleCode] = trackSet.size;
+	}
+
+	// トラック情報を整形
+	const tracksWithRelease = trackList.map((t) => {
+		const release = releaseMap.get(t.releaseId);
+		return {
+			id: t.id,
+			name: t.name,
+			nameJa: t.nameJa,
+			trackNumber: t.trackNumber,
+			release: release
+				? {
+						id: release.id,
+						name: release.name,
+						releaseDate: release.releaseDate,
+					}
+				: null,
+		};
+	});
+
+	return c.json({
+		totalUniqueTrackCount: trackIds.length,
+		byRole: roleCount,
+		tracks: tracksWithRelease,
+	});
+});
+
+export { aliasTracksRouter };

--- a/apps/server/src/routes/admin/artists/index.ts
+++ b/apps/server/src/routes/admin/artists/index.ts
@@ -14,8 +14,12 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { artistTracksRouter } from "./tracks";
 
 const artistsRouter = new Hono<AdminContext>();
+
+// サブルーターをマウント
+artistsRouter.route("/", artistTracksRouter);
 
 // 一覧取得（ページネーション、検索、頭文字フィルタ対応）
 artistsRouter.get("/", async (c) => {

--- a/apps/server/src/routes/admin/artists/tracks.ts
+++ b/apps/server/src/routes/admin/artists/tracks.ts
@@ -1,0 +1,124 @@
+import {
+	db,
+	eq,
+	inArray,
+	releases,
+	trackCreditRoles,
+	trackCredits,
+	tracks,
+} from "@thac/db";
+import { Hono } from "hono";
+import type { AdminContext } from "../../../middleware/admin-auth";
+
+const artistTracksRouter = new Hono<AdminContext>();
+
+// アーティストの関連楽曲取得（role別）
+artistTracksRouter.get("/:artistId/tracks", async (c) => {
+	const artistId = c.req.param("artistId");
+
+	// アーティストのクレジット一覧を取得
+	const credits = await db
+		.select({
+			creditId: trackCredits.id,
+			trackId: trackCredits.trackId,
+			creditName: trackCredits.creditName,
+		})
+		.from(trackCredits)
+		.where(eq(trackCredits.artistId, artistId));
+
+	if (credits.length === 0) {
+		return c.json({
+			totalUniqueTrackCount: 0,
+			byRole: {},
+			tracks: [],
+		});
+	}
+
+	const creditIds = credits.map((c) => c.creditId);
+	const trackIds = [...new Set(credits.map((c) => c.trackId))];
+
+	// クレジットの役割を取得
+	const creditRoles = await db
+		.select({
+			trackCreditId: trackCreditRoles.trackCreditId,
+			roleCode: trackCreditRoles.roleCode,
+		})
+		.from(trackCreditRoles)
+		.where(inArray(trackCreditRoles.trackCreditId, creditIds));
+
+	// トラック情報を取得
+	const trackList = await db
+		.select({
+			id: tracks.id,
+			name: tracks.name,
+			nameJa: tracks.nameJa,
+			releaseId: tracks.releaseId,
+			trackNumber: tracks.trackNumber,
+		})
+		.from(tracks)
+		.where(inArray(tracks.id, trackIds))
+		.orderBy(tracks.name);
+
+	// リリース情報を取得
+	const releaseIds = [...new Set(trackList.map((t) => t.releaseId))];
+	const releaseList = await db
+		.select({
+			id: releases.id,
+			name: releases.name,
+			releaseDate: releases.releaseDate,
+		})
+		.from(releases)
+		.where(inArray(releases.id, releaseIds));
+
+	const releaseMap = new Map(releaseList.map((r) => [r.id, r]));
+
+	// クレジットIDからトラックIDへのマップ
+	const creditToTrack = new Map(credits.map((c) => [c.creditId, c.trackId]));
+
+	// 役割別に楽曲をグループ化
+	const byRole: Record<string, Set<string>> = {};
+	for (const cr of creditRoles) {
+		const trackId = creditToTrack.get(cr.trackCreditId);
+		if (trackId) {
+			if (!byRole[cr.roleCode]) {
+				byRole[cr.roleCode] = new Set();
+			}
+			const roleSet = byRole[cr.roleCode];
+			if (roleSet) {
+				roleSet.add(trackId);
+			}
+		}
+	}
+
+	// 役割別カウント
+	const roleCount: Record<string, number> = {};
+	for (const [roleCode, trackSet] of Object.entries(byRole)) {
+		roleCount[roleCode] = trackSet.size;
+	}
+
+	// トラック情報を整形
+	const tracksWithRelease = trackList.map((t) => {
+		const release = releaseMap.get(t.releaseId);
+		return {
+			id: t.id,
+			name: t.name,
+			nameJa: t.nameJa,
+			trackNumber: t.trackNumber,
+			release: release
+				? {
+						id: release.id,
+						name: release.name,
+						releaseDate: release.releaseDate,
+					}
+				: null,
+		};
+	});
+
+	return c.json({
+		totalUniqueTrackCount: trackIds.length,
+		byRole: roleCount,
+		tracks: tracksWithRelease,
+	});
+});
+
+export { artistTracksRouter };

--- a/apps/server/src/routes/admin/releases/tracks.ts
+++ b/apps/server/src/routes/admin/releases/tracks.ts
@@ -228,8 +228,23 @@ tracksRouter.post("/:releaseId/tracks", async (c) => {
 		);
 	}
 
+	// 親リリースから日付・イベント情報を取得して自動設定
+	const release = existingRelease[0];
+	if (!release) {
+		return c.json({ error: "Release not found" }, 404);
+	}
+	const insertData = {
+		...parsed.data,
+		releaseDate: release.releaseDate,
+		releaseYear: release.releaseYear,
+		releaseMonth: release.releaseMonth,
+		releaseDay: release.releaseDay,
+		eventId: release.eventId,
+		eventDayId: release.eventDayId,
+	};
+
 	// 作成
-	const result = await db.insert(tracks).values(parsed.data).returning();
+	const result = await db.insert(tracks).values(insertData).returning();
 
 	return c.json(result[0], 201);
 });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -943,6 +943,27 @@ export interface CircleWithLinks extends Circle {
 	links: CircleLink[];
 }
 
+// アーティスト関連楽曲の型定義
+export interface ArtistTrackRelease {
+	id: string;
+	name: string;
+	releaseDate: string | null;
+}
+
+export interface ArtistTrack {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	trackNumber: number;
+	release: ArtistTrackRelease | null;
+}
+
+export interface ArtistTracksResponse {
+	totalUniqueTrackCount: number;
+	byRole: Record<string, number>;
+	tracks: ArtistTrack[];
+}
+
 // Artists
 export const artistsApi = {
 	list: (params?: {
@@ -964,6 +985,8 @@ export const artistsApi = {
 	},
 	get: (id: string) =>
 		fetchWithAuth<ArtistWithAliases>(`/api/admin/artists/${id}`),
+	getTracks: (id: string) =>
+		fetchWithAuth<ArtistTracksResponse>(`/api/admin/artists/${id}/tracks`),
 	create: (data: Omit<Artist, "createdAt" | "updatedAt">) =>
 		fetchWithAuth<Artist>("/api/admin/artists", {
 			method: "POST",
@@ -1003,6 +1026,10 @@ export const artistAliasesApi = {
 	},
 	get: (id: string) =>
 		fetchWithAuth<ArtistAlias>(`/api/admin/artist-aliases/${id}`),
+	getTracks: (id: string) =>
+		fetchWithAuth<ArtistTracksResponse>(
+			`/api/admin/artist-aliases/${id}/tracks`,
+		),
 	create: (data: Omit<ArtistAlias, "createdAt" | "updatedAt" | "artistName">) =>
 		fetchWithAuth<ArtistAlias>("/api/admin/artist-aliases", {
 			method: "POST",

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -19,6 +19,7 @@ import type {
 	AliasType,
 	Artist,
 	ArtistAlias,
+	ArtistTracksResponse,
 	ArtistWithAliases,
 	Circle,
 	CircleWithLinks,
@@ -97,6 +98,17 @@ export const artistDetailQueryOptions = (id: string) =>
 		staleTime: STALE_TIME.SHORT,
 	});
 
+/**
+ * アーティストの関連楽曲のqueryOptions
+ */
+export const artistTracksQueryOptions = (id: string) =>
+	queryOptions({
+		queryKey: ["artist", id, "tracks"],
+		queryFn: () =>
+			ssrFetch<ArtistTracksResponse>(`/api/admin/artists/${id}/tracks`),
+		staleTime: STALE_TIME.SHORT,
+	});
+
 // ===== アーティストエイリアス =====
 
 interface ArtistAliasListParams {
@@ -141,6 +153,17 @@ export const artistAliasDetailQueryOptions = (id: string) =>
 	queryOptions({
 		queryKey: ["artistAlias", id],
 		queryFn: () => ssrFetch<ArtistAlias>(`/api/admin/artist-aliases/${id}`),
+		staleTime: STALE_TIME.SHORT,
+	});
+
+/**
+ * アーティストエイリアスの関連楽曲のqueryOptions
+ */
+export const artistAliasTracksQueryOptions = (id: string) =>
+	queryOptions({
+		queryKey: ["artistAlias", id, "tracks"],
+		queryFn: () =>
+			ssrFetch<ArtistTracksResponse>(`/api/admin/artist-aliases/${id}/tracks`),
 		staleTime: STALE_TIME.SHORT,
 	});
 

--- a/apps/web/src/routes/admin/_admin/artist-aliases_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/artist-aliases_.$id.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { detectInitial } from "@thac/utils";
-import { ArrowLeft, Pencil, Trash2 } from "lucide-react";
+import { ArrowLeft, Music, Pencil, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { DetailPageSkeleton } from "@/components/admin/detail-page-skeleton";
 import { Badge } from "@/components/ui/badge";
@@ -10,6 +10,14 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import { Select } from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import {
 	type ArtistAlias,
 	aliasTypesApi,
@@ -20,7 +28,10 @@ import {
 	type InitialScript,
 } from "@/lib/api-client";
 import { createArtistAliasDetailHead } from "@/lib/head";
-import { artistAliasDetailQueryOptions } from "@/lib/query-options";
+import {
+	artistAliasDetailQueryOptions,
+	artistAliasTracksQueryOptions,
+} from "@/lib/query-options";
 
 export const Route = createFileRoute("/admin/_admin/artist-aliases_/$id")({
 	loader: ({ context, params }) =>
@@ -34,6 +45,26 @@ export const Route = createFileRoute("/admin/_admin/artist-aliases_/$id")({
 const initialScriptOptions = Object.entries(INITIAL_SCRIPT_LABELS).map(
 	([value, label]) => ({ value, label }),
 );
+
+/** 役割コードのラベルマップ */
+const ROLE_LABELS: Record<string, string> = {
+	vocal: "ボーカル",
+	arrange: "編曲",
+	lyrics: "作詞",
+	compose: "作曲",
+	circle: "サークル",
+	guitar: "ギター",
+	bass: "ベース",
+	drums: "ドラム",
+	piano: "ピアノ",
+	strings: "ストリングス",
+	chorus: "コーラス",
+	mix: "ミックス",
+	mastering: "マスタリング",
+	illustration: "イラスト",
+	movie: "動画",
+	other: "その他",
+};
 
 const requiresInitial = (initialScript: string) =>
 	["latin", "hiragana", "katakana"].includes(initialScript);
@@ -67,6 +98,9 @@ function ArtistAliasDetailPage() {
 
 	const { data: alias, isPending } = useQuery(
 		artistAliasDetailQueryOptions(id),
+	);
+	const { data: tracksData, isPending: isTracksPending } = useQuery(
+		artistAliasTracksQueryOptions(id),
 	);
 
 	// アーティスト一覧取得
@@ -447,6 +481,101 @@ function ArtistAliasDetailPage() {
 										? `${alias.periodFrom || "?"} 〜 ${alias.periodTo || "現在"}`
 										: "-"}
 								</p>
+							</div>
+						</div>
+					)}
+				</div>
+			</div>
+
+			{/* 関連楽曲カード */}
+			<div className="card bg-base-100 shadow-xl">
+				<div className="card-body">
+					<div className="flex items-center gap-2">
+						<Music className="h-5 w-5" />
+						<h2 className="card-title">関連楽曲</h2>
+						{tracksData && (
+							<Badge variant="secondary">
+								{tracksData.totalUniqueTrackCount}曲
+							</Badge>
+						)}
+					</div>
+
+					{isTracksPending ? (
+						<div className="flex items-center justify-center py-8">
+							<span className="loading loading-spinner loading-md" />
+						</div>
+					) : !tracksData || tracksData.totalUniqueTrackCount === 0 ? (
+						<p className="text-base-content/60">関連する楽曲がありません</p>
+					) : (
+						<div className="space-y-6">
+							{/* 役割別カウント */}
+							<div>
+								<h3 className="mb-3 font-medium text-base-content/80">
+									役割別カウント
+								</h3>
+								<div className="flex flex-wrap gap-2">
+									{Object.entries(tracksData.byRole)
+										.sort((a, b) => b[1] - a[1])
+										.map(([roleCode, count]) => (
+											<Badge key={roleCode} variant="outline">
+												{ROLE_LABELS[roleCode] || roleCode}: {count}曲
+											</Badge>
+										))}
+								</div>
+							</div>
+
+							{/* 楽曲一覧 */}
+							<div>
+								<h3 className="mb-3 font-medium text-base-content/80">
+									楽曲一覧
+								</h3>
+								<div className="overflow-x-auto">
+									<Table zebra>
+										<TableHeader>
+											<TableRow className="hover:bg-transparent">
+												<TableHead>楽曲名</TableHead>
+												<TableHead>リリース</TableHead>
+												<TableHead className="w-[100px]">リリース日</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{tracksData.tracks.map((track) => (
+												<TableRow key={track.id}>
+													<TableCell className="font-medium">
+														<Link
+															to="/admin/tracks/$id"
+															params={{ id: track.id }}
+															className="link link-hover"
+														>
+															{track.name}
+														</Link>
+														{track.nameJa && track.nameJa !== track.name && (
+															<span className="ml-2 text-base-content/60 text-sm">
+																({track.nameJa})
+															</span>
+														)}
+													</TableCell>
+													<TableCell>
+														{track.release ? (
+															<Link
+																to="/admin/releases/$id"
+																params={{ id: track.release.id }}
+																className="link link-hover"
+															>
+																{track.release.name}
+															</Link>
+														) : (
+															"-"
+														)}
+													</TableCell>
+													<TableCell className="text-base-content/70">
+														{track.release?.releaseDate || "-"}
+													</TableCell>
+												</TableRow>
+											))}
+										</TableBody>
+									</Table>
+								</div>
 							</div>
 						</div>
 					)}

--- a/packages/db/src/schema/release.ts
+++ b/packages/db/src/schema/release.ts
@@ -8,7 +8,7 @@ import {
 	uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 import { circles } from "./artist-circle";
-import { eventDays } from "./event";
+import { eventDays, events } from "./event";
 
 // リリースタイプの定義
 export const RELEASE_TYPES = [
@@ -42,7 +42,13 @@ export const releases = sqliteTable(
 		nameEn: text("name_en"),
 		catalogNumber: text("catalog_number"),
 		releaseDate: text("release_date"),
+		releaseYear: integer("release_year"),
+		releaseMonth: integer("release_month"),
+		releaseDay: integer("release_day"),
 		releaseType: text("release_type"),
+		eventId: text("event_id").references(() => events.id, {
+			onDelete: "set null",
+		}),
 		eventDayId: text("event_day_id").references(() => eventDays.id, {
 			onDelete: "set null",
 		}),
@@ -57,7 +63,10 @@ export const releases = sqliteTable(
 	},
 	(table) => [
 		index("idx_releases_date").on(table.releaseDate),
+		index("idx_releases_year").on(table.releaseYear),
+		index("idx_releases_year_month").on(table.releaseYear, table.releaseMonth),
 		index("idx_releases_type").on(table.releaseType),
+		index("idx_releases_event").on(table.eventId),
 		index("idx_releases_event_day").on(table.eventDayId),
 		index("idx_releases_catalog").on(table.catalogNumber),
 	],

--- a/packages/db/src/schema/release.validation.ts
+++ b/packages/db/src/schema/release.validation.ts
@@ -29,7 +29,11 @@ export const insertReleaseSchema = createInsertSchema(releases, {
 	nameEn: optionalString,
 	catalogNumber: optionalString,
 	releaseDate: dateSchema,
+	releaseYear: z.number().int().min(1900).max(2100).optional().nullable(),
+	releaseMonth: z.number().int().min(1).max(12).optional().nullable(),
+	releaseDay: z.number().int().min(1).max(31).optional().nullable(),
 	releaseType: z.enum(RELEASE_TYPES).optional().nullable(),
+	eventId: optionalString,
 	eventDayId: optionalString,
 	notes: optionalString,
 }).omit({ createdAt: true, updatedAt: true });
@@ -40,7 +44,11 @@ export const updateReleaseSchema = z.object({
 	nameEn: optionalString,
 	catalogNumber: optionalString,
 	releaseDate: dateSchema,
+	releaseYear: z.number().int().min(1900).max(2100).optional().nullable(),
+	releaseMonth: z.number().int().min(1).max(12).optional().nullable(),
+	releaseDay: z.number().int().min(1).max(31).optional().nullable(),
 	releaseType: z.enum(RELEASE_TYPES).optional().nullable(),
+	eventId: optionalString,
 	eventDayId: optionalString,
 	notes: optionalString,
 });

--- a/packages/db/src/schema/track.ts
+++ b/packages/db/src/schema/track.ts
@@ -8,6 +8,7 @@ import {
 	uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 import { artistAliases, artists } from "./artist-circle";
+import { eventDays, events } from "./event";
 import { aliasTypes, creditRoles } from "./master";
 import { discs, releases } from "./release";
 
@@ -27,6 +28,16 @@ export const tracks = sqliteTable(
 		name: text("name").notNull(),
 		nameJa: text("name_ja"),
 		nameEn: text("name_en"),
+		releaseDate: text("release_date"),
+		releaseYear: integer("release_year"),
+		releaseMonth: integer("release_month"),
+		releaseDay: integer("release_day"),
+		eventId: text("event_id").references(() => events.id, {
+			onDelete: "set null",
+		}),
+		eventDayId: text("event_day_id").references(() => eventDays.id, {
+			onDelete: "set null",
+		}),
 		createdAt: integer("created_at", { mode: "timestamp_ms" })
 			.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
 			.notNull(),
@@ -38,6 +49,10 @@ export const tracks = sqliteTable(
 	(table) => [
 		index("idx_tracks_release").on(table.releaseId),
 		index("idx_tracks_disc").on(table.discId),
+		index("idx_tracks_date").on(table.releaseDate),
+		index("idx_tracks_year").on(table.releaseYear),
+		index("idx_tracks_event").on(table.eventId),
+		index("idx_tracks_event_day").on(table.eventDayId),
 		// Composite index for ordering tracks by release, disc, and track number
 		index("idx_tracks_ordering").on(
 			table.releaseId,

--- a/packages/db/src/schema/track.validation.ts
+++ b/packages/db/src/schema/track.validation.ts
@@ -6,7 +6,15 @@ import { trackCreditRoles, trackCredits, tracks } from "./track";
 const nonEmptyString = z.string().trim().min(1, "必須項目です");
 const optionalString = z.string().trim().optional().nullable();
 
+// 日付バリデーション（YYYY-MM-DD形式）
+const dateSchema = z
+	.string()
+	.regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD形式で入力してください")
+	.optional()
+	.nullable();
+
 // Track
+// Note: releaseDate, releaseYear/Month/Day, eventId, eventDayId are auto-set from parent release
 export const insertTrackSchema = createInsertSchema(tracks, {
 	id: nonEmptyString,
 	releaseId: nonEmptyString,
@@ -15,6 +23,12 @@ export const insertTrackSchema = createInsertSchema(tracks, {
 	name: nonEmptyString.max(200, "200文字以内で入力してください"),
 	nameJa: optionalString,
 	nameEn: optionalString,
+	releaseDate: dateSchema,
+	releaseYear: z.number().int().min(1900).max(2100).optional().nullable(),
+	releaseMonth: z.number().int().min(1).max(12).optional().nullable(),
+	releaseDay: z.number().int().min(1).max(31).optional().nullable(),
+	eventId: optionalString,
+	eventDayId: optionalString,
 }).omit({ createdAt: true, updatedAt: true });
 
 export const updateTrackSchema = z.object({


### PR DESCRIPTION
## 概要

releases/tracksテーブルにevent_id・日付分解カラムを追加し、アーティスト/名義詳細画面に関連楽曲表示機能を実装

## 変更内容

### データベーススキーマ拡張
* releasesテーブル: `event_id`, `release_year`, `release_month`, `release_day` カラムを追加
* tracksテーブル: `release_date`, `event_id`, `event_day_id`, `release_year`, `release_month`, `release_day` カラムを追加
* 対応するZodバリデーションスキーマを更新

### サーバー側API更新
* リリース作成/更新時に `release_date` から年月日を自動設定
* `event_day_id` から `event_id` を自動導出（整合性チェック付き）
* リリース更新時にトラックへカスケード更新
* トラック作成時に親リリースから日付/イベント情報を自動継承

### アーティスト関連楽曲API（新規）
* `GET /api/admin/artists/:artistId/tracks`: アーティストの関連楽曲取得
* `GET /api/admin/artist-aliases/:aliasId/tracks`: アーティスト名義の関連楽曲取得
* 役割別カウントと総ユニーク楽曲数を返却

### フロントエンド更新
* アーティスト詳細画面に関連楽曲セクションを追加
* アーティスト名義詳細画面に関連楽曲セクションを追加
* 役割別カウント（ボーカル、編曲、作詞等）と楽曲一覧を表示

## 影響範囲

* DBスキーマ変更あり（マイグレーション実行が必要）
* 既存のリリース/トラックデータには新カラムがnullで設定される

## 補足事項

残タスク「レガシーCSVインポートの改善」は別PRで対応予定