### PR TITLE
feat: アーティスト詳細ページの情報を拡充

### DIFF
--- a/apps/server/src/routes/admin/artists/circles.ts
+++ b/apps/server/src/routes/admin/artists/circles.ts
@@ -1,0 +1,116 @@
+import {
+	circles,
+	db,
+	eq,
+	inArray,
+	releaseCircles,
+	trackCredits,
+	tracks,
+} from "@thac/db";
+import { Hono } from "hono";
+import type { AdminContext } from "../../../middleware/admin-auth";
+
+const artistCirclesRouter = new Hono<AdminContext>();
+
+// アーティストの参加サークル一覧取得
+// 経路: artist → trackCredits → tracks → releases → releaseCircles → circles
+artistCirclesRouter.get("/:artistId/circles", async (c) => {
+	const artistId = c.req.param("artistId");
+
+	// アーティストのクレジット一覧からトラックIDを取得
+	const creditsResult = await db
+		.select({
+			trackId: trackCredits.trackId,
+		})
+		.from(trackCredits)
+		.where(eq(trackCredits.artistId, artistId));
+
+	if (creditsResult.length === 0) {
+		return c.json([]);
+	}
+
+	const trackIds = [...new Set(creditsResult.map((c) => c.trackId))];
+
+	// トラックからリリースIDを取得
+	const tracksResult = await db
+		.select({
+			releaseId: tracks.releaseId,
+		})
+		.from(tracks)
+		.where(inArray(tracks.id, trackIds));
+
+	const releaseIds = [
+		...new Set(
+			tracksResult
+				.map((t) => t.releaseId)
+				.filter((id): id is string => id !== null),
+		),
+	];
+
+	if (releaseIds.length === 0) {
+		return c.json([]);
+	}
+
+	// リリースサークル情報を取得
+	const releaseCirclesResult = await db
+		.select({
+			releaseId: releaseCircles.releaseId,
+			circleId: releaseCircles.circleId,
+			participationType: releaseCircles.participationType,
+		})
+		.from(releaseCircles)
+		.where(inArray(releaseCircles.releaseId, releaseIds));
+
+	if (releaseCirclesResult.length === 0) {
+		return c.json([]);
+	}
+
+	// サークル情報を取得
+	const circleIds = [...new Set(releaseCirclesResult.map((rc) => rc.circleId))];
+	const circleList = await db
+		.select({
+			id: circles.id,
+			name: circles.name,
+		})
+		.from(circles)
+		.where(inArray(circles.id, circleIds))
+		.orderBy(circles.name);
+
+	// サークルごとにリリース数と参加形態を集計
+	const circleStats = new Map<
+		string,
+		{
+			releaseCount: number;
+			participationTypes: Set<string>;
+		}
+	>();
+
+	for (const rc of releaseCirclesResult) {
+		const stats = circleStats.get(rc.circleId) || {
+			releaseCount: 0,
+			participationTypes: new Set<string>(),
+		};
+		// 同じサークルでも異なるリリースをカウント
+		if (!circleStats.has(rc.circleId)) {
+			stats.releaseCount = 0;
+		}
+		stats.releaseCount++;
+		stats.participationTypes.add(rc.participationType);
+		circleStats.set(rc.circleId, stats);
+	}
+
+	// レスポンスを整形
+	const result = circleList.map((circle) => {
+		const stats = circleStats.get(circle.id);
+		return {
+			circleId: circle.id,
+			circleName: circle.name,
+			releaseCount: stats?.releaseCount ?? 0,
+			participationTypes: stats ? Array.from(stats.participationTypes) : [],
+		};
+	});
+
+	return c.json(result);
+});
+
+export { artistCirclesRouter };

--- a/apps/server/src/routes/admin/artists/index.ts
+++ b/apps/server/src/routes/admin/artists/index.ts
@@ -14,12 +14,14 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { artistCirclesRouter } from "./circles";
 import { artistTracksRouter } from "./tracks";
 
 const artistsRouter = new Hono<AdminContext>();
 
 // サブルーターをマウント
 artistsRouter.route("/", artistTracksRouter);
