### PR TITLE
feat: クレジット役割管理の編集ダイアログを共通化

### DIFF
--- a/apps/web/src/components/admin/credit-role-edit-dialog.tsx
+++ b/apps/web/src/components/admin/credit-role-edit-dialog.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from "react";
+import { type CreditRole, creditRolesApi } from "@/lib/api-client";
+import { Button } from "../ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "../ui/dialog";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { Textarea } from "../ui/textarea";
+
+export interface CreditRoleFormData {
+	code: string;
+	label: string;
+	description: string | null;
+}
+
+export interface CreditRoleEditDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	mode: "create" | "edit";
+	creditRole?: CreditRole | null;
+	onSuccess?: () => void;
+}
+
+export function CreditRoleEditDialog({
+	open,
+	onOpenChange,
+	mode,
+	creditRole,
+	onSuccess,
+}: CreditRoleEditDialogProps) {
+	const [form, setForm] = useState<CreditRoleFormData>({
+		code: "",
+		label: "",
+		description: null,
+	});
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	// ダイアログが開いた時にフォームを初期化
+	useEffect(() => {
+		if (open) {
+			if (mode === "edit" && creditRole) {
+				setForm({
+					code: creditRole.code,
+					label: creditRole.label,
+					description: creditRole.description,
+				});
+			} else {
+				setForm({
+					code: "",
+					label: "",
+					description: null,
+				});
+			}
+			setError(null);
+		}
+	}, [open, mode, creditRole]);
+
+	const handleSubmit = async () => {
+		if (!form.code.trim()) {
+			setError("コードを入力してください");
+			return;
+		}
+		if (!form.label.trim()) {
+			setError("ラベルを入力してください");
+			return;
+		}
+
+		setIsSubmitting(true);
+		setError(null);
+
+		try {
+			if (mode === "create") {
+				await creditRolesApi.create({
+					code: form.code,
+					label: form.label,
+					description: form.description,
+				});
+			} else if (creditRole) {
+				await creditRolesApi.update(creditRole.code, {
+					label: form.label,
+					description: form.description,
+				});
+			}
+			onOpenChange(false);
+			onSuccess?.();
+		} catch (e) {
+			setError(
+				e instanceof Error
+					? e.message
+					: mode === "create"
+						? "作成に失敗しました"
+						: "更新に失敗しました",
+			);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const title =
+		mode === "create" ? "新規クレジット役割" : "クレジット役割の編集";
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-[500px]">
+				<DialogHeader>
+					<DialogTitle>{title}</DialogTitle>
+				</DialogHeader>
+				<div className="grid gap-4 py-4">
+					{error && (
+						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
+							{error}
+						</div>
+					)}
+					<div className="grid gap-2">
+						<Label htmlFor="credit-role-code">
+							コード <span className="text-error">*</span>
+						</Label>
+						<Input
+							id="credit-role-code"
+							value={form.code}
+							onChange={(e) => setForm({ ...form, code: e.target.value })}
+							placeholder="例: composer"
+							disabled={isSubmitting || mode === "edit"}
+						/>
+						{mode === "edit" && (
+							<p className="text-muted-foreground text-xs">
+								コードは変更できません
+							</p>
+						)}
+					</div>
+					<div className="grid gap-2">
+						<Label htmlFor="credit-role-label">
+							ラベル <span className="text-error">*</span>
+						</Label>
+						<Input
+							id="credit-role-label"
+							value={form.label}
+							onChange={(e) => setForm({ ...form, label: e.target.value })}
+							placeholder="例: 作曲"
+							disabled={isSubmitting}
+						/>
+					</div>
+					<div className="grid gap-2">
+						<Label htmlFor="credit-role-description">説明</Label>
+						<Textarea
+							id="credit-role-description"
+							value={form.description || ""}
+							onChange={(e) =>
+								setForm({ ...form, description: e.target.value || null })
+							}
+							placeholder="例: 楽曲の作曲を担当したクレジット"
+							rows={3}
+							disabled={isSubmitting}
+						/>
+					</div>
+				</div>
+				<DialogFooter>
+					<Button
+						variant="ghost"
+						onClick={() => onOpenChange(false)}
+						disabled={isSubmitting}
+					>
+						キャンセル
+					</Button>
+					<Button
+						variant="primary"
+						onClick={handleSubmit}
+						disabled={isSubmitting || !form.code.trim() || !form.label.trim()}
+					>
+						{isSubmitting
+							? mode === "create"
+								? "作成中..."
+								: "保存中..."
+							: mode === "create"
+								? "作成"
+								: "保存"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/routes/admin/_admin/master/credit-roles_.$code.tsx
+++ b/apps/web/src/routes/admin/_admin/master/credit-roles_.$code.tsx
@@ -2,19 +2,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, Home, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { CreditRoleEditDialog } from "@/components/admin/credit-role-edit-dialog";
 import { Button } from "@/components/ui/button";
-import {
-	Dialog,
-	DialogContent,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import { getCreditRole } from "@/functions/get-credit-role";
-import { type CreditRole, creditRolesApi } from "@/lib/api-client";
+import { creditRolesApi } from "@/lib/api-client";
 import { createMasterDetailHead } from "@/lib/head";
 
 export const Route = createFileRoute(
@@ -32,35 +24,8 @@ function CreditRoleDetailPage() {
 	const queryClient = useQueryClient();
 
 	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-	const [editForm, setEditForm] = useState<Partial<CreditRole>>({});
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-
-	const handleEdit = () => {
-		if (!creditRole) return;
-		setEditForm({
-			label: creditRole.label,
-			description: creditRole.description,
-		});
-		setError(null);
-		setIsEditDialogOpen(true);
-	};
-
-	const handleUpdate = async () => {
-		if (!creditRole) return;
-		setError(null);
-		try {
-			await creditRolesApi.update(creditRole.code, {
-				label: editForm.label,
-				description: editForm.description,
-			});
-			setIsEditDialogOpen(false);
-			queryClient.invalidateQueries({ queryKey: ["creditRoles"] });
-			window.location.reload();
-		} catch (e) {
-			setError(e instanceof Error ? e.message : "更新に失敗しました");
-		}
-	};
 
 	const handleDelete = async () => {
 		if (!creditRole) return;
@@ -131,7 +96,11 @@ function CreditRoleDetailPage() {
 					<h1 className="font-bold text-2xl">{creditRole.label}</h1>
 				</div>
 				<div className="flex gap-2">
-					<Button variant="outline" size="sm" onClick={handleEdit}>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => setIsEditDialogOpen(true)}
+					>
 						<Pencil className="mr-2 h-4 w-4" />
 						編集
 					</Button>
@@ -181,51 +150,16 @@ function CreditRoleDetailPage() {
 			</div>
 
 			{/* 編集ダイアログ */}
-			<Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-				<DialogContent className="sm:max-w-[425px]">
-					<DialogHeader>
-						<DialogTitle>クレジット役割の編集</DialogTitle>
-					</DialogHeader>
-					<div className="grid gap-4 py-4">
-						<div className="grid gap-2">
-							<Label>コード</Label>
-							<Input value={creditRole.code} disabled />
-						</div>
-						<div className="grid gap-2">
-							<Label htmlFor="edit-label">ラベル</Label>
-							<Input
-								id="edit-label"
-								value={editForm.label || ""}
-								onChange={(e) =>
-									setEditForm({ ...editForm, label: e.target.value })
-								}
-								placeholder="例: ボーカル"
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label htmlFor="edit-description">説明</Label>
-							<Textarea
-								id="edit-description"
-								value={editForm.description || ""}
-								onChange={(e) =>
-									setEditForm({ ...editForm, description: e.target.value })
-								}
-								placeholder="例: 歌唱を担当するクレジット"
-							/>
-						</div>
-					</div>
-					{error && <div className="mb-4 text-error text-sm">{error}</div>}
-					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setIsEditDialogOpen(false)}
-						>
-							キャンセル
-						</Button>
-						<Button onClick={handleUpdate}>保存</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			<CreditRoleEditDialog
+				open={isEditDialogOpen}
+				onOpenChange={setIsEditDialogOpen}
+				mode="edit"
+				creditRole={creditRole}
+				onSuccess={() => {
+					queryClient.invalidateQueries({ queryKey: ["creditRoles"] });
+					window.location.reload();
+				}}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## 概要

クレジット役割管理の一覧ページと詳細ページで別々に実装されていた編集ダイアログを、共通コンポーネントに統一しました。

## 変更内容

* 共通編集ダイアログコンポーネント `CreditRoleEditDialog` を作成
  - apps/web/src/components/admin/credit-role-edit-dialog.tsx
  - create/editの両モードに対応（現在はeditのみ使用）
  - OfficialWorkCategoryEditDialogと同じパターンで実装

* 一覧ページのインライン編集ダイアログを削除し、共通ダイアログに置き換え
  - apps/web/src/routes/admin/_admin/master/credit-roles.tsx
  - editingItem、editForm、mutationErrorの状態管理を削除
  - handleUpdate関数を削除
  - 約40行のコード削減

* 詳細ページのインライン編集ダイアログを削除し、共通ダイアログに置き換え
  - apps/web/src/routes/admin/_admin/master/credit-roles_.$code.tsx
  - editForm状態とhandleEdit、handleUpdate関数を削除
  - 約45行のコード削減

* UI/UX改善
  - 説明フィールドを`Input`から`Textarea`に統一（一覧ページのダイアログで変更）
  - すべてのフィールドにプレースホルダーを設定

## 影響範囲

* クレジット役割管理の編集機能のUI
  - 一覧ページの編集ボタン → 共通ダイアログを表示
  - 詳細ページの編集ボタン → 共通ダイアログを表示
  - 説明フィールドの入力方法が改善（複数行入力が可能に）

* コード重複の削減
  - 合計約85行の重複コードを削除
  - 保守性とコード品質の向上

## 補足事項

* 公式作品カテゴリ（#67）と同じリファクタリングパターンを採用
* 新規作成ダイアログ（CreateDialog）は既存のまま維持
* 型チェック・Lint通過済み
