### PR TITLE
feat: トラック一覧にバッチ削除機能を追加

### DIFF
--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -1,17 +1,28 @@
 import type * as React from "react";
+import { useEffect, useRef } from "react";
 
 import { cn } from "@/lib/utils";
 
 interface CheckboxProps extends Omit<React.ComponentProps<"input">, "type"> {
 	onCheckedChange?: (checked: boolean) => void;
+	indeterminate?: boolean;
 }
 
 function Checkbox({
 	className,
 	onCheckedChange,
 	onChange,
+	indeterminate = false,
 	...props
 }: CheckboxProps) {
+	const ref = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (ref.current) {
+			ref.current.indeterminate = indeterminate;
+		}
+	}, [indeterminate]);
+
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		onChange?.(e);
 		onCheckedChange?.(e.target.checked);
@@ -19,6 +30,7 @@ function Checkbox({
 
 	return (
 		<input
+			ref={ref}
 			type="checkbox"
 			data-slot="checkbox"
 			className={cn("checkbox", className)}

--- a/apps/web/src/components/ui/confirm-dialog.tsx
+++ b/apps/web/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,87 @@
+import { AlertTriangle } from "lucide-react";
+import type * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ConfirmDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	title: string;
+	description: React.ReactNode;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	onConfirm: () => void;
+	onCancel?: () => void;
+	isLoading?: boolean;
+	variant?: "danger" | "warning" | "default";
+}
+
+function ConfirmDialog({
+	open,
+	onOpenChange,
+	title,
+	description,
+	confirmLabel = "確認",
+	cancelLabel = "キャンセル",
+	onConfirm,
+	onCancel,
+	isLoading = false,
+	variant = "default",
+}: ConfirmDialogProps) {
+	const handleCancel = () => {
+		onCancel?.();
+		onOpenChange(false);
+	};
+
+	const handleConfirm = () => {
+		onConfirm();
+	};
+
+	const confirmButtonVariant = variant === "danger" ? "destructive" : "primary";
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-[425px]" showCloseButton={false}>
+				<DialogHeader>
+					<div className="flex items-center gap-3">
+						{variant === "danger" && (
+							<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-error/10">
+								<AlertTriangle className="h-5 w-5 text-error" />
+							</div>
+						)}
+						{variant === "warning" && (
+							<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-warning/10">
+								<AlertTriangle className="h-5 w-5 text-warning" />
+							</div>
+						)}
+						<DialogTitle>{title}</DialogTitle>
+					</div>
+				</DialogHeader>
+				<DialogDescription className="py-2">{description}</DialogDescription>
+				<DialogFooter>
+					<Button variant="ghost" onClick={handleCancel} disabled={isLoading}>
+						{cancelLabel}
+					</Button>
+					<Button
+						variant={confirmButtonVariant}
+						onClick={handleConfirm}
+						disabled={isLoading}
+					>
+						{isLoading ? "処理中..." : confirmLabel}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+export { ConfirmDialog };
+export type { ConfirmDialogProps };

--- a/apps/web/src/hooks/use-row-selection.ts
+++ b/apps/web/src/hooks/use-row-selection.ts
@@ -1,0 +1,97 @@
+import { useCallback, useState } from "react";
+
+export interface SelectableItem {
+	id: string;
+}
+
+export interface UseRowSelectionReturn<T extends SelectableItem> {
+	selectedIds: Set<string>;
+	selectedItems: Map<string, T>;
+	isSelected: (id: string) => boolean;
+	isAllSelected: (currentPageItems: T[]) => boolean;
+	isIndeterminate: (currentPageItems: T[]) => boolean;
+	toggleItem: (item: T) => void;
+	toggleAll: (currentPageItems: T[]) => void;
+	clearSelection: () => void;
+	selectedCount: number;
+}
+
+export function useRowSelection<
+	T extends SelectableItem,
+>(): UseRowSelectionReturn<T> {
+	// IDのSetと、選択されたアイテムの完全なデータを保持するMap
+	const [selectedItems, setSelectedItems] = useState<Map<string, T>>(new Map());
+
+	const selectedIds = new Set(selectedItems.keys());
+	const selectedCount = selectedItems.size;
+
+	const isSelected = useCallback(
+		(id: string) => selectedItems.has(id),
+		[selectedItems],
+	);
+
+	const isAllSelected = useCallback(
+		(currentPageItems: T[]) =>
+			currentPageItems.length > 0 &&
+			currentPageItems.every((item) => selectedItems.has(item.id)),
+		[selectedItems],
+	);
+
+	const isIndeterminate = useCallback(
+		(currentPageItems: T[]) => {
+			const selectedOnPage = currentPageItems.filter((item) =>
+				selectedItems.has(item.id),
+			).length;
+			return selectedOnPage > 0 && selectedOnPage < currentPageItems.length;
+		},
+		[selectedItems],
+	);
+
+	const toggleItem = useCallback((item: T) => {
+		setSelectedItems((prev) => {
+			const next = new Map(prev);
+			if (next.has(item.id)) {
+				next.delete(item.id);
+			} else {
+				next.set(item.id, item);
+			}
+			return next;
+		});
+	}, []);
+
+	const toggleAll = useCallback((currentPageItems: T[]) => {
+		setSelectedItems((prev) => {
+			const next = new Map(prev);
+			const allSelected = currentPageItems.every((item) => next.has(item.id));
+
+			if (allSelected) {
+				// 全解除（現在のページのみ）
+				for (const item of currentPageItems) {
+					next.delete(item.id);
+				}
+			} else {
+				// 全選択（現在のページを追加）
+				for (const item of currentPageItems) {
+					next.set(item.id, item);
+				}
+			}
+			return next;
+		});
+	}, []);
+
+	const clearSelection = useCallback(() => {
+		setSelectedItems(new Map());
+	}, []);
+
+	return {
+		selectedIds,
+		selectedItems,
+		isSelected,
+		isAllSelected,
+		isIndeterminate,
+		toggleItem,
+		toggleAll,
+		clearSelection,
+		selectedCount,
+	};
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1717,6 +1717,15 @@ export const tracksApi = {
 				body: JSON.stringify({ direction }),
 			},
 		),
+	batchDelete: (items: Array<{ trackId: string; releaseId: string }>) =>
+		fetchWithAuth<{
+			success: boolean;
+			deleted: number;
+			failed: Array<{ trackId: string; error: string }>;
+		}>("/api/admin/tracks/batch", {
+			method: "DELETE",
+			body: JSON.stringify({ items }),
+		}),
 };
 
 // Track Credits


### PR DESCRIPTION
## 概要

トラック一覧ページに一括削除機能を追加し、大量データの効率的な管理を可能にする。

## 変更内容

* チェックボックスによる複数選択UI
* ページを跨いだ選択状態の保持
* 一括削除API（最大100件）
* 確認ダイアログによる安全な削除実行
* 部分失敗時のエラーハンドリング

## 影響範囲

* トラック一覧ページ（`/admin/tracks`）
* バッチ削除APIエンドポイント（`DELETE /api/admin/tracks/batch`）

## 補足事項

* Issue #82 の対応（トラック一覧のみ、一括削除機能）
* 他のエンティティ（アーティスト、サークル、作品）への拡張は今後対応予定
* `useRowSelection` hookと`ConfirmDialog`コンポーネントは再利用可能な汎用コンポーネントとして実装

closes #82