### PR TITLE
refactor: トラック詳細ページの編集をダイアログに統一（Phase 5）

### DIFF
--- a/apps/web/src/components/admin/track-edit-dialog.tsx
+++ b/apps/web/src/components/admin/track-edit-dialog.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { type Track, tracksApi } from "@/lib/api-client";
+
+interface TrackEditDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	track: Track;
+	onSuccess?: () => void;
+}
+
+export function TrackEditDialog({
+	open,
+	onOpenChange,
+	track,
+	onSuccess,
+}: TrackEditDialogProps) {
+	const [editForm, setEditForm] = useState<Partial<Track>>({});
+	const [mutationError, setMutationError] = useState<string | null>(null);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	// ダイアログが開いたらフォームを初期化
+	useEffect(() => {
+		if (open && track) {
+			setEditForm({
+				name: track.name,
+				nameJa: track.nameJa,
+				nameEn: track.nameEn,
+				trackNumber: track.trackNumber,
+			});
+			setMutationError(null);
+		}
+	}, [open, track]);
+
+	// 保存
+	const handleSave = async () => {
+		setIsSubmitting(true);
+		setMutationError(null);
+		try {
+			await tracksApi.update(track.releaseId, track.id, {
+				name: editForm.name ?? "",
+				nameJa: editForm.nameJa || null,
+				nameEn: editForm.nameEn || null,
+				trackNumber: editForm.trackNumber,
+			});
+			onSuccess?.();
+			onOpenChange(false);
+		} catch (err) {
+			setMutationError(
+				err instanceof Error ? err.message : "保存に失敗しました",
+			);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-[500px]">
+				<DialogHeader>
+					<DialogTitle>トラックの編集</DialogTitle>
+				</DialogHeader>
+				<div className="grid gap-4 py-4">
+					{mutationError && (
+						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
+							{mutationError}
+						</div>
+					)}
+					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+						<div className="grid gap-2">
+							<Label htmlFor="name">
+								トラック名 <span className="text-error">*</span>
+							</Label>
+							<Input
+								id="name"
+								value={editForm.name || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, name: e.target.value })
+								}
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="trackNumber">
+								トラック番号 <span className="text-error">*</span>
+							</Label>
+							<Input
+								id="trackNumber"
+								type="number"
+								min="1"
+								value={editForm.trackNumber || ""}
+								onChange={(e) =>
+									setEditForm({
+										...editForm,
+										trackNumber: Number.parseInt(e.target.value, 10) || 1,
+									})
+								}
+							/>
+						</div>
+					</div>
+					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+						<div className="grid gap-2">
+							<Label htmlFor="nameJa">日本語名</Label>
+							<Input
+								id="nameJa"
+								value={editForm.nameJa || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, nameJa: e.target.value })
+								}
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="nameEn">英語名</Label>
+							<Input
+								id="nameEn"
+								value={editForm.nameEn || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, nameEn: e.target.value })
+								}
+							/>
+						</div>
+					</div>
+				</div>
+				<DialogFooter>
+					<Button
+						variant="ghost"
+						onClick={() => onOpenChange(false)}
+						disabled={isSubmitting}
+					>
+						キャンセル
+					</Button>
+					<Button
+						variant="primary"
+						onClick={handleSave}
+						disabled={isSubmitting || !editForm.name}
+					>
+						{isSubmitting ? "保存中..." : "保存"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/docs/phase5-dialog-conversion.md
+++ b/docs/phase5-dialog-conversion.md
@@ -8,8 +8,8 @@
 
 | ファイル | 状態 | ダイアログコンポーネント |
 |----------|------|------------------------|
-| `apps/web/src/routes/admin/_admin/releases_.$id.tsx` | 未着手 | `ReleaseEditDialog`（作成済み） |
-| `apps/web/src/routes/admin/_admin/tracks_.$id.tsx` | 未着手 | `TrackEditDialog`（作成済み） |
+| `apps/web/src/routes/admin/_admin/releases_.$id.tsx` | ✅ 完了 | `ReleaseEditDialog`（作成済み） |
+| `apps/web/src/routes/admin/_admin/tracks_.$id.tsx` | ✅ 完了 | `TrackEditDialog`（作成済み） |
 
 ## 作成済みコンポーネント
 


### PR DESCRIPTION
## 概要

トラック詳細ページ（tracks_.$id.tsx）のインライン編集をダイアログベースに変換し、他の詳細ページと統一しました。

## 変更内容

* `TrackEditDialog` コンポーネントを新規作成
* `tracks_.$id.tsx` のインライン編集をダイアログベースに変換
  * `isEditing`, `editForm` 状態を `isEditDialogOpen` に統合
  * `startEditing`, `cancelEditing`, `handleSave` 関数を削除
  * 編集ボタンをダイアログトリガーに変更
  * インライン編集フォームを削除
* Phase 5 変換ドキュメントの状態を完了に更新

## 影響範囲

* トラック詳細ページ (`/admin/tracks/:id`) の編集UIが変更
* 機能的な変更はなく、UIパターンの統一のみ

## 補足事項

* `releases_.$id.tsx` は既に前回のPR (#65) でダイアログベースに変換済み
* 関連ドキュメント: `docs/phase5-dialog-conversion.md`