### PR TITLE
feat: 作品管理の編集機能を統一し、イベント・イベント日の設定機能を強化

### DIFF
--- a/apps/web/src/routes/admin/_admin/releases_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/releases_.$id.tsx
@@ -308,16 +308,17 @@ function ReleaseDetailPage() {
 		const events = eventsData?.data ?? [];
 		return events.map((e) => ({
 			value: e.id,
-			label: e.seriesName ? `${e.seriesName} ${e.name}` : e.name,
+			label: e.seriesName ? `【${e.seriesName}】${e.name}` : e.name,
 		}));
 	}, [eventsData?.data]);
 
 	// イベント日オプション
 	const eventDayOptions = useMemo(() => {
 		const days = eventDaysData ?? [];
+		const hasMultipleDays = days.length > 1;
 		return days.map((d) => ({
 			value: d.id,
-			label: `Day ${d.dayNumber} (${d.date})`,
+			label: hasMultipleDays ? `${d.dayNumber}日目（${d.date}）` : d.date,
 		}));
 	}, [eventDaysData]);
 


### PR DESCRIPTION
## 概要

作品管理の一覧画面と詳細画面の編集機能をReleaseEditDialogに統一し、イベント・イベント日の設定機能を強化しました。

## 変更内容

### ReleaseEditDialog（共通コンポーネント）
* イベント表示形式を「【シリーズ名】イベント名」に変更（シリーズなしの場合は「イベント名」のみ）
* イベント日表示形式を「n日目（日付）」または「日付」のみに変更（日数に応じて自動切り替え）
* イベント選択時に1日目のイベント日を自動設定
* イベント日が1日のみの場合は変更不可（disabled）に設定
* イベント日選択時に発売日を自動設定し、発売日フィールドを固定（disabled）
* フィールド並び順を「イベント → イベント日 → 発売日」に変更

### 一覧画面（releases.tsx）
* ディスク追加機能を削除（詳細画面に機能が移動済みのため）
* 編集ダイアログをReleaseEditDialogコンポーネントに統一
* 新規作成ダイアログにイベント・イベント日選択機能を追加
* 新規作成時にもイベント日の1日目を自動設定

### 詳細画面（releases_.$id.tsx）
* イベント・イベント日の表示形式を一覧画面と統一

## 影響範囲

* 作品管理の一覧画面（/admin/releases）
  - 新規作成ダイアログにイベント選択機能が追加
  - 編集ダイアログからディスク管理機能が削除
  - 編集UIがReleaseEditDialogに統一
* 作品管理の詳細画面（/admin/releases/:id）
  - イベント・イベント日の表示形式が変更
* ReleaseEditDialogコンポーネント
  - イベント・イベント日の自動設定機能が追加
  - フィールドのdisabled制御が追加

## 補足事項

### useEffectの依存配列について
イベント日の自動設定を行うuseEffectにおいて、`editForm.eventDayId`と`createForm.eventDayId`を依存配列に含めていません。これは無限ループを防ぐための意図的な設計です。条件式`!editForm.eventDayId`により、手動変更がある場合は自動設定をスキップします。

### ディスク管理機能について
一覧画面からディスク追加機能を削除しましたが、詳細画面では引き続きディスク管理が可能です。責任の分離により、UIがシンプルになりました。