### PR TITLE
feat: アーティスト編集ダイアログのレイアウトとプレースホルダーを改善

### DIFF
--- a/apps/web/src/components/admin/artist-edit-dialog.tsx
+++ b/apps/web/src/components/admin/artist-edit-dialog.tsx
@@ -174,7 +174,7 @@ export function ArtistEditDialog({
 							disabled={isSubmitting}
 						/>
 					</div>
-					<div className="grid grid-cols-2 gap-4">
+					<div className="grid gap-4">
 						<div className="grid gap-2">
 							<Label htmlFor="artist-nameJa">日本語名</Label>
 							<Input
@@ -183,6 +183,7 @@ export function ArtistEditDialog({
 								onChange={(e) =>
 									setForm({ ...form, nameJa: e.target.value || null })
 								}
+								placeholder="例: ZUN"
 								disabled={isSubmitting}
 							/>
 						</div>
@@ -194,6 +195,7 @@ export function ArtistEditDialog({
 								onChange={(e) =>
 									setForm({ ...form, nameEn: e.target.value || null })
 								}
+								placeholder="例: ZUN"
 								disabled={isSubmitting}
 							/>
 						</div>
@@ -206,6 +208,7 @@ export function ArtistEditDialog({
 							onChange={(e) =>
 								setForm({ ...form, sortName: e.target.value || null })
 							}
+							placeholder="例: ZUN"
 							disabled={isSubmitting}
 						/>
 					</div>
@@ -217,6 +220,7 @@ export function ArtistEditDialog({
 							onChange={(e) =>
 								setForm({ ...form, notes: e.target.value || null })
 							}
+							placeholder="例: 来歴、特記事項など"
 							rows={3}
 							disabled={isSubmitting}
 						/>


### PR DESCRIPTION
## 概要

アーティスト編集ダイアログのレイアウトとプレースホルダーを改善し、他のダイアログとUI/UXを統一しました。

## 変更内容

- 日本語名と英語名のレイアウトを横並び（grid-cols-2）から縦並びに変更
- 日本語名フィールドにプレースホルダー「例: ZUN」を追加
- 英語名フィールドにプレースホルダー「例: ZUN」を追加
- ソート用名フィールドにプレースホルダー「例: ZUN」を追加
- 備考フィールドにプレースホルダー「例: 来歴、特記事項など」を追加

## 影響範囲

- アーティスト編集ダイアログ（新規作成・編集）のUIのみ
- 機能的な変更はなし

## 補足事項

- 公式楽曲編集ダイアログ（PR #71）の改善パターンに統一
- プレースホルダーの追加により、ユーザーに入力例を提示
- 縦並びレイアウトによりモバイル対応を強化
