### PR TITLE
feat: トラック編集ダイアログのレイアウトとプレースホルダーを改善

### DIFF
--- a/apps/web/src/components/admin/track-edit-dialog.tsx
+++ b/apps/web/src/components/admin/track-edit-dialog.tsx
@@ -75,58 +75,57 @@ export function TrackEditDialog({
 							{mutationError}
 						</div>
 					)}
-					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-						<div className="grid gap-2">
-							<Label htmlFor="name">
-								トラック名 <span className="text-error">*</span>
-							</Label>
-							<Input
-								id="name"
-								value={editForm.name || ""}
-								onChange={(e) =>
-									setEditForm({ ...editForm, name: e.target.value })
-								}
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label htmlFor="trackNumber">
-								トラック番号 <span className="text-error">*</span>
-							</Label>
-							<Input
-								id="trackNumber"
-								type="number"
-								min="1"
-								value={editForm.trackNumber || ""}
-								onChange={(e) =>
-									setEditForm({
-										...editForm,
-										trackNumber: Number.parseInt(e.target.value, 10) || 1,
-									})
-								}
-							/>
-						</div>
+					<div className="grid gap-2">
+						<Label htmlFor="name">
+							トラック名 <span className="text-error">*</span>
+						</Label>
+						<Input
+							id="name"
+							value={editForm.name || ""}
+							onChange={(e) =>
+								setEditForm({ ...editForm, name: e.target.value })
+							}
+							placeholder="例: ネイティブフェイス"
+						/>
 					</div>
-					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-						<div className="grid gap-2">
-							<Label htmlFor="nameJa">日本語名</Label>
-							<Input
-								id="nameJa"
-								value={editForm.nameJa || ""}
-								onChange={(e) =>
-									setEditForm({ ...editForm, nameJa: e.target.value })
-								}
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label htmlFor="nameEn">英語名</Label>
-							<Input
-								id="nameEn"
-								value={editForm.nameEn || ""}
-								onChange={(e) =>
-									setEditForm({ ...editForm, nameEn: e.target.value })
-								}
-							/>
-						</div>
+					<div className="grid gap-2">
+						<Label htmlFor="trackNumber">
+							トラック番号 <span className="text-error">*</span>
+						</Label>
+						<Input
+							id="trackNumber"
+							type="number"
+							min="1"
+							value={editForm.trackNumber || ""}
+							onChange={(e) =>
+								setEditForm({
+									...editForm,
+									trackNumber: Number.parseInt(e.target.value, 10) || 1,
+								})
+							}
+						/>
+					</div>
+					<div className="grid gap-2">
+						<Label htmlFor="nameJa">日本語名</Label>
+						<Input
+							id="nameJa"
+							value={editForm.nameJa || ""}
+							onChange={(e) =>
+								setEditForm({ ...editForm, nameJa: e.target.value })
+							}
+							placeholder="例: ネイティブフェイス"
+						/>
+					</div>
+					<div className="grid gap-2">
+						<Label htmlFor="nameEn">英語名</Label>
+						<Input
+							id="nameEn"
+							value={editForm.nameEn || ""}
+							onChange={(e) =>
+								setEditForm({ ...editForm, nameEn: e.target.value })
+							}
+							placeholder="例: Native Face"
+						/>
 					</div>
 				</div>
 				<DialogFooter>

--- a/apps/web/src/routes/admin/_admin/tracks.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks.tsx
@@ -534,32 +534,30 @@ function TracksPage() {
 												: createForm.nameJa,
 									});
 								}}
-								placeholder="トラック名を入力"
+								placeholder="例: ネイティブフェイス"
 							/>
 						</div>
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label htmlFor="create-nameJa">日本語名</Label>
-								<Input
-									id="create-nameJa"
-									value={createForm.nameJa || ""}
-									onChange={(e) =>
-										setCreateForm({ ...createForm, nameJa: e.target.value })
-									}
-									placeholder="日本語名を入力"
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label htmlFor="create-nameEn">英語名</Label>
-								<Input
-									id="create-nameEn"
-									value={createForm.nameEn || ""}
-									onChange={(e) =>
-										setCreateForm({ ...createForm, nameEn: e.target.value })
-									}
-									placeholder="英語名を入力"
-								/>
-							</div>
+						<div className="grid gap-2">
+							<Label htmlFor="create-nameJa">日本語名</Label>
+							<Input
+								id="create-nameJa"
+								value={createForm.nameJa || ""}
+								onChange={(e) =>
+									setCreateForm({ ...createForm, nameJa: e.target.value })
+								}
+								placeholder="例: ネイティブフェイス"
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="create-nameEn">英語名</Label>
+							<Input
+								id="create-nameEn"
+								value={createForm.nameEn || ""}
+								onChange={(e) =>
+									setCreateForm({ ...createForm, nameEn: e.target.value })
+								}
+								placeholder="例: Native Face"
+							/>
 						</div>
 						<div className="grid gap-2">
 							<Label htmlFor="create-trackNumber">
