### PR TITLE
feat: アーティスト名義詳細ページの情報を拡充

### DIFF
--- a/apps/server/src/routes/admin/artist-aliases/circles.ts
+++ b/apps/server/src/routes/admin/artist-aliases/circles.ts
@@ -1,0 +1,116 @@
+import {
+	circles,
+	db,
+	eq,
+	inArray,
+	releaseCircles,
+	trackCredits,
+	tracks,
+} from "@thac/db";
+import { Hono } from "hono";
+import type { AdminContext } from "../../../middleware/admin-auth";
+
+const aliasCirclesRouter = new Hono<AdminContext>();
+
+// アーティスト名義の参加サークル一覧取得
+// 経路: artistAlias → trackCredits (artistAliasId) → tracks → releases → releaseCircles → circles
+aliasCirclesRouter.get("/:aliasId/circles", async (c) => {
+	const aliasId = c.req.param("aliasId");
+
+	// アーティスト名義のクレジット一覧からトラックIDを取得
+	const creditsResult = await db
+		.select({
+			trackId: trackCredits.trackId,
+		})
+		.from(trackCredits)
+		.where(eq(trackCredits.artistAliasId, aliasId));
+
+	if (creditsResult.length === 0) {
+		return c.json([]);
+	}
+
+	const trackIds = [...new Set(creditsResult.map((c) => c.trackId))];
+
+	// トラックからリリースIDを取得
+	const tracksResult = await db
+		.select({
+			releaseId: tracks.releaseId,
+		})
+		.from(tracks)
+		.where(inArray(tracks.id, trackIds));
+
+	const releaseIds = [
+		...new Set(
+			tracksResult
+				.map((t) => t.releaseId)
+				.filter((id): id is string => id !== null),
+		),
+	];
+
+	if (releaseIds.length === 0) {
+		return c.json([]);
+	}
+
+	// リリースサークル情報を取得
+	const releaseCirclesResult = await db
+		.select({
+			releaseId: releaseCircles.releaseId,
+			circleId: releaseCircles.circleId,
+			participationType: releaseCircles.participationType,
+		})
+		.from(releaseCircles)
+		.where(inArray(releaseCircles.releaseId, releaseIds));
+
+	if (releaseCirclesResult.length === 0) {
+		return c.json([]);
+	}
+
+	// サークル情報を取得
+	const circleIds = [...new Set(releaseCirclesResult.map((rc) => rc.circleId))];
+	const circleList = await db
+		.select({
+			id: circles.id,
+			name: circles.name,
+		})
+		.from(circles)
+		.where(inArray(circles.id, circleIds))
+		.orderBy(circles.name);
+
+	// サークルごとにリリース数と参加形態を集計
+	const circleStats = new Map<
+		string,
+		{
+			releaseCount: number;
+			participationTypes: Set<string>;
+		}
+	>();
+
+	for (const rc of releaseCirclesResult) {
+		const stats = circleStats.get(rc.circleId) || {
+			releaseCount: 0,
+			participationTypes: new Set<string>(),
+		};
+		// 同じサークルでも異なるリリースをカウント
+		if (!circleStats.has(rc.circleId)) {
+			stats.releaseCount = 0;
+		}
+		stats.releaseCount++;
+		stats.participationTypes.add(rc.participationType);
+		circleStats.set(rc.circleId, stats);
+	}
+
+	// レスポンスを整形
+	const result = circleList.map((circle) => {
+		const stats = circleStats.get(circle.id);
+		return {
+			circleId: circle.id,
+			circleName: circle.name,
+			releaseCount: stats?.releaseCount ?? 0,
+			participationTypes: stats ? Array.from(stats.participationTypes) : [],
+		};
+	});
+
+	return c.json(result);
+});
+
+export { aliasCirclesRouter };

--- a/apps/server/src/routes/admin/artist-aliases/index.ts
+++ b/apps/server/src/routes/admin/artist-aliases/index.ts
@@ -12,12 +12,14 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { aliasCirclesRouter } from "./circles";
 import { aliasTracksRouter } from "./tracks";
 
 const artistAliasesRouter = new Hono<AdminContext>();
 
 // サブルーターをマウント
 artistAliasesRouter.route("/", aliasTracksRouter);