+artistsRouter.route("/", artistCirclesRouter);
 
 // 一覧取得（ページネーション、検索、頭文字フィルタ対応）
 artistsRouter.get("/", async (c) => {

--- a/apps/web/src/components/admin/artist-alias-edit-dialog.tsx
+++ b/apps/web/src/components/admin/artist-alias-edit-dialog.tsx
@@ -29,6 +29,8 @@ export interface ArtistAliasFormData {
 	aliasTypeCode: string | null;
 	initialScript: InitialScript;
 	nameInitial: string | null;
+	periodFrom: string | null;
+	periodTo: string | null;
 }
 
 export interface ArtistAliasEditDialogProps {
@@ -56,6 +58,8 @@ export function ArtistAliasEditDialog({
 		aliasTypeCode: "main",
 		initialScript: "latin",
 		nameInitial: null,
+		periodFrom: null,
+		periodTo: null,
 	});
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -98,6 +102,8 @@ export function ArtistAliasEditDialog({
 					aliasTypeCode: alias.aliasTypeCode,
 					initialScript: alias.initialScript,
 					nameInitial: alias.nameInitial,
+					periodFrom: alias.periodFrom,
+					periodTo: alias.periodTo,
 				});
 			} else {
 				setForm({
@@ -106,6 +112,8 @@ export function ArtistAliasEditDialog({
 					aliasTypeCode: "main",
 					initialScript: "latin",
 					nameInitial: null,
+					periodFrom: null,
+					periodTo: null,
 				});
 			}
 			setError(null);
@@ -175,8 +183,8 @@ export function ArtistAliasEditDialog({
 					aliasTypeCode: form.aliasTypeCode,
 					initialScript: form.initialScript,
 					nameInitial: form.nameInitial,
-					periodFrom: null,
-					periodTo: null,
+					periodFrom: form.periodFrom || null,
+					periodTo: form.periodTo || null,
 				});
 			} else if (alias) {
 				await artistAliasesApi.update(alias.id, {
@@ -185,6 +193,8 @@ export function ArtistAliasEditDialog({
 					aliasTypeCode: form.aliasTypeCode,
 					initialScript: form.initialScript,
 					nameInitial: form.nameInitial,
+					periodFrom: form.periodFrom || null,
+					periodTo: form.periodTo || null,
 				});
 			}
 			onOpenChange(false);
@@ -272,6 +282,32 @@ export function ArtistAliasEditDialog({
 									</option>
 								))}
 							</Select>
+						</div>
+						<div className="grid grid-cols-2 gap-4">
+							<div className="grid gap-2">
+								<Label htmlFor="period-from">活動開始</Label>
+								<Input
+									id="period-from"
+									type="month"
+									value={form.periodFrom || ""}
+									onChange={(e) =>
+										setForm({ ...form, periodFrom: e.target.value || null })
+									}
+									disabled={isSubmitting}
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label htmlFor="period-to">活動終了</Label>
+								<Input
+									id="period-to"
+									type="month"
+									value={form.periodTo || ""}
+									onChange={(e) =>
+										setForm({ ...form, periodTo: e.target.value || null })
+									}
+									disabled={isSubmitting}
+								/>
+							</div>
 						</div>
 					</div>
 					<DialogFooter>

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -964,6 +964,7 @@ export interface ArtistTrackRelease {
 	id: string;
 	name: string;
 	releaseDate: string | null;
+	circleNames: string | null;
 }
 
 export interface ArtistTrack {
@@ -974,10 +975,24 @@ export interface ArtistTrack {
 	release: ArtistTrackRelease | null;
 }
 
+export interface ArtistStatistics {
+	releaseCount: number;
+	earliestReleaseDate: string | null;
+	latestReleaseDate: string | null;
+}
+
 export interface ArtistTracksResponse {
 	totalUniqueTrackCount: number;
 	byRole: Record<string, number>;
 	tracks: ArtistTrack[];
+	statistics: ArtistStatistics;
+}
+
+export interface ArtistCircle {
+	circleId: string;
+	circleName: string;
+	releaseCount: number;
+	participationTypes: string[];
 }
 
 // Artists
@@ -1003,6 +1018,8 @@ export const artistsApi = {
 		fetchWithAuth<ArtistWithAliases>(`/api/admin/artists/${id}`),
 	getTracks: (id: string) =>
 		fetchWithAuth<ArtistTracksResponse>(`/api/admin/artists/${id}/tracks`),
+	getCircles: (id: string) =>
+		fetchWithAuth<ArtistCircle[]>(`/api/admin/artists/${id}/circles`),
 	create: (data: Omit<Artist, "createdAt" | "updatedAt">) =>
 		fetchWithAuth<Artist>("/api/admin/artists", {
 			method: "POST",

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -19,6 +19,7 @@ import type {
 	AliasType,
 	Artist,
 	ArtistAlias,
+	ArtistCircle,
 	ArtistTracksResponse,
 	ArtistWithAliases,
 	Circle,
@@ -106,6 +107,16 @@ export const artistTracksQueryOptions = (id: string) =>
 		queryKey: ["artist", id, "tracks"],
 		queryFn: () =>
 			ssrFetch<ArtistTracksResponse>(`/api/admin/artists/${id}/tracks`),
+		staleTime: STALE_TIME.SHORT,
+	});
+
+/**
+ * アーティストの参加サークルのqueryOptions
+ */
+export const artistCirclesQueryOptions = (id: string) =>
+	queryOptions({
+		queryKey: ["artist", id, "circles"],
+		queryFn: () => ssrFetch<ArtistCircle[]>(`/api/admin/artists/${id}/circles`),
 		staleTime: STALE_TIME.SHORT,
 	});
 


### PR DESCRIPTION
## 概要

アーティスト詳細ページに関連情報を表示し、管理機能を拡充する。

Closes #80

## 変更内容

### 別名義CRUD機能の拡張
* 活動期間フィールド（periodFrom/periodTo）を追加
* テーブルに編集・削除ボタンを配置
* 別名義追加ボタンをヘッダーに配置

### 統計情報セクション追加
* 参加トラック数、参加リリース数、活動期間を表示
* 役割別内訳をBadgeで表示

### 参加サークル一覧セクション追加
* 新規API: `GET /api/admin/artists/:id/circles`
* サークル名（リンク）、参加形態（Badge）、リリース数を表示

### 関連楽曲テーブルの改善
* ヘッダーを「作品」「トラック名」に変更
* トラック番号列とサークル列を追加
* 作品名→トラック番号でソート
* フロントエンドページネーション（20件/ページ）
* N+1クエリを回避（一括取得＆マップ変換）

## 影響範囲

* アーティスト詳細ページ（`/admin/artists/:id`）
* アーティスト関連API

## 補足事項

* APIレスポンスに`statistics`フィールドと`circleNames`フィールドを追加
* 既存のフロントエンド型定義を拡張