@@ -578,6 +576,7 @@ function TracksPage() {
 											: undefined,
 									})
 								}
+								placeholder="1"
 							/>
 						</div>
 						{mutationError && (
@@ -645,32 +644,30 @@ function TracksPage() {
 												: editForm.nameJa,
 									});
 								}}
-								placeholder="トラック名を入力"
+								placeholder="例: ネイティブフェイス"
 							/>
 						</div>
-						<div className="grid grid-cols-2 gap-4">
-							<div className="grid gap-2">
-								<Label htmlFor="edit-nameJa">日本語名</Label>
-								<Input
-									id="edit-nameJa"
-									value={editForm.nameJa || ""}
-									onChange={(e) =>
-										setEditForm({ ...editForm, nameJa: e.target.value })
-									}
-									placeholder="日本語名を入力"
-								/>
-							</div>
-							<div className="grid gap-2">
-								<Label htmlFor="edit-nameEn">英語名</Label>
-								<Input
-									id="edit-nameEn"
-									value={editForm.nameEn || ""}
-									onChange={(e) =>
-										setEditForm({ ...editForm, nameEn: e.target.value })
-									}
-									placeholder="英語名を入力"
-								/>
-							</div>
+						<div className="grid gap-2">
+							<Label htmlFor="edit-nameJa">日本語名</Label>
+							<Input
+								id="edit-nameJa"
+								value={editForm.nameJa || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, nameJa: e.target.value })
+								}
+								placeholder="例: ネイティブフェイス"
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="edit-nameEn">英語名</Label>
+							<Input
+								id="edit-nameEn"
+								value={editForm.nameEn || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, nameEn: e.target.value })
+								}
+								placeholder="例: Native Face"
+							/>
 						</div>
 						<div className="grid gap-2">
 							<Label htmlFor="edit-trackNumber">
@@ -689,6 +686,7 @@ function TracksPage() {
 											: undefined,
 									})
 								}
+								placeholder="1"
 							/>
 						</div>
 						{mutationError && (


### PR DESCRIPTION
## 概要

トラック編集ダイアログのレイアウトを改善し、すべてのフィールドにプレースホルダーを追加しました。

## 問題の原因

<!-- バグ修正の場合のみ記載してください -->

## 変更内容

### 1. `track-edit-dialog.tsx` (詳細ページの編集ダイアログ)
* トラック名・トラック番号・日本語名・英語名のレイアウトを横並び（`grid-cols-2`）から縦並びに変更
* トラック名に `placeholder="例: ネイティブフェイス"` を追加
* 日本語名に `placeholder="例: ネイティブフェイス"` を追加
* 英語名に `placeholder="例: Native Face"` を追加

### 2. `tracks.tsx` (リストページの新規作成・編集ダイアログ)
* 新規作成ダイアログ・編集ダイアログの日本語名・英語名のレイアウトを横並び（`grid-cols-2`）から縦並びに変更
* トラック名のプレースホルダーを `"トラック名を入力"` から `"例: ネイティブフェイス"` に変更
* 日本語名のプレースホルダーを `"日本語名を入力"` から `"例: ネイティブフェイス"` に変更
* 英語名のプレースホルダーを `"英語名を入力"` から `"例: Native Face"` に変更
* トラック番号に `placeholder="1"` を追加

## 影響範囲

* **既存データ**: 影響なし（表示ロジックは変更していません）
* **機能**: 影響なし（UIレイアウトとプレースホルダーテキストのみの変更）

## 補足事項

* アーティスト編集ダイアログ（PR #73）、サークル編集ダイアログ（PR #74）、リリース編集ダイアログ（PR #75）と同様のUI改善パターンを適用
* マスタデータ管理画面全体で一貫したUIデザインを実現
* 縦並びレイアウトにより、各フィールドが広く使えるようになりモバイルでも見やすくなります
* 具体的なプレースホルダー例（東方Projectの曲名）により、入力内容がより明確になります
