### PR TITLE
feat: 作品編集ダイアログのレイアウトとプレースホルダーを改善

### DIFF
--- a/apps/web/src/components/admin/release-edit-dialog.tsx
+++ b/apps/web/src/components/admin/release-edit-dialog.tsx
@@ -138,7 +138,7 @@ export function ReleaseEditDialog({
 							{mutationError}
 						</div>
 					)}
-					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<div className="grid gap-4">
 						<div className="grid gap-2">
 							<Label>
 								作品名 <span className="text-error">*</span>
@@ -148,6 +148,7 @@ export function ReleaseEditDialog({
 								onChange={(e) =>
 									setEditForm({ ...editForm, name: e.target.value })
 								}
+								placeholder="例: 東方紅魔郷オリジナルサウンドトラック"
 							/>
 						</div>
 						<div className="grid gap-2">
@@ -157,6 +158,7 @@ export function ReleaseEditDialog({
 								onChange={(e) =>
 									setEditForm({ ...editForm, nameJa: e.target.value })
 								}
+								placeholder="例: 東方紅魔郷"
 							/>
 						</div>
 						<div className="grid gap-2">
@@ -166,6 +168,7 @@ export function ReleaseEditDialog({
 								onChange={(e) =>
 									setEditForm({ ...editForm, nameEn: e.target.value })
 								}
+								placeholder="例: Touhou Koumakyou"
 							/>
 						</div>
 						<div className="grid gap-2">
@@ -216,7 +219,7 @@ export function ReleaseEditDialog({
 								clearable
 							/>
 						</div>
-						<div className="grid gap-2 md:col-span-2">
+						<div className="grid gap-2">
 							<Label>イベント日</Label>
 							<SearchableSelect
 								value={editForm.eventDayId || ""}
@@ -235,13 +238,14 @@ export function ReleaseEditDialog({
 								clearable
 							/>
 						</div>
-						<div className="grid gap-2 md:col-span-2">
+						<div className="grid gap-2">
 							<Label>メモ</Label>
 							<Textarea
 								value={editForm.notes || ""}
 								onChange={(e) =>
 									setEditForm({ ...editForm, notes: e.target.value })
 								}
+								placeholder="例: 来歴、特記事項など"
 							/>
 						</div>
 					</div>

--- a/apps/web/src/routes/admin/_admin/releases.tsx
+++ b/apps/web/src/routes/admin/_admin/releases.tsx
@@ -588,29 +588,27 @@ function ReleasesPage() {
 								placeholder="例: 東方紅魔郷オリジナルサウンドトラック"
 							/>
 						</div>
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label htmlFor="create-nameJa">日本語名</Label>
-								<Input
-									id="create-nameJa"
-									value={createForm.nameJa || ""}
-									onChange={(e) =>
-										setCreateForm({ ...createForm, nameJa: e.target.value })
-									}
-									placeholder="例: 東方紅魔郷"
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label htmlFor="create-nameEn">英語名</Label>
-								<Input
-									id="create-nameEn"
-									value={createForm.nameEn || ""}
-									onChange={(e) =>
-										setCreateForm({ ...createForm, nameEn: e.target.value })
-									}
-									placeholder="例: Touhou Koumakyou"
-								/>
-							</div>
+						<div className="grid gap-2">
+							<Label htmlFor="create-nameJa">日本語名</Label>
+							<Input
+								id="create-nameJa"
+								value={createForm.nameJa || ""}
+								onChange={(e) =>
+									setCreateForm({ ...createForm, nameJa: e.target.value })
+								}
+								placeholder="例: 東方紅魔郷"
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="create-nameEn">英語名</Label>
+							<Input
+								id="create-nameEn"
+								value={createForm.nameEn || ""}
+								onChange={(e) =>
+									setCreateForm({ ...createForm, nameEn: e.target.value })
+								}
+								placeholder="例: Touhou Koumakyou"
+							/>
 						</div>
 						<div className="grid gap-4">
 							<div className="grid gap-2">
@@ -654,6 +652,7 @@ function ReleasesPage() {
 									setCreateForm({ ...createForm, notes: e.target.value })
 								}
 								rows={3}
+								placeholder="例: 来歴、特記事項など"
 							/>
 						</div>
 					</div>
@@ -706,29 +705,27 @@ function ReleasesPage() {
 								placeholder="例: 東方紅魔郷オリジナルサウンドトラック"
 							/>
 						</div>
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label htmlFor="edit-nameJa">日本語名</Label>
-								<Input
-									id="edit-nameJa"
-									value={editForm.nameJa || ""}
-									onChange={(e) =>
-										setEditForm({ ...editForm, nameJa: e.target.value })
-									}
-									placeholder="例: 東方紅魔郷"
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label htmlFor="edit-nameEn">英語名</Label>
-								<Input
-									id="edit-nameEn"
-									value={editForm.nameEn || ""}
-									onChange={(e) =>
-										setEditForm({ ...editForm, nameEn: e.target.value })
-									}
-									placeholder="例: Touhou Koumakyou"
-								/>
-							</div>
+						<div className="grid gap-2">
+							<Label htmlFor="edit-nameJa">日本語名</Label>
+							<Input
+								id="edit-nameJa"
+								value={editForm.nameJa || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, nameJa: e.target.value })
+								}
+								placeholder="例: 東方紅魔郷"
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="edit-nameEn">英語名</Label>
+							<Input
+								id="edit-nameEn"
+								value={editForm.nameEn || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, nameEn: e.target.value })
+								}
+								placeholder="例: Touhou Koumakyou"
+							/>
 						</div>
 						<div className="grid gap-4">
 							<div className="grid gap-2">
@@ -772,6 +769,7 @@ function ReleasesPage() {
 									setEditForm({ ...editForm, notes: e.target.value })
 								}
 								rows={3}
+								placeholder="例: 来歴、特記事項など"
 							/>
 						</div>
 


### PR DESCRIPTION
## 概要

作品編集ダイアログのレイアウトを改善し、日本語名・英語名を縦並びに変更、全フィールドにプレースホルダーを追加しました。

## 変更内容

* `release-edit-dialog.tsx`: 日本語名・英語名を横並び（`grid-cols-2`）から縦並びに変更し、全フィールドにプレースホルダーを追加
* `releases.tsx`: 新規作成・編集ダイアログの日本語名・英語名を縦並びに変更し、メモフィールドにプレースホルダーを追加
* アーティスト・サークル編集ダイアログと同じレイアウトパターンに統一

## 影響範囲

* 作品編集ダイアログ・新規作成ダイアログのレイアウトが変更されます
* フィールドにプレースホルダーが表示されるようになり、ユーザビリティが向上します
* 機能的な変更はなく、既存のデータや動作には影響しません

## 補足事項

* PR #73（アーティスト）、PR #74（サークル）と同じUI改善パターンを適用
* マスタデータ管理画面全体でUIの一貫性が向上しました
