### PR TITLE
feat: 公式楽曲編集ダイアログのレイアウトとUXを改善

### DIFF
--- a/apps/web/src/components/admin/official-song-edit-dialog.tsx
+++ b/apps/web/src/components/admin/official-song-edit-dialog.tsx
@@ -284,28 +284,26 @@ export function OfficialSongEditDialog({
 							{error}
 						</div>
 					)}
-					<div className="grid grid-cols-2 gap-4">
-						<div className="grid gap-2">
-							<Label>作品</Label>
-							<SearchableGroupedSelect
-								value={form.officialWorkId || ""}
-								onChange={(val) => handleWorkChange(val || null)}
-								groups={workGroups}
-								placeholder="作品を選択..."
-								searchPlaceholder="作品を検索..."
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label htmlFor="song-id">
-								ID {mode === "create" && "(自動生成)"}
-							</Label>
-							<Input
-								id="song-id"
-								value={form.id}
-								disabled
-								className="font-mono"
-							/>
-						</div>
+					<div className="grid gap-2">
+						<Label htmlFor="song-id">
+							ID {mode === "create" && "(自動生成)"}
+						</Label>
+						<Input
+							id="song-id"
+							value={form.id}
+							disabled
+							className="font-mono"
+						/>
+					</div>
+					<div className="grid gap-2">
+						<Label>作品</Label>
+						<SearchableGroupedSelect
+							value={form.officialWorkId || ""}
+							onChange={(val) => handleWorkChange(val || null)}
+							groups={workGroups}
+							placeholder="作品を選択..."
+							searchPlaceholder="作品を検索..."
+						/>
 					</div>
 					<div className="grid gap-2">
 						<Label htmlFor="song-name">
@@ -340,6 +338,7 @@ export function OfficialSongEditDialog({
 								onChange={(e) =>
 									setForm({ ...form, nameEn: e.target.value || null })
 								}
+								placeholder="例: A Sacred Lot"
 								disabled={isSubmitting}
 							/>
 						</div>
@@ -420,6 +419,7 @@ export function OfficialSongEditDialog({
 								onChange={(e) =>
 									setForm({ ...form, arrangerName: e.target.value || null })
 								}
+								placeholder="例: ZUN"
 								disabled={isSubmitting}
 							/>
 						</div>
@@ -432,6 +432,7 @@ export function OfficialSongEditDialog({
 							onChange={(e) =>
 								setForm({ ...form, notes: e.target.value || null })
 							}
+							placeholder="例: アレンジバージョン、特記事項など"
 							rows={3}
 							disabled={isSubmitting}
 						/>


### PR DESCRIPTION
## 概要

公式楽曲編集ダイアログのレイアウトとUXを改善し、入力時の視認性とユーザビリティを向上させました。

## 変更内容

* IDフィールドを最上部に移動し、重要な識別情報の視認性を向上
* ID、作品、名前フィールドを2カラムから1カラム（縦並び）に変更し、入力フォームの可読性を改善
* 英語名フィールドにプレースホルダー（`例: A Sacred Lot`）を追加
* 編曲者フィールドにプレースホルダー（`例: ZUN`）を追加
* 備考フィールドにプレースホルダー（`例: アレンジバージョン、特記事項など`）を追加

## 影響範囲

* `apps/web/src/components/admin/official-song-edit-dialog.tsx` のみ
* UIレイアウトの変更のため、既存の機能やデータには影響なし