+artistAliasesRouter.route("/", aliasCirclesRouter);
 
 // 一覧取得（ページネーション、検索、アーティストIDフィルタ対応）
 artistAliasesRouter.get("/", async (c) => {

--- a/apps/server/src/routes/admin/artist-aliases/tracks.ts
+++ b/apps/server/src/routes/admin/artist-aliases/tracks.ts
@@ -1,7 +1,9 @@
 import {
+	circles,
 	db,
 	eq,
 	inArray,
+	releaseCircles,
 	releases,
 	trackCreditRoles,
 	trackCredits,
@@ -31,6 +33,11 @@ aliasTracksRouter.get("/:aliasId/tracks", async (c) => {
 			totalUniqueTrackCount: 0,
 			byRole: {},
 			tracks: [],
+			statistics: {
+				releaseCount: 0,
+				earliestReleaseDate: null,
+				latestReleaseDate: null,
+			},
 		});
 	}
 
@@ -78,6 +85,46 @@ aliasTracksRouter.get("/:aliasId/tracks", async (c) => {
 
 	const releaseMap = new Map(releaseList.map((r) => [r.id, r]));
 
+	// リリースサークル情報を取得
+	const releaseCirclesList =
+		releaseIds.length > 0
+			? await db
+					.select({
+						releaseId: releaseCircles.releaseId,
+						circleId: releaseCircles.circleId,
+					})
+					.from(releaseCircles)
+					.where(inArray(releaseCircles.releaseId, releaseIds))
+			: [];
+
+	// サークル情報を取得
+	const circleIds = [...new Set(releaseCirclesList.map((rc) => rc.circleId))];
+	const circleList =
+		circleIds.length > 0
+			? await db
+					.select({
+						id: circles.id,
+						name: circles.name,
+					})
+					.from(circles)
+					.where(inArray(circles.id, circleIds))
+			: [];
+
+	const circleMap = new Map(circleList.map((c) => [c.id, c.name]));
+
+	// リリースIDからサークル名一覧へのマップを作成
+	const releaseCircleNamesMap = new Map<string, string[]>();
+	for (const rc of releaseCirclesList) {
+		const circleName = circleMap.get(rc.circleId);
+		if (circleName) {
+			const names = releaseCircleNamesMap.get(rc.releaseId) || [];
+			if (!names.includes(circleName)) {
+				names.push(circleName);
+			}
+			releaseCircleNamesMap.set(rc.releaseId, names);
+		}
+	}
+
 	// クレジットIDからトラックIDへのマップ
 	const creditToTrack = new Map(credits.map((c) => [c.creditId, c.trackId]));
 
@@ -103,27 +150,66 @@ aliasTracksRouter.get("/:aliasId/tracks", async (c) => {
 	}
 
 	// トラック情報を整形
-	const tracksWithRelease = trackList.map((t) => {
-		const release = t.releaseId ? releaseMap.get(t.releaseId) : undefined;
-		return {
-			id: t.id,
-			name: t.name,
-			nameJa: t.nameJa,
-			trackNumber: t.trackNumber,
-			release: release
-				? {
-						id: release.id,
-						name: release.name,
-						releaseDate: release.releaseDate,
-					}
-				: null,
-		};
-	});
+	const tracksWithRelease = trackList
+		.map((t) => {
+			const release = t.releaseId ? releaseMap.get(t.releaseId) : undefined;
+			const circleNames = t.releaseId
+				? releaseCircleNamesMap.get(t.releaseId)
+				: undefined;
+			return {
+				id: t.id,
+				name: t.name,
+				nameJa: t.nameJa,
+				trackNumber: t.trackNumber,
+				release: release
+					? {
+							id: release.id,
+							name: release.name,
+							releaseDate: release.releaseDate,
+							circleNames: circleNames ? circleNames.join(" / ") : null,
+						}
+					: null,
+			};
+		})
+		// 作品名 → トラック番号でソート
+		.sort((a, b) => {
+			// 作品なしは後ろへ
+			if (!a.release && b.release) return 1;
+			if (a.release && !b.release) return -1;
+			if (!a.release && !b.release) return a.name.localeCompare(b.name);
+
+			// ここに到達した時点で両方ともreleaseが存在する（上記の条件で除外済み）
+			// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
+			const releaseA = a.release!;
+			// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
+			const releaseB = b.release!;
+
+			// 作品名でソート
+			const releaseCompare = releaseA.name.localeCompare(releaseB.name);
+			if (releaseCompare !== 0) return releaseCompare;
+
+			// 同じ作品内ではトラック番号でソート
+			return a.trackNumber - b.trackNumber;
+		});
+
+	// 統計情報を計算
+	const releaseDates = releaseList
+		.map((r) => r.releaseDate)
+		.filter((d): d is string => d !== null)
+		.sort();
+
+	const statistics = {
+		releaseCount: releaseList.length,
+		earliestReleaseDate: releaseDates.length > 0 ? releaseDates[0] : null,
+		latestReleaseDate:
+			releaseDates.length > 0 ? releaseDates[releaseDates.length - 1] : null,
+	};
 
 	return c.json({
 		totalUniqueTrackCount: trackIds.length,
 		byRole: roleCount,
 		tracks: tracksWithRelease,
+		statistics,
 	});
 });
 

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -178,6 +178,17 @@ export const artistAliasTracksQueryOptions = (id: string) =>
 		staleTime: STALE_TIME.SHORT,
 	});
 
+/**
+ * アーティストエイリアスの参加サークルのqueryOptions
+ */
+export const artistAliasCirclesQueryOptions = (id: string) =>
+	queryOptions({
+		queryKey: ["artistAlias", id, "circles"],
+		queryFn: () =>
+			ssrFetch<ArtistCircle[]>(`/api/admin/artist-aliases/${id}/circles`),
+		staleTime: STALE_TIME.SHORT,
+	});
+
 // ===== サークル =====
 
 interface CircleListParams {


### PR DESCRIPTION
## 概要

アーティスト詳細ページと同等の機能をアーティスト名義詳細ページに実装

## 変更内容

* 統計情報カードを追加（参加トラック数、参加リリース数、活動期間、役割別内訳）
* 参加サークルカードを追加（サークル名、参加形態、リリース数）
* 関連楽曲テーブルを改善（ページネーション、サークル名・トラック番号カラム追加）
* tracks APIにstatisticsとcircleNamesを追加
* circles API新規作成（アーティスト名義経由のサークル一覧取得）

## 影響範囲

* アーティスト名義詳細ページ（`/admin/artist-aliases/:id`）
* APIエンドポイント
  * `GET /api/admin/artist-aliases/:id/tracks` - レスポンス拡張
  * `GET /api/admin/artist-aliases/:id/circles` - 新規追加