### PR TITLE
fix: レガシーCSVインポートの問題を修正

### DIFF
--- a/apps/web/src/routes/admin/_admin/import-legacy.tsx
+++ b/apps/web/src/routes/admin/_admin/import-legacy.tsx
@@ -283,6 +283,7 @@ function LegacyImportPage() {
 			<AdminPageHeader
 				title="レガシーCSVインポート"
 				description="旧システムのCSVデータをインポートします"
+				breadcrumbs={[{ label: "レガシーCSVインポート" }]}
 			/>
 
 			{/* ステップインジケーター */}


### PR DESCRIPTION
## 概要

レガシーCSVインポートのパンくずリスト追加と、イベント日付が作品・トラックの発売日に設定されない問題を修正

## 問題の原因

- パンくずリストが設定されておらず、ナビゲーションが不便だった
- 新規イベント作成時と既存イベント更新時に、イベント日のキャッシュが追加されていなかった
- リリースとトラックにイベント情報（eventId, eventDayId）と発売日情報（releaseYear/Month/Day）が設定されていなかった

## 変更内容

* パンくずリストを追加
* リリース作成時にイベント情報と発売日情報を設定するよう修正
* トラック作成時に親リリースからイベント情報と発売日情報を継承するよう修正
* 新規イベント作成時に1日目のイベント日をキャッシュに追加
* 既存イベント更新時にも1日目のイベント日をキャッシュに追加
* リリースキャッシュを拡張してイベント情報も保持するよう変更

## 影響範囲

- レガシーCSVインポート機能

## 補足事項

なし