### PR TITLE
feat: イベント編集ダイアログの新規シリーズ作成ボタンスタイルを統一

### DIFF
--- a/apps/web/src/routes/admin/_admin/events.tsx
+++ b/apps/web/src/routes/admin/_admin/events.tsx
@@ -607,31 +607,30 @@ function EventsPage() {
 							/>
 						</div>
 						<div className="grid gap-2">
-							<Label htmlFor="edit-seriesId">シリーズ</Label>
-							<div className="flex items-center gap-2">
-								<SearchableSelect
-									id="edit-seriesId"
-									value={editForm.eventSeriesId || ""}
-									onChange={(value) =>
-										setEditForm({ ...editForm, eventSeriesId: value })
-									}
-									options={seriesList.map((s) => ({
-										value: s.id,
-										label: s.name,
-									}))}
-									placeholder="選択してください"
-									searchPlaceholder="シリーズを検索..."
-									className="flex-1"
-								/>
+							<div className="flex items-center justify-between">
+								<Label htmlFor="edit-seriesId">シリーズ</Label>
 								<Button
-									type="button"
-									variant="outline"
+									variant="ghost"
+									size="sm"
+									className="h-auto p-0 text-primary text-xs hover:underline"
 									onClick={() => setIsSeriesDialogOpen(true)}
 								>
-									<Plus className="mr-1 h-4 w-4" />
-									新規シリーズ
+									+ 新規シリーズ作成
 								</Button>
 							</div>
+							<SearchableSelect
+								id="edit-seriesId"
+								value={editForm.eventSeriesId || ""}
+								onChange={(value) =>
+									setEditForm({ ...editForm, eventSeriesId: value })
+								}
+								options={seriesList.map((s) => ({
+									value: s.id,
+									label: s.name,
+								}))}
+								placeholder="選択してください"
+								searchPlaceholder="シリーズを検索..."
+							/>
 						</div>
 						<div className="grid grid-cols-2 gap-4">
 							<div className="grid gap-2">


### PR DESCRIPTION
## 概要

イベント管理画面の編集ダイアログで、新規シリーズ作成ボタンのスタイルを EventEditDialog と統一し、UI の一貫性を向上させました。

## 変更内容

- events.tsx の編集ダイアログ内の新規シリーズ作成ボタンを以下のように変更:
  - ボタンスタイルをアウトライン型からリンク風（ghost variant）に変更
  - ボタンをラベルと同じ行に配置（justify-between レイアウト）
  - ボタンテキストを「新規シリーズ」から「+ 新規シリーズ作成」に変更
  - Plus アイコンコンポーネントを削除（テキストに含めた）
- EventEditDialog および ArtistAliasEditDialog と同じパターンに統一

## 影響範囲

- UI のみの変更（機能的な影響なし）
- イベント編集ダイアログのレイアウトが若干変更される
- ユーザー体験の一貫性が向上

## 補足事項

- 最近のダイアログ統一作業（PR #71, #70, #69など）の流れに沿った改善
- リンク風ボタンは補助的なアクションに適した UI パターン
