### PR TITLE
feat: サークル編集ダイアログのレイアウトとプレースホルダーを改善

### DIFF
--- a/apps/web/src/components/admin/circle-edit-dialog.tsx
+++ b/apps/web/src/components/admin/circle-edit-dialog.tsx
@@ -174,7 +174,7 @@ export function CircleEditDialog({
 							disabled={isSubmitting}
 						/>
 					</div>
-					<div className="grid grid-cols-2 gap-4">
+					<div className="grid gap-4">
 						<div className="grid gap-2">
 							<Label htmlFor="circle-nameJa">日本語名</Label>
 							<Input
@@ -183,6 +183,7 @@ export function CircleEditDialog({
 								onChange={(e) =>
 									setForm({ ...form, nameJa: e.target.value || null })
 								}
+								placeholder="例: 上海アリス幻樂団"
 								disabled={isSubmitting}
 							/>
 						</div>
@@ -194,6 +195,7 @@ export function CircleEditDialog({
 								onChange={(e) =>
 									setForm({ ...form, nameEn: e.target.value || null })
 								}
+								placeholder="例: Team Shanghai Alice"
 								disabled={isSubmitting}
 							/>
 						</div>
@@ -206,6 +208,7 @@ export function CircleEditDialog({
 							onChange={(e) =>
 								setForm({ ...form, sortName: e.target.value || null })
 							}
+							placeholder="例: 上海アリス幻樂団"
 							disabled={isSubmitting}
 						/>
 					</div>
@@ -217,6 +220,7 @@ export function CircleEditDialog({
 							onChange={(e) =>
 								setForm({ ...form, notes: e.target.value || null })
 							}
+							placeholder="例: 来歴、特記事項など"
 							rows={3}
 							disabled={isSubmitting}
 						/>

--- a/apps/web/src/routes/admin/_admin/circles.tsx
+++ b/apps/web/src/routes/admin/_admin/circles.tsx
@@ -634,9 +634,10 @@ function CirclesPage() {
 										nameInitial: initial.nameInitial,
 									});
 								}}
+								placeholder="例: 上海アリス幻樂団"
 							/>
 						</div>
-						<div className="grid grid-cols-2 gap-4">
+						<div className="grid gap-4">
 							<div className="grid gap-2">
 								<Label htmlFor="edit-nameJa">日本語名</Label>
 								<Input
@@ -645,6 +646,7 @@ function CirclesPage() {
 									onChange={(e) =>
 										setEditForm({ ...editForm, nameJa: e.target.value })
 									}
+									placeholder="例: 上海アリス幻樂団"
 								/>
 							</div>
 							<div className="grid gap-2">
@@ -655,6 +657,7 @@ function CirclesPage() {
 									onChange={(e) =>
 										setEditForm({ ...editForm, nameEn: e.target.value })
 									}
+									placeholder="例: Team Shanghai Alice"
 								/>
 							</div>
 						</div>
@@ -666,6 +669,7 @@ function CirclesPage() {
 								onChange={(e) =>
 									setEditForm({ ...editForm, sortName: e.target.value })
 								}
+								placeholder="例: 上海アリス幻樂団"
 							/>
 						</div>
 						<div className="grid grid-cols-2 gap-4">
@@ -722,6 +726,7 @@ function CirclesPage() {
 								onChange={(e) =>
 									setEditForm({ ...editForm, notes: e.target.value })
 								}
+								placeholder="例: 来歴、特記事項など"
 								rows={2}
 							/>
 						</div>


### PR DESCRIPTION
## 概要

サークル編集ダイアログのレイアウトとプレースホルダーを改善しました。

## 変更内容

* 日本語名と英語名のフィールドを横並び（2列）から縦並びに変更
* 全フィールドにプレースホルダーを追加
  * 名前: `例: 上海アリス幻樂団`
  * 日本語名: `例: 上海アリス幻樂団`
  * 英語名: `例: Team Shanghai Alice`
  * ソート用名: `例: 上海アリス幻樂団`
  * 備考: `例: 来歴、特記事項など`

## 影響範囲

* `apps/web/src/components/admin/circle-edit-dialog.tsx` - サークル編集ダイアログコンポーネント
* `apps/web/src/routes/admin/_admin/circles.tsx` - サークル一覧画面の編集ダイアログ

## 補足事項

アーティスト編集ダイアログ（#73）と同様のUI改善を実施しました。
