### PR TITLE
feat: レガシーCSVインポート機能を改善

### DIFF
--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -383,11 +383,24 @@ export interface NewEventInput {
 	eventDates: string[];
 }
 
+export interface ExistingEventDay {
+	id: string;
+	dayNumber: number;
+	eventDate: string | null;
+}
+
+export interface ExistingEventWithDays {
+	eventId: string;
+	eventName: string;
+	eventDays: ExistingEventDay[];
+}
+
 export interface LegacyPreviewResponse {
 	success: boolean;
 	records: LegacyCSVRecord[];
 	songMatches: SongMatchResult[];
 	newEventsNeeded: NewEventNeeded[];
+	existingEventsWithDays?: ExistingEventWithDays[];
 	errors: { row: number; message: string }[];
 	error?: string;
 }
@@ -475,6 +488,7 @@ export const legacyImportApi = {
 		customSongNames: Record<string, string>,
 		newEvents: NewEventInput[] | undefined,
 		onProgress: (progress: ImportProgress) => void,
+		eventDayMappings?: Record<string, string>,
 	): Promise<LegacyImportResult> => {
 		const res = await fetch(`${API_BASE_URL}/api/admin/import/legacy/execute`, {
 			method: "POST",
@@ -488,6 +502,7 @@ export const legacyImportApi = {
 				songMappings,
 				customSongNames,
 				newEvents,
+				eventDayMappings,
 			}),
 		});
 
@@ -562,6 +577,7 @@ export const legacyImportApi = {
 		songMappings: Record<string, string>,
 		customSongNames: Record<string, string>,
 		newEvents?: NewEventInput[],
+		eventDayMappings?: Record<string, string>,
 	): Promise<LegacyImportResult> => {
 		return legacyImportApi.executeWithProgress(
 			records,
@@ -569,6 +585,7 @@ export const legacyImportApi = {
 			customSongNames,
 			newEvents,
 			() => {}, // 進捗を無視
+			eventDayMappings,
 		);
 	},
 };


### PR DESCRIPTION
## 概要

レガシーCSVインポート機能を改善し、トラッククレジットへのアーティスト名義紐付けと既存イベントのイベント日選択を可能にする

## 変更内容

* トラッククレジットにアーティスト名義ID（artistAliasId）を紐付け
  * `ImportCache`に`artistAliases`マップを追加し、本名義IDをキャッシュ
  * クレジット作成時に`artistAliasId`を設定
* 複数日開催のイベントでイベント日を選択できるUIを追加
  * `getExistingEventsWithMultipleDays`関数を追加
  * プレビューAPIで`existingEventsWithDays`を返却
  * ラジオボタンでイベント日を選択（デフォルトは1日目）
  * 選択したイベント日IDをリリース作成時に使用

## 影響範囲

* レガシーCSVインポート機能のみ
* 既存データへの影響なし