### PR TITLE
feat: 管理APIエンドポイントに統一エラーハンドリングを追加

### DIFF
--- a/apps/server/src/routes/admin/artist-aliases/circles.ts
+++ b/apps/server/src/routes/admin/artist-aliases/circles.ts
@@ -9,108 +9,119 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const aliasCirclesRouter = new Hono<AdminContext>();
 
 // アーティスト名義の参加サークル一覧取得
 // 経路: artistAlias → trackCredits (artistAliasId) → tracks → releases → releaseCircles → circles
 aliasCirclesRouter.get("/:aliasId/circles", async (c) => {
-	const aliasId = c.req.param("aliasId");
+	try {
+		const aliasId = c.req.param("aliasId");
 
-	// アーティスト名義のクレジット一覧からトラックIDを取得
-	const creditsResult = await db
-		.select({
-			trackId: trackCredits.trackId,
-		})
-		.from(trackCredits)
-		.where(eq(trackCredits.artistAliasId, aliasId));
+		// アーティスト名義のクレジット一覧からトラックIDを取得
+		const creditsResult = await db
+			.select({
+				trackId: trackCredits.trackId,
+			})
+			.from(trackCredits)
+			.where(eq(trackCredits.artistAliasId, aliasId));
 
-	if (creditsResult.length === 0) {
-		return c.json([]);
-	}
-
-	const trackIds = [...new Set(creditsResult.map((c) => c.trackId))];
-
-	// トラックからリリースIDを取得
-	const tracksResult = await db
-		.select({
-			releaseId: tracks.releaseId,
-		})
-		.from(tracks)
-		.where(inArray(tracks.id, trackIds));
-
-	const releaseIds = [
-		...new Set(
-			tracksResult
-				.map((t) => t.releaseId)
-				.filter((id): id is string => id !== null),
-		),
-	];
-
-	if (releaseIds.length === 0) {
-		return c.json([]);
-	}
-
-	// リリースサークル情報を取得
-	const releaseCirclesResult = await db
-		.select({
-			releaseId: releaseCircles.releaseId,
-			circleId: releaseCircles.circleId,
-			participationType: releaseCircles.participationType,
-		})
-		.from(releaseCircles)
-		.where(inArray(releaseCircles.releaseId, releaseIds));
-
-	if (releaseCirclesResult.length === 0) {
-		return c.json([]);
-	}
-
-	// サークル情報を取得
-	const circleIds = [...new Set(releaseCirclesResult.map((rc) => rc.circleId))];
-	const circleList = await db
-		.select({
-			id: circles.id,
-			name: circles.name,
-		})
-		.from(circles)
-		.where(inArray(circles.id, circleIds))
-		.orderBy(circles.name);
-
-	// サークルごとにリリース数と参加形態を集計
-	const circleStats = new Map<
-		string,
-		{
-			releaseCount: number;
-			participationTypes: Set<string>;
+		if (creditsResult.length === 0) {
+			return c.json([]);
 		}
-	>();
 
-	for (const rc of releaseCirclesResult) {
-		const stats = circleStats.get(rc.circleId) || {
-			releaseCount: 0,
-			participationTypes: new Set<string>(),
-		};
-		// 同じサークルでも異なるリリースをカウント
-		if (!circleStats.has(rc.circleId)) {
-			stats.releaseCount = 0;
+		const trackIds = [...new Set(creditsResult.map((c) => c.trackId))];
+
+		// トラックからリリースIDを取得
+		const tracksResult = await db
+			.select({
+				releaseId: tracks.releaseId,
+			})
+			.from(tracks)
+			.where(inArray(tracks.id, trackIds));
+
+		const releaseIds = [
+			...new Set(
+				tracksResult
+					.map((t) => t.releaseId)
+					.filter((id): id is string => id !== null),
+			),
+		];
+
+		if (releaseIds.length === 0) {
+			return c.json([]);
 		}
-		stats.releaseCount++;
-		stats.participationTypes.add(rc.participationType);
-		circleStats.set(rc.circleId, stats);
+
+		// リリースサークル情報を取得
+		const releaseCirclesResult = await db
+			.select({
+				releaseId: releaseCircles.releaseId,
+				circleId: releaseCircles.circleId,
+				participationType: releaseCircles.participationType,
+			})
+			.from(releaseCircles)
+			.where(inArray(releaseCircles.releaseId, releaseIds));
+
+		if (releaseCirclesResult.length === 0) {
+			return c.json([]);
+		}
+
+		// サークル情報を取得
+		const circleIds = [
+			...new Set(releaseCirclesResult.map((rc) => rc.circleId)),
+		];
+		const circleList = await db
+			.select({
+				id: circles.id,
+				name: circles.name,
+			})
+			.from(circles)
+			.where(inArray(circles.id, circleIds))
+			.orderBy(circles.name);
+
+		// サークルごとにリリース数と参加形態を集計
+		const circleStats = new Map<
+			string,
+			{
+				releaseCount: number;
+				participationTypes: Set<string>;
+			}
+		>();
+
+		for (const rc of releaseCirclesResult) {
+			const stats = circleStats.get(rc.circleId) || {
+				releaseCount: 0,
+				participationTypes: new Set<string>(),
+			};
+			// 同じサークルでも異なるリリースをカウント
+			if (!circleStats.has(rc.circleId)) {
+				stats.releaseCount = 0;
+			}
+			stats.releaseCount++;
+			stats.participationTypes.add(rc.participationType);
+			circleStats.set(rc.circleId, stats);
+		}
+
+		// レスポンスを整形
+		const result = circleList.map((circle) => {
+			const stats = circleStats.get(circle.id);
+			return {
+				circleId: circle.id,
+				circleName: circle.name,
+				releaseCount: stats?.releaseCount ?? 0,
+				participationTypes: stats ? Array.from(stats.participationTypes) : [],
+			};
+		});
+
+		return c.json(result);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"GET /admin/artist-aliases/:aliasId/circles",
+		);
 	}
-
-	// レスポンスを整形
-	const result = circleList.map((circle) => {
-		const stats = circleStats.get(circle.id);
-		return {
-			circleId: circle.id,
-			circleName: circle.name,
-			releaseCount: stats?.releaseCount ?? 0,
-			participationTypes: stats ? Array.from(stats.participationTypes) : [],
-		};
-	});
-
-	return c.json(result);
 });
 
 export { aliasCirclesRouter };

--- a/apps/server/src/routes/admin/artist-aliases/index.ts
+++ b/apps/server/src/routes/admin/artist-aliases/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 import { aliasCirclesRouter } from "./circles";
 import { aliasTracksRouter } from "./tracks";
 
@@ -23,30 +24,73 @@ artistAliasesRouter.route("/", aliasCirclesRouter);
 
 // 一覧取得（ページネーション、検索、アーティストIDフィルタ対応）
 artistAliasesRouter.get("/", async (c) => {
-	const page = Number(c.req.query("page")) || 1;
-	const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
-	const artistId = c.req.query("artistId");
-	const search = c.req.query("search");
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const artistId = c.req.query("artistId");
+		const search = c.req.query("search");
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 条件を構築
-	const conditions = [];
+		// 条件を構築
+		const conditions = [];
 
-	if (artistId) {
-		conditions.push(eq(artistAliases.artistId, artistId));
+		if (artistId) {
+			conditions.push(eq(artistAliases.artistId, artistId));
+		}
+
+		if (search) {
+			const searchPattern = `%${search}%`;
+			conditions.push(like(artistAliases.name, searchPattern));
+		}
+
+		const whereCondition =
+			conditions.length > 0 ? and(...conditions) : undefined;
+
+		// データ取得（親アーティスト名を結合）
+		const [data, totalResult] = await Promise.all([
+			db
+				.select({
+					id: artistAliases.id,
+					artistId: artistAliases.artistId,
+					name: artistAliases.name,
+					aliasTypeCode: artistAliases.aliasTypeCode,
+					nameInitial: artistAliases.nameInitial,
+					initialScript: artistAliases.initialScript,
+					periodFrom: artistAliases.periodFrom,
+					periodTo: artistAliases.periodTo,
+					createdAt: artistAliases.createdAt,
+					updatedAt: artistAliases.updatedAt,
+					artistName: artists.name,
+				})
+				.from(artistAliases)
+				.leftJoin(artists, eq(artistAliases.artistId, artists.id))
+				.where(whereCondition)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(artistAliases.name),
+			db.select({ count: count() }).from(artistAliases).where(whereCondition),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/artist-aliases");
 	}
+});
 
-	if (search) {
-		const searchPattern = `%${search}%`;
-		conditions.push(like(artistAliases.name, searchPattern));
-	}
+// 個別取得
+artistAliasesRouter.get("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
 
-	const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
-
-	// データ取得（親アーティスト名を結合）
-	const [data, totalResult] = await Promise.all([
-		db
+		const result = await db
 			.select({
 				id: artistAliases.id,
 				artistId: artistAliases.artistId,
@@ -62,193 +106,177 @@ artistAliasesRouter.get("/", async (c) => {
 			})
 			.from(artistAliases)
 			.leftJoin(artists, eq(artistAliases.artistId, artists.id))
-			.where(whereCondition)
-			.limit(limit)
-			.offset(offset)
-			.orderBy(artistAliases.name),
-		db.select({ count: count() }).from(artistAliases).where(whereCondition),
-	]);
+			.where(eq(artistAliases.id, id))
+			.limit(1);
 
-	const total = totalResult[0]?.count ?? 0;
+		if (result.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
 
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
-});
-
-// 個別取得
-artistAliasesRouter.get("/:id", async (c) => {
-	const id = c.req.param("id");
-
-	const result = await db
-		.select({
-			id: artistAliases.id,
-			artistId: artistAliases.artistId,
-			name: artistAliases.name,
-			aliasTypeCode: artistAliases.aliasTypeCode,
-			nameInitial: artistAliases.nameInitial,
-			initialScript: artistAliases.initialScript,
-			periodFrom: artistAliases.periodFrom,
-			periodTo: artistAliases.periodTo,
-			createdAt: artistAliases.createdAt,
-			updatedAt: artistAliases.updatedAt,
-			artistName: artists.name,
-		})
-		.from(artistAliases)
-		.leftJoin(artists, eq(artistAliases.artistId, artists.id))
-		.where(eq(artistAliases.id, id))
-		.limit(1);
-
-	if (result.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/artist-aliases/:id");
 	}
-
-	return c.json(result[0]);
 });
 
 // 新規作成
 artistAliasesRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertArtistAliasSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		// バリデーション
+		const parsed = insertArtistAliasSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// 親アーティスト存在チェック
-	const existingArtist = await db
-		.select()
-		.from(artists)
-		.where(eq(artists.id, parsed.data.artistId))
-		.limit(1);
+		// 親アーティスト存在チェック
+		const existingArtist = await db
+			.select()
+			.from(artists)
+			.where(eq(artists.id, parsed.data.artistId))
+			.limit(1);
 
-	if (existingArtist.length === 0) {
-		return c.json({ error: "Artist not found" }, 404);
-	}
+		if (existingArtist.length === 0) {
+			return c.json({ error: "Artist not found" }, 404);
+		}
 
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(artistAliases)
-		.where(eq(artistAliases.id, parsed.data.id))
-		.limit(1);
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(artistAliases)
+			.where(eq(artistAliases.id, parsed.data.id))
+			.limit(1);
 
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
 
-	// 同一アーティスト内での名前重複チェック（大文字小文字無視）
-	const existingName = await db
-		.select()
-		.from(artistAliases)
-		.where(
-			and(
-				eq(artistAliases.artistId, parsed.data.artistId),
-				sql`lower(${artistAliases.name}) = lower(${parsed.data.name})`,
-			),
-		)
-		.limit(1);
-
-	if (existingName.length > 0) {
-		return c.json({ error: "Alias name already exists for this artist" }, 409);
-	}
-
-	// 作成
-	const result = await db.insert(artistAliases).values(parsed.data).returning();
-
-	return c.json(result[0], 201);
-});
-
-// 更新
-artistAliasesRouter.put("/:id", async (c) => {
-	const id = c.req.param("id");
-	const body = await c.req.json();
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(artistAliases)
-		.where(eq(artistAliases.id, id))
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateArtistAliasSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	const currentArtistId = parsed.data.artistId || existing[0]?.artistId;
-
-	// 名前重複チェック（同一アーティスト内、自身以外）
-	if (parsed.data.name && currentArtistId) {
+		// 同一アーティスト内での名前重複チェック（大文字小文字無視）
 		const existingName = await db
 			.select()
 			.from(artistAliases)
 			.where(
 				and(
-					eq(artistAliases.artistId, currentArtistId),
+					eq(artistAliases.artistId, parsed.data.artistId),
 					sql`lower(${artistAliases.name}) = lower(${parsed.data.name})`,
 				),
 			)
 			.limit(1);
 
-		if (existingName.length > 0 && existingName[0]?.id !== id) {
+		if (existingName.length > 0) {
 			return c.json(
 				{ error: "Alias name already exists for this artist" },
 				409,
 			);
 		}
+
+		// 作成
+		const result = await db
+			.insert(artistAliases)
+			.values(parsed.data)
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/artist-aliases");
 	}
+});
 
-	// 更新
-	const result = await db
-		.update(artistAliases)
-		.set(parsed.data)
-		.where(eq(artistAliases.id, id))
-		.returning();
+// 更新
+artistAliasesRouter.put("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+		const body = await c.req.json();
 
-	return c.json(result[0]);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(artistAliases)
+			.where(eq(artistAliases.id, id))
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateArtistAliasSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		const currentArtistId = parsed.data.artistId || existing[0]?.artistId;
+
+		// 名前重複チェック（同一アーティスト内、自身以外）
+		if (parsed.data.name && currentArtistId) {
+			const existingName = await db
+				.select()
+				.from(artistAliases)
+				.where(
+					and(
+						eq(artistAliases.artistId, currentArtistId),
+						sql`lower(${artistAliases.name}) = lower(${parsed.data.name})`,
+					),
+				)
+				.limit(1);
+
+			if (existingName.length > 0 && existingName[0]?.id !== id) {
+				return c.json(
+					{ error: "Alias name already exists for this artist" },
+					409,
+				);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(artistAliases)
+			.set(parsed.data)
+			.where(eq(artistAliases.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/artist-aliases/:id");
+	}
 });
 
 // 削除
 artistAliasesRouter.delete("/:id", async (c) => {
-	const id = c.req.param("id");
+	try {
+		const id = c.req.param("id");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(artistAliases)
-		.where(eq(artistAliases.id, id))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(artistAliases)
+			.where(eq(artistAliases.id, id))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(artistAliases).where(eq(artistAliases.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/artist-aliases/:id");
 	}
-
-	// 削除
-	await db.delete(artistAliases).where(eq(artistAliases.id, id));
-
-	return c.json({ success: true });
 });
 
 export { artistAliasesRouter };

--- a/apps/server/src/routes/admin/artist-aliases/tracks.ts
+++ b/apps/server/src/routes/admin/artist-aliases/tracks.ts
@@ -11,206 +11,211 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const aliasTracksRouter = new Hono<AdminContext>();
 
 // アーティスト名義の関連楽曲取得（role別）
 aliasTracksRouter.get("/:aliasId/tracks", async (c) => {
-	const aliasId = c.req.param("aliasId");
+	try {
+		const aliasId = c.req.param("aliasId");
 
-	// アーティスト名義のクレジット一覧を取得
-	const credits = await db
-		.select({
-			creditId: trackCredits.id,
-			trackId: trackCredits.trackId,
-			creditName: trackCredits.creditName,
-		})
-		.from(trackCredits)
-		.where(eq(trackCredits.artistAliasId, aliasId));
+		// アーティスト名義のクレジット一覧を取得
+		const credits = await db
+			.select({
+				creditId: trackCredits.id,
+				trackId: trackCredits.trackId,
+				creditName: trackCredits.creditName,
+			})
+			.from(trackCredits)
+			.where(eq(trackCredits.artistAliasId, aliasId));
 
-	if (credits.length === 0) {
+		if (credits.length === 0) {
+			return c.json({
+				totalUniqueTrackCount: 0,
+				byRole: {},
+				tracks: [],
+				statistics: {
+					releaseCount: 0,
+					earliestReleaseDate: null,
+					latestReleaseDate: null,
+				},
+			});
+		}
+
+		const creditIds = credits.map((c) => c.creditId);
+		const trackIds = [...new Set(credits.map((c) => c.trackId))];
+
+		// クレジットの役割を取得
+		const creditRoles = await db
+			.select({
+				trackCreditId: trackCreditRoles.trackCreditId,
+				roleCode: trackCreditRoles.roleCode,
+			})
+			.from(trackCreditRoles)
+			.where(inArray(trackCreditRoles.trackCreditId, creditIds));
+
+		// トラック情報を取得
+		const trackList = await db
+			.select({
+				id: tracks.id,
+				name: tracks.name,
+				nameJa: tracks.nameJa,
+				releaseId: tracks.releaseId,
+				trackNumber: tracks.trackNumber,
+			})
+			.from(tracks)
+			.where(inArray(tracks.id, trackIds))
+			.orderBy(tracks.name);
+
+		// リリース情報を取得（nullを除外）
+		const releaseIds = [
+			...new Set(
+				trackList
+					.map((t) => t.releaseId)
+					.filter((id): id is string => id !== null),
+			),
+		];
+		const releaseList = await db
+			.select({
+				id: releases.id,
+				name: releases.name,
+				releaseDate: releases.releaseDate,
+			})
+			.from(releases)
+			.where(inArray(releases.id, releaseIds));
+
+		const releaseMap = new Map(releaseList.map((r) => [r.id, r]));
+
+		// リリースサークル情報を取得
+		const releaseCirclesList =
+			releaseIds.length > 0
+				? await db
+						.select({
+							releaseId: releaseCircles.releaseId,
+							circleId: releaseCircles.circleId,
+						})
+						.from(releaseCircles)
+						.where(inArray(releaseCircles.releaseId, releaseIds))
+				: [];
+
+		// サークル情報を取得
+		const circleIds = [...new Set(releaseCirclesList.map((rc) => rc.circleId))];
+		const circleList =
+			circleIds.length > 0
+				? await db
+						.select({
+							id: circles.id,
+							name: circles.name,
+						})
+						.from(circles)
+						.where(inArray(circles.id, circleIds))
+				: [];
+
+		const circleMap = new Map(circleList.map((c) => [c.id, c.name]));
+
+		// リリースIDからサークル名一覧へのマップを作成
+		const releaseCircleNamesMap = new Map<string, string[]>();
+		for (const rc of releaseCirclesList) {
+			const circleName = circleMap.get(rc.circleId);
+			if (circleName) {
+				const names = releaseCircleNamesMap.get(rc.releaseId) || [];
+				if (!names.includes(circleName)) {
+					names.push(circleName);
+				}
+				releaseCircleNamesMap.set(rc.releaseId, names);
+			}
+		}
+
+		// クレジットIDからトラックIDへのマップ
+		const creditToTrack = new Map(credits.map((c) => [c.creditId, c.trackId]));
+
+		// 役割別に楽曲をグループ化
+		const byRole: Record<string, Set<string>> = {};
+		for (const cr of creditRoles) {
+			const trackId = creditToTrack.get(cr.trackCreditId);
+			if (trackId) {
+				if (!byRole[cr.roleCode]) {
+					byRole[cr.roleCode] = new Set();
+				}
+				const roleSet = byRole[cr.roleCode];
+				if (roleSet) {
+					roleSet.add(trackId);
+				}
+			}
+		}
+
+		// 役割別カウント
+		const roleCount: Record<string, number> = {};
+		for (const [roleCode, trackSet] of Object.entries(byRole)) {
+			roleCount[roleCode] = trackSet.size;
+		}
+
+		// トラック情報を整形
+		const tracksWithRelease = trackList
+			.map((t) => {
+				const release = t.releaseId ? releaseMap.get(t.releaseId) : undefined;
+				const circleNames = t.releaseId
+					? releaseCircleNamesMap.get(t.releaseId)
+					: undefined;
+				return {
+					id: t.id,
+					name: t.name,
+					nameJa: t.nameJa,
+					trackNumber: t.trackNumber,
+					release: release
+						? {
+								id: release.id,
+								name: release.name,
+								releaseDate: release.releaseDate,
+								circleNames: circleNames ? circleNames.join(" / ") : null,
+							}
+						: null,
+				};
+			})
+			// 作品名 → トラック番号でソート
+			.sort((a, b) => {
+				// 作品なしは後ろへ
+				if (!a.release && b.release) return 1;
+				if (a.release && !b.release) return -1;
+				if (!a.release && !b.release) return a.name.localeCompare(b.name);
+
+				// ここに到達した時点で両方ともreleaseが存在する（上記の条件で除外済み）
+				// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
+				const releaseA = a.release!;
+				// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
+				const releaseB = b.release!;
+
+				// 作品名でソート
+				const releaseCompare = releaseA.name.localeCompare(releaseB.name);
+				if (releaseCompare !== 0) return releaseCompare;
+
+				// 同じ作品内ではトラック番号でソート
+				return a.trackNumber - b.trackNumber;
+			});
+
+		// 統計情報を計算
+		const releaseDates = releaseList
+			.map((r) => r.releaseDate)
+			.filter((d): d is string => d !== null)
+			.sort();
+
+		const statistics = {
+			releaseCount: releaseList.length,
+			earliestReleaseDate: releaseDates.length > 0 ? releaseDates[0] : null,
+			latestReleaseDate:
+				releaseDates.length > 0 ? releaseDates[releaseDates.length - 1] : null,
+		};
+
 		return c.json({
-			totalUniqueTrackCount: 0,
-			byRole: {},
-			tracks: [],
-			statistics: {
-				releaseCount: 0,
-				earliestReleaseDate: null,
-				latestReleaseDate: null,
-			},
+			totalUniqueTrackCount: trackIds.length,
+			byRole: roleCount,
+			tracks: tracksWithRelease,
+			statistics,
 		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/artist-aliases/:aliasId/tracks");
 	}
-
-	const creditIds = credits.map((c) => c.creditId);
-	const trackIds = [...new Set(credits.map((c) => c.trackId))];
-
-	// クレジットの役割を取得
-	const creditRoles = await db
-		.select({
-			trackCreditId: trackCreditRoles.trackCreditId,
-			roleCode: trackCreditRoles.roleCode,
-		})
-		.from(trackCreditRoles)
-		.where(inArray(trackCreditRoles.trackCreditId, creditIds));
-
-	// トラック情報を取得
-	const trackList = await db
-		.select({
-			id: tracks.id,
-			name: tracks.name,
-			nameJa: tracks.nameJa,
-			releaseId: tracks.releaseId,
-			trackNumber: tracks.trackNumber,
-		})
-		.from(tracks)
-		.where(inArray(tracks.id, trackIds))
-		.orderBy(tracks.name);
-
-	// リリース情報を取得（nullを除外）
-	const releaseIds = [
-		...new Set(
-			trackList
-				.map((t) => t.releaseId)
-				.filter((id): id is string => id !== null),
-		),
-	];
-	const releaseList = await db
-		.select({
-			id: releases.id,
-			name: releases.name,
-			releaseDate: releases.releaseDate,
-		})
-		.from(releases)
-		.where(inArray(releases.id, releaseIds));
-
-	const releaseMap = new Map(releaseList.map((r) => [r.id, r]));
-
-	// リリースサークル情報を取得
-	const releaseCirclesList =
-		releaseIds.length > 0
-			? await db
-					.select({
-						releaseId: releaseCircles.releaseId,
-						circleId: releaseCircles.circleId,
-					})
-					.from(releaseCircles)
-					.where(inArray(releaseCircles.releaseId, releaseIds))
-			: [];
-
-	// サークル情報を取得
-	const circleIds = [...new Set(releaseCirclesList.map((rc) => rc.circleId))];
-	const circleList =
-		circleIds.length > 0
-			? await db
-					.select({
-						id: circles.id,
-						name: circles.name,
-					})
-					.from(circles)
-					.where(inArray(circles.id, circleIds))
-			: [];
-
-	const circleMap = new Map(circleList.map((c) => [c.id, c.name]));
-
-	// リリースIDからサークル名一覧へのマップを作成
-	const releaseCircleNamesMap = new Map<string, string[]>();
-	for (const rc of releaseCirclesList) {
-		const circleName = circleMap.get(rc.circleId);
-		if (circleName) {
-			const names = releaseCircleNamesMap.get(rc.releaseId) || [];
-			if (!names.includes(circleName)) {
-				names.push(circleName);
-			}
-			releaseCircleNamesMap.set(rc.releaseId, names);
-		}
-	}
-
-	// クレジットIDからトラックIDへのマップ
-	const creditToTrack = new Map(credits.map((c) => [c.creditId, c.trackId]));
-
-	// 役割別に楽曲をグループ化
-	const byRole: Record<string, Set<string>> = {};
-	for (const cr of creditRoles) {
-		const trackId = creditToTrack.get(cr.trackCreditId);
-		if (trackId) {
-			if (!byRole[cr.roleCode]) {
-				byRole[cr.roleCode] = new Set();
-			}
-			const roleSet = byRole[cr.roleCode];
-			if (roleSet) {
-				roleSet.add(trackId);
-			}
-		}
-	}
-
-	// 役割別カウント
-	const roleCount: Record<string, number> = {};
-	for (const [roleCode, trackSet] of Object.entries(byRole)) {
-		roleCount[roleCode] = trackSet.size;
-	}
-
-	// トラック情報を整形
-	const tracksWithRelease = trackList
-		.map((t) => {
-			const release = t.releaseId ? releaseMap.get(t.releaseId) : undefined;
-			const circleNames = t.releaseId
-				? releaseCircleNamesMap.get(t.releaseId)
-				: undefined;
-			return {
-				id: t.id,
-				name: t.name,
-				nameJa: t.nameJa,
-				trackNumber: t.trackNumber,
-				release: release
-					? {
-							id: release.id,
-							name: release.name,
-							releaseDate: release.releaseDate,
-							circleNames: circleNames ? circleNames.join(" / ") : null,
-						}
-					: null,
-			};
-		})
-		// 作品名 → トラック番号でソート
-		.sort((a, b) => {
-			// 作品なしは後ろへ
-			if (!a.release && b.release) return 1;
-			if (a.release && !b.release) return -1;
-			if (!a.release && !b.release) return a.name.localeCompare(b.name);
-
-			// ここに到達した時点で両方ともreleaseが存在する（上記の条件で除外済み）
-			// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
-			const releaseA = a.release!;
-			// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
-			const releaseB = b.release!;
-
-			// 作品名でソート
-			const releaseCompare = releaseA.name.localeCompare(releaseB.name);
-			if (releaseCompare !== 0) return releaseCompare;
-
-			// 同じ作品内ではトラック番号でソート
-			return a.trackNumber - b.trackNumber;
-		});
-
-	// 統計情報を計算
-	const releaseDates = releaseList
-		.map((r) => r.releaseDate)
-		.filter((d): d is string => d !== null)
-		.sort();
-
-	const statistics = {
-		releaseCount: releaseList.length,
-		earliestReleaseDate: releaseDates.length > 0 ? releaseDates[0] : null,
-		latestReleaseDate:
-			releaseDates.length > 0 ? releaseDates[releaseDates.length - 1] : null,
-	};
-
-	return c.json({
-		totalUniqueTrackCount: trackIds.length,
-		byRole: roleCount,
-		tracks: tracksWithRelease,
-		statistics,
-	});
 });
 
 export { aliasTracksRouter };

--- a/apps/server/src/routes/admin/artists/circles.ts
+++ b/apps/server/src/routes/admin/artists/circles.ts
@@ -9,108 +9,115 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const artistCirclesRouter = new Hono<AdminContext>();
 
 // アーティストの参加サークル一覧取得
 // 経路: artist → trackCredits → tracks → releases → releaseCircles → circles
 artistCirclesRouter.get("/:artistId/circles", async (c) => {
-	const artistId = c.req.param("artistId");
+	try {
+		const artistId = c.req.param("artistId");
 
-	// アーティストのクレジット一覧からトラックIDを取得
-	const creditsResult = await db
-		.select({
-			trackId: trackCredits.trackId,
-		})
-		.from(trackCredits)
-		.where(eq(trackCredits.artistId, artistId));
+		// アーティストのクレジット一覧からトラックIDを取得
+		const creditsResult = await db
+			.select({
+				trackId: trackCredits.trackId,
+			})
+			.from(trackCredits)
+			.where(eq(trackCredits.artistId, artistId));
 
-	if (creditsResult.length === 0) {
-		return c.json([]);
-	}
-
-	const trackIds = [...new Set(creditsResult.map((c) => c.trackId))];
-
-	// トラックからリリースIDを取得
-	const tracksResult = await db
-		.select({
-			releaseId: tracks.releaseId,
-		})
-		.from(tracks)
-		.where(inArray(tracks.id, trackIds));
-
-	const releaseIds = [
-		...new Set(
-			tracksResult
-				.map((t) => t.releaseId)
-				.filter((id): id is string => id !== null),
-		),
-	];
-
-	if (releaseIds.length === 0) {
-		return c.json([]);
-	}
-
-	// リリースサークル情報を取得
-	const releaseCirclesResult = await db
-		.select({
-			releaseId: releaseCircles.releaseId,
-			circleId: releaseCircles.circleId,
-			participationType: releaseCircles.participationType,
-		})
-		.from(releaseCircles)
-		.where(inArray(releaseCircles.releaseId, releaseIds));
-
-	if (releaseCirclesResult.length === 0) {
-		return c.json([]);
-	}
-
-	// サークル情報を取得
-	const circleIds = [...new Set(releaseCirclesResult.map((rc) => rc.circleId))];
-	const circleList = await db
-		.select({
-			id: circles.id,
-			name: circles.name,
-		})
-		.from(circles)
-		.where(inArray(circles.id, circleIds))
-		.orderBy(circles.name);
-
-	// サークルごとにリリース数と参加形態を集計
-	const circleStats = new Map<
-		string,
-		{
-			releaseCount: number;
-			participationTypes: Set<string>;
+		if (creditsResult.length === 0) {
+			return c.json([]);
 		}
-	>();
 
-	for (const rc of releaseCirclesResult) {
-		const stats = circleStats.get(rc.circleId) || {
-			releaseCount: 0,
-			participationTypes: new Set<string>(),
-		};
-		// 同じサークルでも異なるリリースをカウント
-		if (!circleStats.has(rc.circleId)) {
-			stats.releaseCount = 0;
+		const trackIds = [...new Set(creditsResult.map((c) => c.trackId))];
+
+		// トラックからリリースIDを取得
+		const tracksResult = await db
+			.select({
+				releaseId: tracks.releaseId,
+			})
+			.from(tracks)
+			.where(inArray(tracks.id, trackIds));
+
+		const releaseIds = [
+			...new Set(
+				tracksResult
+					.map((t) => t.releaseId)
+					.filter((id): id is string => id !== null),
+			),
+		];
+
+		if (releaseIds.length === 0) {
+			return c.json([]);
 		}
-		stats.releaseCount++;
-		stats.participationTypes.add(rc.participationType);
-		circleStats.set(rc.circleId, stats);
+
+		// リリースサークル情報を取得
+		const releaseCirclesResult = await db
+			.select({
+				releaseId: releaseCircles.releaseId,
+				circleId: releaseCircles.circleId,
+				participationType: releaseCircles.participationType,
+			})
+			.from(releaseCircles)
+			.where(inArray(releaseCircles.releaseId, releaseIds));
+
+		if (releaseCirclesResult.length === 0) {
+			return c.json([]);
+		}
+
+		// サークル情報を取得
+		const circleIds = [
+			...new Set(releaseCirclesResult.map((rc) => rc.circleId)),
+		];
+		const circleList = await db
+			.select({
+				id: circles.id,
+				name: circles.name,
+			})
+			.from(circles)
+			.where(inArray(circles.id, circleIds))
+			.orderBy(circles.name);
+
+		// サークルごとにリリース数と参加形態を集計
+		const circleStats = new Map<
+			string,
+			{
+				releaseCount: number;
+				participationTypes: Set<string>;
+			}
+		>();
+
+		for (const rc of releaseCirclesResult) {
+			const stats = circleStats.get(rc.circleId) || {
+				releaseCount: 0,
+				participationTypes: new Set<string>(),
+			};
+			// 同じサークルでも異なるリリースをカウント
+			if (!circleStats.has(rc.circleId)) {
+				stats.releaseCount = 0;
+			}
+			stats.releaseCount++;
+			stats.participationTypes.add(rc.participationType);
+			circleStats.set(rc.circleId, stats);
+		}
+
+		// レスポンスを整形
+		const result = circleList.map((circle) => {
+			const stats = circleStats.get(circle.id);
+			return {
+				circleId: circle.id,
+				circleName: circle.name,
+				releaseCount: stats?.releaseCount ?? 0,
+				participationTypes: stats ? Array.from(stats.participationTypes) : [],
+			};
+		});
+
+		return c.json(result);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/artists/:artistId/circles");
 	}
-
-	// レスポンスを整形
-	const result = circleList.map((circle) => {
-		const stats = circleStats.get(circle.id);
-		return {
-			circleId: circle.id,
-			circleName: circle.name,
-			releaseCount: stats?.releaseCount ?? 0,
-			participationTypes: stats ? Array.from(stats.participationTypes) : [],
-		};
-	});
-
-	return c.json(result);
 });
 
 export { artistCirclesRouter };

--- a/apps/server/src/routes/admin/artists/index.ts
+++ b/apps/server/src/routes/admin/artists/index.ts
@@ -14,6 +14,7 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 import { artistCirclesRouter } from "./circles";
 import { artistTracksRouter } from "./tracks";
 
@@ -25,198 +26,219 @@ artistsRouter.route("/", artistCirclesRouter);
 
 // 一覧取得（ページネーション、検索、頭文字フィルタ対応）
 artistsRouter.get("/", async (c) => {
-	const page = Number(c.req.query("page")) || 1;
-	const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
-	const initialScript = c.req.query("initialScript");
-	const search = c.req.query("search");
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const initialScript = c.req.query("initialScript");
+		const search = c.req.query("search");
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 条件を構築
-	const conditions = [];
+		// 条件を構築
+		const conditions = [];
 
-	if (initialScript) {
-		conditions.push(eq(artists.initialScript, initialScript));
+		if (initialScript) {
+			conditions.push(eq(artists.initialScript, initialScript));
+		}
+
+		if (search) {
+			const searchPattern = `%${search}%`;
+			conditions.push(
+				or(
+					like(artists.name, searchPattern),
+					like(artists.nameJa, searchPattern),
+					like(artists.nameEn, searchPattern),
+					like(artists.sortName, searchPattern),
+				),
+			);
+		}
+
+		const whereCondition =
+			conditions.length > 0 ? and(...conditions) : undefined;
+
+		// データ取得
+		const [data, totalResult] = await Promise.all([
+			db
+				.select()
+				.from(artists)
+				.where(whereCondition)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(artists.name),
+			db.select({ count: count() }).from(artists).where(whereCondition),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/artists");
 	}
-
-	if (search) {
-		const searchPattern = `%${search}%`;
-		conditions.push(
-			or(
-				like(artists.name, searchPattern),
-				like(artists.nameJa, searchPattern),
-				like(artists.nameEn, searchPattern),
-				like(artists.sortName, searchPattern),
-			),
-		);
-	}
-
-	const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
-
-	// データ取得
-	const [data, totalResult] = await Promise.all([
-		db
-			.select()
-			.from(artists)
-			.where(whereCondition)
-			.limit(limit)
-			.offset(offset)
-			.orderBy(artists.name),
-		db.select({ count: count() }).from(artists).where(whereCondition),
-	]);
-
-	const total = totalResult[0]?.count ?? 0;
-
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
 });
 
 // 個別取得（別名義一覧を含む）
 artistsRouter.get("/:id", async (c) => {
-	const id = c.req.param("id");
+	try {
+		const id = c.req.param("id");
 
-	// アーティスト取得
-	const result = await db
-		.select()
-		.from(artists)
-		.where(eq(artists.id, id))
-		.limit(1);
+		// アーティスト取得
+		const result = await db
+			.select()
+			.from(artists)
+			.where(eq(artists.id, id))
+			.limit(1);
 
-	if (result.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (result.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 別名義一覧取得
+		const aliases = await db
+			.select()
+			.from(artistAliases)
+			.where(eq(artistAliases.artistId, id))
+			.orderBy(asc(artistAliases.name));
+
+		return c.json({
+			...result[0],
+			aliases,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/artists/:id");
 	}
-
-	// 別名義一覧取得
-	const aliases = await db
-		.select()
-		.from(artistAliases)
-		.where(eq(artistAliases.artistId, id))
-		.orderBy(asc(artistAliases.name));
-
-	return c.json({
-		...result[0],
-		aliases,
-	});
 });
 
 // 新規作成
 artistsRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertArtistSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		// バリデーション
+		const parsed = insertArtistSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(artists)
-		.where(eq(artists.id, parsed.data.id))
-		.limit(1);
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(artists)
+			.where(eq(artists.id, parsed.data.id))
+			.limit(1);
 
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
 
-	// 名前重複チェック（大文字小文字無視）
-	const existingName = await db
-		.select()
-		.from(artists)
-		.where(sql`lower(${artists.name}) = lower(${parsed.data.name})`)
-		.limit(1);
-
-	if (existingName.length > 0) {
-		return c.json({ error: "Name already exists" }, 409);
-	}
-
-	// 作成
-	const result = await db.insert(artists).values(parsed.data).returning();
-
-	return c.json(result[0], 201);
-});
-
-// 更新
-artistsRouter.put("/:id", async (c) => {
-	const id = c.req.param("id");
-	const body = await c.req.json();
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(artists)
-		.where(eq(artists.id, id))
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateArtistSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 名前重複チェック（自身以外に同じ名前がある場合）
-	if (parsed.data.name) {
+		// 名前重複チェック（大文字小文字無視）
 		const existingName = await db
 			.select()
 			.from(artists)
 			.where(sql`lower(${artists.name}) = lower(${parsed.data.name})`)
 			.limit(1);
 
-		if (existingName.length > 0 && existingName[0]?.id !== id) {
+		if (existingName.length > 0) {
 			return c.json({ error: "Name already exists" }, 409);
 		}
+
+		// 作成
+		const result = await db.insert(artists).values(parsed.data).returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/artists");
 	}
+});
 
-	// 更新
-	const result = await db
-		.update(artists)
-		.set(parsed.data)
-		.where(eq(artists.id, id))
-		.returning();
+// 更新
+artistsRouter.put("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+		const body = await c.req.json();
 
-	return c.json(result[0]);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(artists)
+			.where(eq(artists.id, id))
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateArtistSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 名前重複チェック（自身以外に同じ名前がある場合）
+		if (parsed.data.name) {
+			const existingName = await db
+				.select()
+				.from(artists)
+				.where(sql`lower(${artists.name}) = lower(${parsed.data.name})`)
+				.limit(1);
+
+			if (existingName.length > 0 && existingName[0]?.id !== id) {
+				return c.json({ error: "Name already exists" }, 409);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(artists)
+			.set(parsed.data)
+			.where(eq(artists.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/artists/:id");
+	}
 });
 
 // 削除
 artistsRouter.delete("/:id", async (c) => {
-	const id = c.req.param("id");
+	try {
+		const id = c.req.param("id");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(artists)
-		.where(eq(artists.id, id))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(artists)
+			.where(eq(artists.id, id))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除（関連別名義はCASCADE削除）
+		await db.delete(artists).where(eq(artists.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/artists/:id");
 	}
-
-	// 削除（関連別名義はCASCADE削除）
-	await db.delete(artists).where(eq(artists.id, id));
-
-	return c.json({ success: true });
 });
 
 export { artistsRouter };

--- a/apps/server/src/routes/admin/artists/tracks.ts
+++ b/apps/server/src/routes/admin/artists/tracks.ts
@@ -11,206 +11,211 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const artistTracksRouter = new Hono<AdminContext>();
 
 // アーティストの関連楽曲取得（role別）
 artistTracksRouter.get("/:artistId/tracks", async (c) => {
-	const artistId = c.req.param("artistId");
+	try {
+		const artistId = c.req.param("artistId");
 
-	// アーティストのクレジット一覧を取得
-	const credits = await db
-		.select({
-			creditId: trackCredits.id,
-			trackId: trackCredits.trackId,
-			creditName: trackCredits.creditName,
-		})
-		.from(trackCredits)
-		.where(eq(trackCredits.artistId, artistId));
+		// アーティストのクレジット一覧を取得
+		const credits = await db
+			.select({
+				creditId: trackCredits.id,
+				trackId: trackCredits.trackId,
+				creditName: trackCredits.creditName,
+			})
+			.from(trackCredits)
+			.where(eq(trackCredits.artistId, artistId));
 
-	if (credits.length === 0) {
+		if (credits.length === 0) {
+			return c.json({
+				totalUniqueTrackCount: 0,
+				byRole: {},
+				tracks: [],
+				statistics: {
+					releaseCount: 0,
+					earliestReleaseDate: null,
+					latestReleaseDate: null,
+				},
+			});
+		}
+
+		const creditIds = credits.map((c) => c.creditId);
+		const trackIds = [...new Set(credits.map((c) => c.trackId))];
+
+		// クレジットの役割を取得
+		const creditRoles = await db
+			.select({
+				trackCreditId: trackCreditRoles.trackCreditId,
+				roleCode: trackCreditRoles.roleCode,
+			})
+			.from(trackCreditRoles)
+			.where(inArray(trackCreditRoles.trackCreditId, creditIds));
+
+		// トラック情報を取得
+		const trackList = await db
+			.select({
+				id: tracks.id,
+				name: tracks.name,
+				nameJa: tracks.nameJa,
+				releaseId: tracks.releaseId,
+				trackNumber: tracks.trackNumber,
+			})
+			.from(tracks)
+			.where(inArray(tracks.id, trackIds))
+			.orderBy(tracks.name);
+
+		// リリース情報を取得（nullを除外）
+		const releaseIds = [
+			...new Set(
+				trackList
+					.map((t) => t.releaseId)
+					.filter((id): id is string => id !== null),
+			),
+		];
+		const releaseList = await db
+			.select({
+				id: releases.id,
+				name: releases.name,
+				releaseDate: releases.releaseDate,
+			})
+			.from(releases)
+			.where(inArray(releases.id, releaseIds));
+
+		const releaseMap = new Map(releaseList.map((r) => [r.id, r]));
+
+		// リリースサークル情報を取得
+		const releaseCirclesList =
+			releaseIds.length > 0
+				? await db
+						.select({
+							releaseId: releaseCircles.releaseId,
+							circleId: releaseCircles.circleId,
+						})
+						.from(releaseCircles)
+						.where(inArray(releaseCircles.releaseId, releaseIds))
+				: [];
+
+		// サークル情報を取得
+		const circleIds = [...new Set(releaseCirclesList.map((rc) => rc.circleId))];
+		const circleList =
+			circleIds.length > 0
+				? await db
+						.select({
+							id: circles.id,
+							name: circles.name,
+						})
+						.from(circles)
+						.where(inArray(circles.id, circleIds))
+				: [];
+
+		const circleMap = new Map(circleList.map((c) => [c.id, c.name]));
+
+		// リリースIDからサークル名一覧へのマップを作成
+		const releaseCircleNamesMap = new Map<string, string[]>();
+		for (const rc of releaseCirclesList) {
+			const circleName = circleMap.get(rc.circleId);
+			if (circleName) {
+				const names = releaseCircleNamesMap.get(rc.releaseId) || [];
+				if (!names.includes(circleName)) {
+					names.push(circleName);
+				}
+				releaseCircleNamesMap.set(rc.releaseId, names);
+			}
+		}
+
+		// クレジットIDからトラックIDへのマップ
+		const creditToTrack = new Map(credits.map((c) => [c.creditId, c.trackId]));
+
+		// 役割別に楽曲をグループ化
+		const byRole: Record<string, Set<string>> = {};
+		for (const cr of creditRoles) {
+			const trackId = creditToTrack.get(cr.trackCreditId);
+			if (trackId) {
+				if (!byRole[cr.roleCode]) {
+					byRole[cr.roleCode] = new Set();
+				}
+				const roleSet = byRole[cr.roleCode];
+				if (roleSet) {
+					roleSet.add(trackId);
+				}
+			}
+		}
+
+		// 役割別カウント
+		const roleCount: Record<string, number> = {};
+		for (const [roleCode, trackSet] of Object.entries(byRole)) {
+			roleCount[roleCode] = trackSet.size;
+		}
+
+		// トラック情報を整形
+		const tracksWithRelease = trackList
+			.map((t) => {
+				const release = t.releaseId ? releaseMap.get(t.releaseId) : undefined;
+				const circleNames = t.releaseId
+					? releaseCircleNamesMap.get(t.releaseId)
+					: undefined;
+				return {
+					id: t.id,
+					name: t.name,
+					nameJa: t.nameJa,
+					trackNumber: t.trackNumber,
+					release: release
+						? {
+								id: release.id,
+								name: release.name,
+								releaseDate: release.releaseDate,
+								circleNames: circleNames ? circleNames.join(" / ") : null,
+							}
+						: null,
+				};
+			})
+			// 作品名 → トラック番号でソート
+			.sort((a, b) => {
+				// 作品なしは後ろへ
+				if (!a.release && b.release) return 1;
+				if (a.release && !b.release) return -1;
+				if (!a.release && !b.release) return a.name.localeCompare(b.name);
+
+				// ここに到達した時点で両方ともreleaseが存在する（上記の条件で除外済み）
+				// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
+				const releaseA = a.release!;
+				// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
+				const releaseB = b.release!;
+
+				// 作品名でソート
+				const releaseCompare = releaseA.name.localeCompare(releaseB.name);
+				if (releaseCompare !== 0) return releaseCompare;
+
+				// 同じ作品内ではトラック番号でソート
+				return a.trackNumber - b.trackNumber;
+			});
+
+		// 統計情報を計算
+		const releaseDates = releaseList
+			.map((r) => r.releaseDate)
+			.filter((d): d is string => d !== null)
+			.sort();
+
+		const statistics = {
+			releaseCount: releaseList.length,
+			earliestReleaseDate: releaseDates.length > 0 ? releaseDates[0] : null,
+			latestReleaseDate:
+				releaseDates.length > 0 ? releaseDates[releaseDates.length - 1] : null,
+		};
+
 		return c.json({
-			totalUniqueTrackCount: 0,
-			byRole: {},
-			tracks: [],
-			statistics: {
-				releaseCount: 0,
-				earliestReleaseDate: null,
-				latestReleaseDate: null,
-			},
+			totalUniqueTrackCount: trackIds.length,
+			byRole: roleCount,
+			tracks: tracksWithRelease,
+			statistics,
 		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/artists/:artistId/tracks");
 	}
-
-	const creditIds = credits.map((c) => c.creditId);
-	const trackIds = [...new Set(credits.map((c) => c.trackId))];
-
-	// クレジットの役割を取得
-	const creditRoles = await db
-		.select({
-			trackCreditId: trackCreditRoles.trackCreditId,
-			roleCode: trackCreditRoles.roleCode,
-		})
-		.from(trackCreditRoles)
-		.where(inArray(trackCreditRoles.trackCreditId, creditIds));
-
-	// トラック情報を取得
-	const trackList = await db
-		.select({
-			id: tracks.id,
-			name: tracks.name,
-			nameJa: tracks.nameJa,
-			releaseId: tracks.releaseId,
-			trackNumber: tracks.trackNumber,
-		})
-		.from(tracks)
-		.where(inArray(tracks.id, trackIds))
-		.orderBy(tracks.name);
-
-	// リリース情報を取得（nullを除外）
-	const releaseIds = [
-		...new Set(
-			trackList
-				.map((t) => t.releaseId)
-				.filter((id): id is string => id !== null),
-		),
-	];
-	const releaseList = await db
-		.select({
-			id: releases.id,
-			name: releases.name,
-			releaseDate: releases.releaseDate,
-		})
-		.from(releases)
-		.where(inArray(releases.id, releaseIds));
-
-	const releaseMap = new Map(releaseList.map((r) => [r.id, r]));
-
-	// リリースサークル情報を取得
-	const releaseCirclesList =
-		releaseIds.length > 0
-			? await db
-					.select({
-						releaseId: releaseCircles.releaseId,
-						circleId: releaseCircles.circleId,
-					})
-					.from(releaseCircles)
-					.where(inArray(releaseCircles.releaseId, releaseIds))
-			: [];
-
-	// サークル情報を取得
-	const circleIds = [...new Set(releaseCirclesList.map((rc) => rc.circleId))];
-	const circleList =
-		circleIds.length > 0
-			? await db
-					.select({
-						id: circles.id,
-						name: circles.name,
-					})
-					.from(circles)
-					.where(inArray(circles.id, circleIds))
-			: [];
-
-	const circleMap = new Map(circleList.map((c) => [c.id, c.name]));
-
-	// リリースIDからサークル名一覧へのマップを作成
-	const releaseCircleNamesMap = new Map<string, string[]>();
-	for (const rc of releaseCirclesList) {
-		const circleName = circleMap.get(rc.circleId);
-		if (circleName) {
-			const names = releaseCircleNamesMap.get(rc.releaseId) || [];
-			if (!names.includes(circleName)) {
-				names.push(circleName);
-			}
-			releaseCircleNamesMap.set(rc.releaseId, names);
-		}
-	}
-
-	// クレジットIDからトラックIDへのマップ
-	const creditToTrack = new Map(credits.map((c) => [c.creditId, c.trackId]));
-
-	// 役割別に楽曲をグループ化
-	const byRole: Record<string, Set<string>> = {};
-	for (const cr of creditRoles) {
-		const trackId = creditToTrack.get(cr.trackCreditId);
-		if (trackId) {
-			if (!byRole[cr.roleCode]) {
-				byRole[cr.roleCode] = new Set();
-			}
-			const roleSet = byRole[cr.roleCode];
-			if (roleSet) {
-				roleSet.add(trackId);
-			}
-		}
-	}
-
-	// 役割別カウント
-	const roleCount: Record<string, number> = {};
-	for (const [roleCode, trackSet] of Object.entries(byRole)) {
-		roleCount[roleCode] = trackSet.size;
-	}
-
-	// トラック情報を整形
-	const tracksWithRelease = trackList
-		.map((t) => {
-			const release = t.releaseId ? releaseMap.get(t.releaseId) : undefined;
-			const circleNames = t.releaseId
-				? releaseCircleNamesMap.get(t.releaseId)
-				: undefined;
-			return {
-				id: t.id,
-				name: t.name,
-				nameJa: t.nameJa,
-				trackNumber: t.trackNumber,
-				release: release
-					? {
-							id: release.id,
-							name: release.name,
-							releaseDate: release.releaseDate,
-							circleNames: circleNames ? circleNames.join(" / ") : null,
-						}
-					: null,
-			};
-		})
-		// 作品名 → トラック番号でソート
-		.sort((a, b) => {
-			// 作品なしは後ろへ
-			if (!a.release && b.release) return 1;
-			if (a.release && !b.release) return -1;
-			if (!a.release && !b.release) return a.name.localeCompare(b.name);
-
-			// ここに到達した時点で両方ともreleaseが存在する（上記の条件で除外済み）
-			// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
-			const releaseA = a.release!;
-			// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
-			const releaseB = b.release!;
-
-			// 作品名でソート
-			const releaseCompare = releaseA.name.localeCompare(releaseB.name);
-			if (releaseCompare !== 0) return releaseCompare;
-
-			// 同じ作品内ではトラック番号でソート
-			return a.trackNumber - b.trackNumber;
-		});
-
-	// 統計情報を計算
-	const releaseDates = releaseList
-		.map((r) => r.releaseDate)
-		.filter((d): d is string => d !== null)
-		.sort();
-
-	const statistics = {
-		releaseCount: releaseList.length,
-		earliestReleaseDate: releaseDates.length > 0 ? releaseDates[0] : null,
-		latestReleaseDate:
-			releaseDates.length > 0 ? releaseDates[releaseDates.length - 1] : null,
-	};
-
-	return c.json({
-		totalUniqueTrackCount: trackIds.length,
-		byRole: roleCount,
-		tracks: tracksWithRelease,
-		statistics,
-	});
 });
 
 export { artistTracksRouter };

--- a/apps/server/src/routes/admin/circles/artists.ts
+++ b/apps/server/src/routes/admin/circles/artists.ts
@@ -11,185 +11,193 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const circleArtistsRouter = new Hono<AdminContext>();
 
 // サークルの参加アーティスト一覧取得
 // 経路: circle → releaseCircles → releases → tracks → trackCredits → artists
 circleArtistsRouter.get("/:circleId/artists", async (c) => {
-	const circleId = c.req.param("circleId");
+	try {
+		const circleId = c.req.param("circleId");
 
-	// サークルのリリース一覧からリリースIDを取得
-	const releaseCirclesResult = await db
-		.select({
-			releaseId: releaseCircles.releaseId,
-		})
-		.from(releaseCircles)
-		.where(eq(releaseCircles.circleId, circleId));
+		// サークルのリリース一覧からリリースIDを取得
+		const releaseCirclesResult = await db
+			.select({
+				releaseId: releaseCircles.releaseId,
+			})
+			.from(releaseCircles)
+			.where(eq(releaseCircles.circleId, circleId));
 
-	if (releaseCirclesResult.length === 0) {
-		return c.json({
-			artists: [],
-			statistics: {
-				totalArtistCount: 0,
-				totalTrackCount: 0,
-				releaseCount: 0,
-			},
-		});
-	}
-
-	const releaseIds = [...new Set(releaseCirclesResult.map((r) => r.releaseId))];
-
-	// リリースからトラックIDを取得（リリース日も取得して活動期間計算に使用）
-	const tracksResult = await db
-		.select({
-			id: tracks.id,
-			releaseId: tracks.releaseId,
-		})
-		.from(tracks)
-		.where(inArray(tracks.releaseId, releaseIds));
-
-	if (tracksResult.length === 0) {
-		return c.json({
-			artists: [],
-			statistics: {
-				totalArtistCount: 0,
-				totalTrackCount: 0,
-				releaseCount: releaseIds.length,
-			},
-		});
-	}
-
-	const trackIds = [...new Set(tracksResult.map((t) => t.id))];
-
-	// トラックからクレジット情報を取得
-	const creditsResult = await db
-		.select({
-			id: trackCredits.id,
-			artistId: trackCredits.artistId,
-			trackId: trackCredits.trackId,
-		})
-		.from(trackCredits)
-		.where(inArray(trackCredits.trackId, trackIds));
-
-	if (creditsResult.length === 0) {
-		return c.json({
-			artists: [],
-			statistics: {
-				totalArtistCount: 0,
-				totalTrackCount: trackIds.length,
-				releaseCount: releaseIds.length,
-			},
-		});
-	}
-
-	// クレジットの役割情報を取得
-	const creditIds = creditsResult.map((c) => c.id);
-	const rolesResult = await db
-		.select({
-			trackCreditId: trackCreditRoles.trackCreditId,
-			roleCode: trackCreditRoles.roleCode,
-		})
-		.from(trackCreditRoles)
-		.where(inArray(trackCreditRoles.trackCreditId, creditIds));
-
-	// クレジットIDと役割のマッピング
-	const creditToRolesMap = new Map<string, Set<string>>();
-	for (const role of rolesResult) {
-		const roles = creditToRolesMap.get(role.trackCreditId) || new Set<string>();
-		roles.add(role.roleCode);
-		creditToRolesMap.set(role.trackCreditId, roles);
-	}
-
-	// アーティスト情報を取得
-	const artistIds = [...new Set(creditsResult.map((c) => c.artistId))];
-	const artistList = await db
-		.select({
-			id: artists.id,
-			name: artists.name,
-		})
-		.from(artists)
-		.where(inArray(artists.id, artistIds))
-		.orderBy(artists.name);
-
-	// トラックとリリースのマッピング
-	const trackToReleaseMap = new Map<string, string>();
-	for (const track of tracksResult) {
-		if (track.releaseId) {
-			trackToReleaseMap.set(track.id, track.releaseId);
+		if (releaseCirclesResult.length === 0) {
+			return c.json({
+				artists: [],
+				statistics: {
+					totalArtistCount: 0,
+					totalTrackCount: 0,
+					releaseCount: 0,
+				},
+			});
 		}
-	}
 
-	// アーティストごとにトラック数、リリース数、役割を集計
-	const artistStats = new Map<
-		string,
-		{
-			trackIds: Set<string>;
-			releaseIds: Set<string>;
-			roles: Set<string>;
+		const releaseIds = [
+			...new Set(releaseCirclesResult.map((r) => r.releaseId)),
+		];
+
+		// リリースからトラックIDを取得（リリース日も取得して活動期間計算に使用）
+		const tracksResult = await db
+			.select({
+				id: tracks.id,
+				releaseId: tracks.releaseId,
+			})
+			.from(tracks)
+			.where(inArray(tracks.releaseId, releaseIds));
+
+		if (tracksResult.length === 0) {
+			return c.json({
+				artists: [],
+				statistics: {
+					totalArtistCount: 0,
+					totalTrackCount: 0,
+					releaseCount: releaseIds.length,
+				},
+			});
 		}
-	>();
 
-	for (const credit of creditsResult) {
-		const stats = artistStats.get(credit.artistId) || {
-			trackIds: new Set<string>(),
-			releaseIds: new Set<string>(),
-			roles: new Set<string>(),
-		};
+		const trackIds = [...new Set(tracksResult.map((t) => t.id))];
 
-		stats.trackIds.add(credit.trackId);
+		// トラックからクレジット情報を取得
+		const creditsResult = await db
+			.select({
+				id: trackCredits.id,
+				artistId: trackCredits.artistId,
+				trackId: trackCredits.trackId,
+			})
+			.from(trackCredits)
+			.where(inArray(trackCredits.trackId, trackIds));
 
-		// クレジットに紐づく役割を追加
-		const creditRoles = creditToRolesMap.get(credit.id);
-		if (creditRoles) {
-			for (const role of creditRoles) {
-				stats.roles.add(role);
+		if (creditsResult.length === 0) {
+			return c.json({
+				artists: [],
+				statistics: {
+					totalArtistCount: 0,
+					totalTrackCount: trackIds.length,
+					releaseCount: releaseIds.length,
+				},
+			});
+		}
+
+		// クレジットの役割情報を取得
+		const creditIds = creditsResult.map((c) => c.id);
+		const rolesResult = await db
+			.select({
+				trackCreditId: trackCreditRoles.trackCreditId,
+				roleCode: trackCreditRoles.roleCode,
+			})
+			.from(trackCreditRoles)
+			.where(inArray(trackCreditRoles.trackCreditId, creditIds));
+
+		// クレジットIDと役割のマッピング
+		const creditToRolesMap = new Map<string, Set<string>>();
+		for (const role of rolesResult) {
+			const roles =
+				creditToRolesMap.get(role.trackCreditId) || new Set<string>();
+			roles.add(role.roleCode);
+			creditToRolesMap.set(role.trackCreditId, roles);
+		}
+
+		// アーティスト情報を取得
+		const artistIds = [...new Set(creditsResult.map((c) => c.artistId))];
+		const artistList = await db
+			.select({
+				id: artists.id,
+				name: artists.name,
+			})
+			.from(artists)
+			.where(inArray(artists.id, artistIds))
+			.orderBy(artists.name);
+
+		// トラックとリリースのマッピング
+		const trackToReleaseMap = new Map<string, string>();
+		for (const track of tracksResult) {
+			if (track.releaseId) {
+				trackToReleaseMap.set(track.id, track.releaseId);
 			}
 		}
 
-		const releaseId = trackToReleaseMap.get(credit.trackId);
-		if (releaseId) {
-			stats.releaseIds.add(releaseId);
+		// アーティストごとにトラック数、リリース数、役割を集計
+		const artistStats = new Map<
+			string,
+			{
+				trackIds: Set<string>;
+				releaseIds: Set<string>;
+				roles: Set<string>;
+			}
+		>();
+
+		for (const credit of creditsResult) {
+			const stats = artistStats.get(credit.artistId) || {
+				trackIds: new Set<string>(),
+				releaseIds: new Set<string>(),
+				roles: new Set<string>(),
+			};
+
+			stats.trackIds.add(credit.trackId);
+
+			// クレジットに紐づく役割を追加
+			const creditRoles = creditToRolesMap.get(credit.id);
+			if (creditRoles) {
+				for (const role of creditRoles) {
+					stats.roles.add(role);
+				}
+			}
+
+			const releaseId = trackToReleaseMap.get(credit.trackId);
+			if (releaseId) {
+				stats.releaseIds.add(releaseId);
+			}
+
+			artistStats.set(credit.artistId, stats);
 		}
 
-		artistStats.set(credit.artistId, stats);
+		// レスポンスを整形
+		const result = artistList.map((artist) => {
+			const stats = artistStats.get(artist.id);
+			return {
+				artistId: artist.id,
+				artistName: artist.name,
+				trackCount: stats?.trackIds.size ?? 0,
+				releaseCount: stats?.releaseIds.size ?? 0,
+				roles: stats ? Array.from(stats.roles).sort() : [],
+			};
+		});
+
+		// リリース日情報を取得して活動期間を計算
+		const releasesData = await db
+			.select({
+				releaseDate: releases.releaseDate,
+			})
+			.from(releases)
+			.where(inArray(releases.id, releaseIds));
+
+		const releaseDates = releasesData
+			.map((r) => r.releaseDate)
+			.filter((d): d is string => d !== null)
+			.sort();
+
+		return c.json({
+			artists: result,
+			statistics: {
+				totalArtistCount: artistList.length,
+				totalTrackCount: trackIds.length,
+				releaseCount: releaseIds.length,
+				earliestReleaseDate: releaseDates[0] ?? null,
+				latestReleaseDate: releaseDates[releaseDates.length - 1] ?? null,
+			},
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/circles/:circleId/artists");
 	}
-
-	// レスポンスを整形
-	const result = artistList.map((artist) => {
-		const stats = artistStats.get(artist.id);
-		return {
-			artistId: artist.id,
-			artistName: artist.name,
-			trackCount: stats?.trackIds.size ?? 0,
-			releaseCount: stats?.releaseIds.size ?? 0,
-			roles: stats ? Array.from(stats.roles).sort() : [],
-		};
-	});
-
-	// リリース日情報を取得して活動期間を計算
-	const releasesData = await db
-		.select({
-			releaseDate: releases.releaseDate,
-		})
-		.from(releases)
-		.where(inArray(releases.id, releaseIds));
-
-	const releaseDates = releasesData
-		.map((r) => r.releaseDate)
-		.filter((d): d is string => d !== null)
-		.sort();
-
-	return c.json({
-		artists: result,
-		statistics: {
-			totalArtistCount: artistList.length,
-			totalTrackCount: trackIds.length,
-			releaseCount: releaseIds.length,
-			earliestReleaseDate: releaseDates[0] ?? null,
-			latestReleaseDate: releaseDates[releaseDates.length - 1] ?? null,
-		},
-	});
 });
 
 export { circleArtistsRouter };

--- a/apps/server/src/routes/admin/circles/index.ts
+++ b/apps/server/src/routes/admin/circles/index.ts
@@ -16,6 +16,7 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 import { circleArtistsRouter } from "./artists";
 import { circleReleasesRouter } from "./releases";
 
@@ -27,377 +28,319 @@ circlesRouter.route("/", circleArtistsRouter);
 
 // サークル一覧取得（ページネーション、検索、頭文字フィルタ対応）
 circlesRouter.get("/", async (c) => {
-	const page = Number(c.req.query("page")) || 1;
-	const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
-	const initialScript = c.req.query("initialScript");
-	const search = c.req.query("search");
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const initialScript = c.req.query("initialScript");
+		const search = c.req.query("search");
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 条件を構築
-	const conditions = [];
+		// 条件を構築
+		const conditions = [];
 
-	if (initialScript) {
-		conditions.push(eq(circles.initialScript, initialScript));
+		if (initialScript) {
+			conditions.push(eq(circles.initialScript, initialScript));
+		}
+
+		if (search) {
+			const searchPattern = `%${search}%`;
+			conditions.push(
+				or(
+					like(circles.name, searchPattern),
+					like(circles.nameJa, searchPattern),
+					like(circles.nameEn, searchPattern),
+				),
+			);
+		}
+
+		const whereCondition =
+			conditions.length > 0 ? and(...conditions) : undefined;
+
+		// データ取得
+		const [data, totalResult] = await Promise.all([
+			db
+				.select()
+				.from(circles)
+				.where(whereCondition)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(circles.name),
+			db.select({ count: count() }).from(circles).where(whereCondition),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/circles");
 	}
-
-	if (search) {
-		const searchPattern = `%${search}%`;
-		conditions.push(
-			or(
-				like(circles.name, searchPattern),
-				like(circles.nameJa, searchPattern),
-				like(circles.nameEn, searchPattern),
-			),
-		);
-	}
-
-	const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
-
-	// データ取得
-	const [data, totalResult] = await Promise.all([
-		db
-			.select()
-			.from(circles)
-			.where(whereCondition)
-			.limit(limit)
-			.offset(offset)
-			.orderBy(circles.name),
-		db.select({ count: count() }).from(circles).where(whereCondition),
-	]);
-
-	const total = totalResult[0]?.count ?? 0;
-
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
 });
 
 // サークル個別取得（リンク情報を含む）
 circlesRouter.get("/:id", async (c) => {
-	const id = c.req.param("id");
+	try {
+		const id = c.req.param("id");
 
-	const result = await db
-		.select()
-		.from(circles)
-		.where(eq(circles.id, id))
-		.limit(1);
+		const result = await db
+			.select()
+			.from(circles)
+			.where(eq(circles.id, id))
+			.limit(1);
 
-	if (result.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (result.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 関連リンクを取得
+		const links = await db
+			.select({
+				id: circleLinks.id,
+				circleId: circleLinks.circleId,
+				platformCode: circleLinks.platformCode,
+				url: circleLinks.url,
+				platformId: circleLinks.platformId,
+				handle: circleLinks.handle,
+				isOfficial: circleLinks.isOfficial,
+				isPrimary: circleLinks.isPrimary,
+				createdAt: circleLinks.createdAt,
+				updatedAt: circleLinks.updatedAt,
+				platformName: platforms.name,
+			})
+			.from(circleLinks)
+			.leftJoin(platforms, eq(circleLinks.platformCode, platforms.code))
+			.where(eq(circleLinks.circleId, id))
+			.orderBy(circleLinks.isPrimary, circleLinks.createdAt);
+
+		return c.json({
+			...result[0],
+			links,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/circles/:id");
 	}
-
-	// 関連リンクを取得
-	const links = await db
-		.select({
-			id: circleLinks.id,
-			circleId: circleLinks.circleId,
-			platformCode: circleLinks.platformCode,
-			url: circleLinks.url,
-			platformId: circleLinks.platformId,
-			handle: circleLinks.handle,
-			isOfficial: circleLinks.isOfficial,
-			isPrimary: circleLinks.isPrimary,
-			createdAt: circleLinks.createdAt,
-			updatedAt: circleLinks.updatedAt,
-			platformName: platforms.name,
-		})
-		.from(circleLinks)
-		.leftJoin(platforms, eq(circleLinks.platformCode, platforms.code))
-		.where(eq(circleLinks.circleId, id))
-		.orderBy(circleLinks.isPrimary, circleLinks.createdAt);
-
-	return c.json({
-		...result[0],
-		links,
-	});
 });
 
 // サークル新規作成
 circlesRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertCircleSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		// バリデーション
+		const parsed = insertCircleSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(circles)
-		.where(eq(circles.id, parsed.data.id))
-		.limit(1);
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(circles)
+			.where(eq(circles.id, parsed.data.id))
+			.limit(1);
 
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
 
-	// 名前重複チェック（大文字小文字無視）
-	const existingName = await db
-		.select()
-		.from(circles)
-		.where(sql`lower(${circles.name}) = lower(${parsed.data.name})`)
-		.limit(1);
-
-	if (existingName.length > 0) {
-		return c.json({ error: "Name already exists" }, 409);
-	}
-
-	// 作成
-	const result = await db.insert(circles).values(parsed.data).returning();
-
-	return c.json(result[0], 201);
-});
-
-// サークル更新
-circlesRouter.put("/:id", async (c) => {
-	const id = c.req.param("id");
-	const body = await c.req.json();
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(circles)
-		.where(eq(circles.id, id))
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateCircleSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 名前重複チェック（自身以外に同じ名前がある場合）
-	if (parsed.data.name) {
+		// 名前重複チェック（大文字小文字無視）
 		const existingName = await db
 			.select()
 			.from(circles)
 			.where(sql`lower(${circles.name}) = lower(${parsed.data.name})`)
 			.limit(1);
 
-		if (existingName.length > 0 && existingName[0]?.id !== id) {
+		if (existingName.length > 0) {
 			return c.json({ error: "Name already exists" }, 409);
 		}
+
+		// 作成
+		const result = await db.insert(circles).values(parsed.data).returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/circles");
 	}
+});
 
-	// 更新
-	const result = await db
-		.update(circles)
-		.set(parsed.data)
-		.where(eq(circles.id, id))
-		.returning();
+// サークル更新
+circlesRouter.put("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+		const body = await c.req.json();
 
-	return c.json(result[0]);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(circles)
+			.where(eq(circles.id, id))
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateCircleSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 名前重複チェック（自身以外に同じ名前がある場合）
+		if (parsed.data.name) {
+			const existingName = await db
+				.select()
+				.from(circles)
+				.where(sql`lower(${circles.name}) = lower(${parsed.data.name})`)
+				.limit(1);
+
+			if (existingName.length > 0 && existingName[0]?.id !== id) {
+				return c.json({ error: "Name already exists" }, 409);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(circles)
+			.set(parsed.data)
+			.where(eq(circles.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/circles/:id");
+	}
 });
 
 // サークル削除
 circlesRouter.delete("/:id", async (c) => {
-	const id = c.req.param("id");
+	try {
+		const id = c.req.param("id");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(circles)
-		.where(eq(circles.id, id))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(circles)
+			.where(eq(circles.id, id))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除（関連リンクはCASCADE削除）
+		await db.delete(circles).where(eq(circles.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/circles/:id");
 	}
-
-	// 削除（関連リンクはCASCADE削除）
-	await db.delete(circles).where(eq(circles.id, id));
-
-	return c.json({ success: true });
 });
 
 // ===== サークルリンク関連エンドポイント =====
 
 // サークルのリンク一覧取得
 circlesRouter.get("/:circleId/links", async (c) => {
-	const circleId = c.req.param("circleId");
+	try {
+		const circleId = c.req.param("circleId");
 
-	// サークル存在チェック
-	const existingCircle = await db
-		.select()
-		.from(circles)
-		.where(eq(circles.id, circleId))
-		.limit(1);
+		// サークル存在チェック
+		const existingCircle = await db
+			.select()
+			.from(circles)
+			.where(eq(circles.id, circleId))
+			.limit(1);
 
-	if (existingCircle.length === 0) {
-		return c.json({ error: "Circle not found" }, 404);
+		if (existingCircle.length === 0) {
+			return c.json({ error: "Circle not found" }, 404);
+		}
+
+		const links = await db
+			.select({
+				id: circleLinks.id,
+				circleId: circleLinks.circleId,
+				platformCode: circleLinks.platformCode,
+				url: circleLinks.url,
+				platformId: circleLinks.platformId,
+				handle: circleLinks.handle,
+				isOfficial: circleLinks.isOfficial,
+				isPrimary: circleLinks.isPrimary,
+				createdAt: circleLinks.createdAt,
+				updatedAt: circleLinks.updatedAt,
+				platformName: platforms.name,
+			})
+			.from(circleLinks)
+			.leftJoin(platforms, eq(circleLinks.platformCode, platforms.code))
+			.where(eq(circleLinks.circleId, circleId))
+			.orderBy(circleLinks.isPrimary, circleLinks.createdAt);
+
+		return c.json(links);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/circles/:circleId/links");
 	}
-
-	const links = await db
-		.select({
-			id: circleLinks.id,
-			circleId: circleLinks.circleId,
-			platformCode: circleLinks.platformCode,
-			url: circleLinks.url,
-			platformId: circleLinks.platformId,
-			handle: circleLinks.handle,
-			isOfficial: circleLinks.isOfficial,
-			isPrimary: circleLinks.isPrimary,
-			createdAt: circleLinks.createdAt,
-			updatedAt: circleLinks.updatedAt,
-			platformName: platforms.name,
-		})
-		.from(circleLinks)
-		.leftJoin(platforms, eq(circleLinks.platformCode, platforms.code))
-		.where(eq(circleLinks.circleId, circleId))
-		.orderBy(circleLinks.isPrimary, circleLinks.createdAt);
-
-	return c.json(links);
 });
 
 // サークルリンク追加
 circlesRouter.post("/:circleId/links", async (c) => {
-	const circleId = c.req.param("circleId");
-	const body = await c.req.json();
-
-	// サークル存在チェック
-	const existingCircle = await db
-		.select()
-		.from(circles)
-		.where(eq(circles.id, circleId))
-		.limit(1);
-
-	if (existingCircle.length === 0) {
-		return c.json({ error: "Circle not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = insertCircleLinkSchema.safeParse({
-		...body,
-		circleId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(circleLinks)
-		.where(eq(circleLinks.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// URL重複チェック（同一サークル内）
-	const existingUrl = await db
-		.select()
-		.from(circleLinks)
-		.where(
-			and(
-				eq(circleLinks.circleId, circleId),
-				eq(circleLinks.url, parsed.data.url),
-			),
-		)
-		.limit(1);
-
-	if (existingUrl.length > 0) {
-		return c.json({ error: "URL already exists for this circle" }, 409);
-	}
-
-	// プラットフォームのURLパターンを取得してバリデーション
-	const platform = await db
-		.select({ urlPattern: platforms.urlPattern })
-		.from(platforms)
-		.where(eq(platforms.code, parsed.data.platformCode))
-		.limit(1);
-
-	if (platform[0]?.urlPattern) {
-		try {
-			const regex = new RegExp(platform[0].urlPattern);
-			if (!regex.test(parsed.data.url)) {
-				return c.json(
-					{ error: "URLが選択されたプラットフォームの形式と一致しません" },
-					400,
-				);
-			}
-		} catch (e) {
-			// 無効な正規表現パターンの場合はスキップ
-			console.error("Invalid URL pattern:", platform[0].urlPattern, e);
-		}
-	}
-
-	// 作成
 	try {
-		const result = await db.insert(circleLinks).values(parsed.data).returning();
-		return c.json(result[0], 201);
-	} catch (e) {
-		console.error("Failed to create circle link:", e);
-		return c.json(
-			{ error: e instanceof Error ? e.message : "リンクの作成に失敗しました" },
-			500,
-		);
-	}
-});
+		const circleId = c.req.param("circleId");
+		const body = await c.req.json();
 
-// サークルリンク更新
-circlesRouter.put("/:circleId/links/:linkId", async (c) => {
-	const circleId = c.req.param("circleId");
-	const linkId = c.req.param("linkId");
-	const body = await c.req.json();
+		// サークル存在チェック
+		const existingCircle = await db
+			.select()
+			.from(circles)
+			.where(eq(circles.id, circleId))
+			.limit(1);
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(circleLinks)
-		.where(and(eq(circleLinks.id, linkId), eq(circleLinks.circleId, circleId)))
-		.limit(1);
+		if (existingCircle.length === 0) {
+			return c.json({ error: "Circle not found" }, 404);
+		}
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
+		// バリデーション
+		const parsed = insertCircleLinkSchema.safeParse({
+			...body,
+			circleId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// biome-ignore lint/style/noNonNullAssertion: existing.length > 0 is guaranteed by the check above
-	const existingLink = existing[0]!;
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(circleLinks)
+			.where(eq(circleLinks.id, parsed.data.id))
+			.limit(1);
 
-	// バリデーション
-	const parsed = updateCircleLinkSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
 
-	// URL重複チェック（同一サークル内、自身以外）
-	if (parsed.data.url) {
+		// URL重複チェック（同一サークル内）
 		const existingUrl = await db
 			.select()
 			.from(circleLinks)
@@ -409,26 +352,21 @@ circlesRouter.put("/:circleId/links/:linkId", async (c) => {
 			)
 			.limit(1);
 
-		if (existingUrl.length > 0 && existingUrl[0]?.id !== linkId) {
+		if (existingUrl.length > 0) {
 			return c.json({ error: "URL already exists for this circle" }, 409);
 		}
-	}
 
-	// URLまたはplatformCodeが更新される場合、URLパターンバリデーション
-	if (parsed.data.url || parsed.data.platformCode) {
-		const platformCode = parsed.data.platformCode || existingLink.platformCode;
-		const url = parsed.data.url || existingLink.url;
-
+		// プラットフォームのURLパターンを取得してバリデーション
 		const platform = await db
 			.select({ urlPattern: platforms.urlPattern })
 			.from(platforms)
-			.where(eq(platforms.code, platformCode))
+			.where(eq(platforms.code, parsed.data.platformCode))
 			.limit(1);
 
 		if (platform[0]?.urlPattern) {
 			try {
 				const regex = new RegExp(platform[0].urlPattern);
-				if (!regex.test(url)) {
+				if (!regex.test(parsed.data.url)) {
 					return c.json(
 						{ error: "URLが選択されたプラットフォームの形式と一致しません" },
 						400,
@@ -439,45 +377,142 @@ circlesRouter.put("/:circleId/links/:linkId", async (c) => {
 				console.error("Invalid URL pattern:", platform[0].urlPattern, e);
 			}
 		}
-	}
 
-	// 更新
+		// 作成
+		const result = await db.insert(circleLinks).values(parsed.data).returning();
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/circles/:circleId/links");
+	}
+});
+
+// サークルリンク更新
+circlesRouter.put("/:circleId/links/:linkId", async (c) => {
 	try {
+		const circleId = c.req.param("circleId");
+		const linkId = c.req.param("linkId");
+		const body = await c.req.json();
+
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(circleLinks)
+			.where(
+				and(eq(circleLinks.id, linkId), eq(circleLinks.circleId, circleId)),
+			)
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// biome-ignore lint/style/noNonNullAssertion: existing.length > 0 is guaranteed by the check above
+		const existingLink = existing[0]!;
+
+		// バリデーション
+		const parsed = updateCircleLinkSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// URL重複チェック（同一サークル内、自身以外）
+		if (parsed.data.url) {
+			const existingUrl = await db
+				.select()
+				.from(circleLinks)
+				.where(
+					and(
+						eq(circleLinks.circleId, circleId),
+						eq(circleLinks.url, parsed.data.url),
+					),
+				)
+				.limit(1);
+
+			if (existingUrl.length > 0 && existingUrl[0]?.id !== linkId) {
+				return c.json({ error: "URL already exists for this circle" }, 409);
+			}
+		}
+
+		// URLまたはplatformCodeが更新される場合、URLパターンバリデーション
+		if (parsed.data.url || parsed.data.platformCode) {
+			const platformCode =
+				parsed.data.platformCode || existingLink.platformCode;
+			const url = parsed.data.url || existingLink.url;
+
+			const platform = await db
+				.select({ urlPattern: platforms.urlPattern })
+				.from(platforms)
+				.where(eq(platforms.code, platformCode))
+				.limit(1);
+
+			if (platform[0]?.urlPattern) {
+				try {
+					const regex = new RegExp(platform[0].urlPattern);
+					if (!regex.test(url)) {
+						return c.json(
+							{ error: "URLが選択されたプラットフォームの形式と一致しません" },
+							400,
+						);
+					}
+				} catch (e) {
+					// 無効な正規表現パターンの場合はスキップ
+					console.error("Invalid URL pattern:", platform[0].urlPattern, e);
+				}
+			}
+		}
+
+		// 更新
 		const result = await db
 			.update(circleLinks)
 			.set(parsed.data)
 			.where(eq(circleLinks.id, linkId))
 			.returning();
 		return c.json(result[0]);
-	} catch (e) {
-		console.error("Failed to update circle link:", e);
-		return c.json(
-			{ error: e instanceof Error ? e.message : "リンクの更新に失敗しました" },
-			500,
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/circles/:circleId/links/:linkId",
 		);
 	}
 });
 
 // サークルリンク削除
 circlesRouter.delete("/:circleId/links/:linkId", async (c) => {
-	const circleId = c.req.param("circleId");
-	const linkId = c.req.param("linkId");
+	try {
+		const circleId = c.req.param("circleId");
+		const linkId = c.req.param("linkId");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(circleLinks)
-		.where(and(eq(circleLinks.id, linkId), eq(circleLinks.circleId, circleId)))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(circleLinks)
+			.where(
+				and(eq(circleLinks.id, linkId), eq(circleLinks.circleId, circleId)),
+			)
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(circleLinks).where(eq(circleLinks.id, linkId));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/circles/:circleId/links/:linkId",
+		);
 	}
-
-	// 削除
-	await db.delete(circleLinks).where(eq(circleLinks.id, linkId));
-
-	return c.json({ success: true });
 });
 
 export { circlesRouter };

--- a/apps/server/src/routes/admin/circles/releases.ts
+++ b/apps/server/src/routes/admin/circles/releases.ts
@@ -8,62 +8,67 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const circleReleasesRouter = new Hono<AdminContext>();
 
 // サークルのリリース一覧取得（参加形態別にグループ化）
 circleReleasesRouter.get("/:circleId/releases", async (c) => {
-	const circleId = c.req.param("circleId");
+	try {
+		const circleId = c.req.param("circleId");
 
-	// サークル存在チェック
-	const existingCircle = await db
-		.select()
-		.from(circles)
-		.where(eq(circles.id, circleId))
-		.limit(1);
+		// サークル存在チェック
+		const existingCircle = await db
+			.select()
+			.from(circles)
+			.where(eq(circles.id, circleId))
+			.limit(1);
 
-	if (existingCircle.length === 0) {
-		return c.json({ error: "Circle not found" }, 404);
+		if (existingCircle.length === 0) {
+			return c.json({ error: "Circle not found" }, 404);
+		}
+
+		// リリースを参加形態別に取得
+		const data = await db
+			.select({
+				releaseId: releases.id,
+				releaseName: releases.name,
+				releaseDate: releases.releaseDate,
+				releaseType: releases.releaseType,
+				participationType: releaseCircles.participationType,
+			})
+			.from(releaseCircles)
+			.innerJoin(releases, eq(releaseCircles.releaseId, releases.id))
+			.where(eq(releaseCircles.circleId, circleId))
+			.orderBy(releases.releaseDate, releaseCircles.position);
+
+		// 参加形態別にグループ化
+		const participationOrder: ParticipationType[] = [
+			"host",
+			"co-host",
+			"participant",
+			"guest",
+			"split_partner",
+		];
+
+		const grouped = participationOrder
+			.map((type) => ({
+				participationType: type,
+				releases: data
+					.filter((d) => d.participationType === type)
+					.map((d) => ({
+						id: d.releaseId,
+						name: d.releaseName,
+						releaseDate: d.releaseDate,
+						releaseType: d.releaseType,
+					})),
+			}))
+			.filter((g) => g.releases.length > 0);
+
+		return c.json(grouped);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/circles/:circleId/releases");
 	}
-
-	// リリースを参加形態別に取得
-	const data = await db
-		.select({
-			releaseId: releases.id,
-			releaseName: releases.name,
-			releaseDate: releases.releaseDate,
-			releaseType: releases.releaseType,
-			participationType: releaseCircles.participationType,
-		})
-		.from(releaseCircles)
-		.innerJoin(releases, eq(releaseCircles.releaseId, releases.id))
-		.where(eq(releaseCircles.circleId, circleId))
-		.orderBy(releases.releaseDate, releaseCircles.position);
-
-	// 参加形態別にグループ化
-	const participationOrder: ParticipationType[] = [
-		"host",
-		"co-host",
-		"participant",
-		"guest",
-		"split_partner",
-	];
-
-	const grouped = participationOrder
-		.map((type) => ({
-			participationType: type,
-			releases: data
-				.filter((d) => d.participationType === type)
-				.map((d) => ({
-					id: d.releaseId,
-					name: d.releaseName,
-					releaseDate: d.releaseDate,
-					releaseType: d.releaseType,
-				})),
-		}))
-		.filter((g) => g.releases.length > 0);
-
-	return c.json(grouped);
 });
 
 export { circleReleasesRouter };

--- a/apps/server/src/routes/admin/events/event-days.ts
+++ b/apps/server/src/routes/admin/events/event-days.ts
@@ -9,141 +9,82 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const eventDaysRouter = new Hono<AdminContext>();
 
 // イベントの開催日一覧取得（日番号順）
 eventDaysRouter.get("/:eventId/days", async (c) => {
-	const eventId = c.req.param("eventId");
+	try {
+		const eventId = c.req.param("eventId");
 
-	// イベント存在チェック
-	const existingEvent = await db
-		.select()
-		.from(events)
-		.where(eq(events.id, eventId))
-		.limit(1);
+		// イベント存在チェック
+		const existingEvent = await db
+			.select()
+			.from(events)
+			.where(eq(events.id, eventId))
+			.limit(1);
 
-	if (existingEvent.length === 0) {
-		return c.json({ error: "Event not found" }, 404);
+		if (existingEvent.length === 0) {
+			return c.json({ error: "Event not found" }, 404);
+		}
+
+		const days = await db
+			.select()
+			.from(eventDays)
+			.where(eq(eventDays.eventId, eventId))
+			.orderBy(eventDays.dayNumber);
+
+		return c.json(days);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/events/:eventId/days");
 	}
-
-	const days = await db
-		.select()
-		.from(eventDays)
-		.where(eq(eventDays.eventId, eventId))
-		.orderBy(eventDays.dayNumber);
-
-	return c.json(days);
 });
 
 // 開催日追加
 eventDaysRouter.post("/:eventId/days", async (c) => {
-	const eventId = c.req.param("eventId");
-	const body = await c.req.json();
+	try {
+		const eventId = c.req.param("eventId");
+		const body = await c.req.json();
 
-	// イベント存在チェック
-	const existingEvent = await db
-		.select()
-		.from(events)
-		.where(eq(events.id, eventId))
-		.limit(1);
+		// イベント存在チェック
+		const existingEvent = await db
+			.select()
+			.from(events)
+			.where(eq(events.id, eventId))
+			.limit(1);
 
-	if (existingEvent.length === 0) {
-		return c.json({ error: "Event not found" }, 404);
-	}
+		if (existingEvent.length === 0) {
+			return c.json({ error: "Event not found" }, 404);
+		}
 
-	// バリデーション
-	const parsed = insertEventDaySchema.safeParse({
-		...body,
-		eventId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		// バリデーション
+		const parsed = insertEventDaySchema.safeParse({
+			...body,
+			eventId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(eventDays)
-		.where(eq(eventDays.id, parsed.data.id))
-		.limit(1);
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(eventDays)
+			.where(eq(eventDays.id, parsed.data.id))
+			.limit(1);
 
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
 
-	// 日番号重複チェック（同一イベント内）
-	const existingDayNumber = await db
-		.select()
-		.from(eventDays)
-		.where(
-			and(
-				eq(eventDays.eventId, eventId),
-				eq(eventDays.dayNumber, parsed.data.dayNumber),
-			),
-		)
-		.limit(1);
-
-	if (existingDayNumber.length > 0) {
-		return c.json({ error: "Day number already exists for this event" }, 409);
-	}
-
-	// 日付重複チェック（同一イベント内）
-	const existingDate = await db
-		.select()
-		.from(eventDays)
-		.where(
-			and(eq(eventDays.eventId, eventId), eq(eventDays.date, parsed.data.date)),
-		)
-		.limit(1);
-
-	if (existingDate.length > 0) {
-		return c.json({ error: "Date already exists for this event" }, 409);
-	}
-
-	// 作成
-	const result = await db.insert(eventDays).values(parsed.data).returning();
-
-	return c.json(result[0], 201);
-});
-
-// 開催日更新
-eventDaysRouter.put("/:eventId/days/:dayId", async (c) => {
-	const eventId = c.req.param("eventId");
-	const dayId = c.req.param("dayId");
-	const body = await c.req.json();
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(eventDays)
-		.where(and(eq(eventDays.id, dayId), eq(eventDays.eventId, eventId)))
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateEventDaySchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 日番号重複チェック（同一イベント内、自身以外）
-	if (parsed.data.dayNumber !== undefined) {
+		// 日番号重複チェック（同一イベント内）
 		const existingDayNumber = await db
 			.select()
 			.from(eventDays)
@@ -155,13 +96,11 @@ eventDaysRouter.put("/:eventId/days/:dayId", async (c) => {
 			)
 			.limit(1);
 
-		if (existingDayNumber.length > 0 && existingDayNumber[0]?.id !== dayId) {
+		if (existingDayNumber.length > 0) {
 			return c.json({ error: "Day number already exists for this event" }, 409);
 		}
-	}
 
-	// 日付重複チェック（同一イベント内、自身以外）
-	if (parsed.data.date !== undefined) {
+		// 日付重複チェック（同一イベント内）
 		const existingDate = await db
 			.select()
 			.from(eventDays)
@@ -173,41 +112,125 @@ eventDaysRouter.put("/:eventId/days/:dayId", async (c) => {
 			)
 			.limit(1);
 
-		if (existingDate.length > 0 && existingDate[0]?.id !== dayId) {
+		if (existingDate.length > 0) {
 			return c.json({ error: "Date already exists for this event" }, 409);
 		}
+
+		// 作成
+		const result = await db.insert(eventDays).values(parsed.data).returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/events/:eventId/days");
 	}
+});
 
-	// 更新
-	const result = await db
-		.update(eventDays)
-		.set(parsed.data)
-		.where(eq(eventDays.id, dayId))
-		.returning();
+// 開催日更新
+eventDaysRouter.put("/:eventId/days/:dayId", async (c) => {
+	try {
+		const eventId = c.req.param("eventId");
+		const dayId = c.req.param("dayId");
+		const body = await c.req.json();
 
-	return c.json(result[0]);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(eventDays)
+			.where(and(eq(eventDays.id, dayId), eq(eventDays.eventId, eventId)))
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateEventDaySchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 日番号重複チェック（同一イベント内、自身以外）
+		if (parsed.data.dayNumber !== undefined) {
+			const existingDayNumber = await db
+				.select()
+				.from(eventDays)
+				.where(
+					and(
+						eq(eventDays.eventId, eventId),
+						eq(eventDays.dayNumber, parsed.data.dayNumber),
+					),
+				)
+				.limit(1);
+
+			if (existingDayNumber.length > 0 && existingDayNumber[0]?.id !== dayId) {
+				return c.json(
+					{ error: "Day number already exists for this event" },
+					409,
+				);
+			}
+		}
+
+		// 日付重複チェック（同一イベント内、自身以外）
+		if (parsed.data.date !== undefined) {
+			const existingDate = await db
+				.select()
+				.from(eventDays)
+				.where(
+					and(
+						eq(eventDays.eventId, eventId),
+						eq(eventDays.date, parsed.data.date),
+					),
+				)
+				.limit(1);
+
+			if (existingDate.length > 0 && existingDate[0]?.id !== dayId) {
+				return c.json({ error: "Date already exists for this event" }, 409);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(eventDays)
+			.set(parsed.data)
+			.where(eq(eventDays.id, dayId))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/events/:eventId/days/:dayId");
+	}
 });
 
 // 開催日削除
 eventDaysRouter.delete("/:eventId/days/:dayId", async (c) => {
-	const eventId = c.req.param("eventId");
-	const dayId = c.req.param("dayId");
+	try {
+		const eventId = c.req.param("eventId");
+		const dayId = c.req.param("dayId");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(eventDays)
-		.where(and(eq(eventDays.id, dayId), eq(eventDays.eventId, eventId)))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(eventDays)
+			.where(and(eq(eventDays.id, dayId), eq(eventDays.eventId, eventId)))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(eventDays).where(eq(eventDays.id, dayId));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/events/:eventId/days/:dayId");
 	}
-
-	// 削除
-	await db.delete(eventDays).where(eq(eventDays.id, dayId));
-
-	return c.json({ success: true });
 });
 
 export { eventDaysRouter };

--- a/apps/server/src/routes/admin/events/event-series.ts
+++ b/apps/server/src/routes/admin/events/event-series.ts
@@ -14,238 +14,263 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const eventSeriesRouter = new Hono<AdminContext>();
 
 // イベントシリーズ一覧取得（検索対応）
 eventSeriesRouter.get("/", async (c) => {
-	const search = c.req.query("search");
-	const sortBy = c.req.query("sortBy") || "sortOrder";
-	const sortOrderParam = c.req.query("sortOrder") || "asc";
+	try {
+		const search = c.req.query("search");
+		const sortBy = c.req.query("sortBy") || "sortOrder";
+		const sortOrderParam = c.req.query("sortOrder") || "asc";
 
-	// 条件を構築
-	const whereCondition = search
-		? like(eventSeries.name, `%${search}%`)
-		: undefined;
+		// 条件を構築
+		const whereCondition = search
+			? like(eventSeries.name, `%${search}%`)
+			: undefined;
 
-	// ソート列のマッピング
-	const sortColumnMap: Record<
-		string,
-		typeof eventSeries.sortOrder | typeof eventSeries.name
-	> = {
-		sortOrder: eventSeries.sortOrder,
-		name: eventSeries.name,
-	};
-	const sortColumn = sortColumnMap[sortBy] || eventSeries.sortOrder;
-	const orderFn = sortOrderParam === "desc" ? desc : asc;
+		// ソート列のマッピング
+		const sortColumnMap: Record<
+			string,
+			typeof eventSeries.sortOrder | typeof eventSeries.name
+		> = {
+			sortOrder: eventSeries.sortOrder,
+			name: eventSeries.name,
+		};
+		const sortColumn = sortColumnMap[sortBy] || eventSeries.sortOrder;
+		const orderFn = sortOrderParam === "desc" ? desc : asc;
 
-	// データ取得
-	const [data, totalResult] = await Promise.all([
-		db
-			.select()
-			.from(eventSeries)
-			.where(whereCondition)
-			.orderBy(orderFn(sortColumn), asc(eventSeries.name)),
-		db.select({ count: count() }).from(eventSeries).where(whereCondition),
-	]);
+		// データ取得
+		const [data, totalResult] = await Promise.all([
+			db
+				.select()
+				.from(eventSeries)
+				.where(whereCondition)
+				.orderBy(orderFn(sortColumn), asc(eventSeries.name)),
+			db.select({ count: count() }).from(eventSeries).where(whereCondition),
+		]);
 
-	const total = totalResult[0]?.count ?? 0;
+		const total = totalResult[0]?.count ?? 0;
 
-	return c.json({
-		data,
-		total,
-	});
+		return c.json({
+			data,
+			total,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/event-series");
+	}
 });
 
 // イベントシリーズ新規作成
 eventSeriesRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertEventSeriesSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(eventSeries)
-		.where(eq(eventSeries.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// 名前重複チェック（大文字小文字無視）
-	const existingName = await db
-		.select()
-		.from(eventSeries)
-		.where(sql`lower(${eventSeries.name}) = lower(${parsed.data.name})`)
-		.limit(1);
-
-	if (existingName.length > 0) {
-		return c.json({ error: "Name already exists" }, 409);
-	}
-
-	// sortOrderが明示的に指定されていない場合は自動設定（最大値 + 1）
-	let sortOrder: number;
-	if (body.sortOrder === undefined || body.sortOrder === null) {
-		const maxResult = await db
-			.select({ maxOrder: max(eventSeries.sortOrder) })
-			.from(eventSeries);
-		sortOrder = (maxResult[0]?.maxOrder ?? -1) + 1;
-	} else {
-		sortOrder = parsed.data.sortOrder ?? 0;
-	}
-
-	// 作成
-	const result = await db
-		.insert(eventSeries)
-		.values({ ...parsed.data, sortOrder })
-		.returning();
-
-	return c.json(result[0], 201);
-});
-
-// ソート順序の一括更新（/:id より先に定義する必要がある）
-eventSeriesRouter.put("/reorder", async (c) => {
-	const body = await c.req.json();
-
-	// バリデーション: { items: [{ id: string, sortOrder: number }] }
-	if (!body.items || !Array.isArray(body.items)) {
-		return c.json({ error: "items array is required" }, 400);
-	}
-
-	// 各アイテムのソート順序を更新
-	for (const item of body.items) {
-		if (!item.id || typeof item.sortOrder !== "number") {
-			return c.json({ error: "Each item must have id and sortOrder" }, 400);
+		// バリデーション
+		const parsed = insertEventSeriesSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
 		}
-		await db
-			.update(eventSeries)
-			.set({ sortOrder: item.sortOrder })
-			.where(eq(eventSeries.id, item.id));
-	}
 
-	return c.json({ success: true });
-});
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(eventSeries)
+			.where(eq(eventSeries.id, parsed.data.id))
+			.limit(1);
 
-// イベントシリーズ詳細取得（所属イベント一覧を含む）
-eventSeriesRouter.get("/:id", async (c) => {
-	const id = c.req.param("id");
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
 
-	// イベントシリーズ取得
-	const series = await db
-		.select()
-		.from(eventSeries)
-		.where(eq(eventSeries.id, id))
-		.limit(1);
-
-	if (series.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// 所属イベント一覧取得（回次順）
-	const seriesEvents = await db
-		.select()
-		.from(events)
-		.where(eq(events.eventSeriesId, id))
-		.orderBy(asc(events.edition));
-
-	return c.json({
-		...series[0],
-		events: seriesEvents,
-	});
-});
-
-// イベントシリーズ更新
-eventSeriesRouter.put("/:id", async (c) => {
-	const id = c.req.param("id");
-	const body = await c.req.json();
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(eventSeries)
-		.where(eq(eventSeries.id, id))
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateEventSeriesSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 名前重複チェック（自身以外に同じ名前がある場合）
-	if (parsed.data.name) {
+		// 名前重複チェック（大文字小文字無視）
 		const existingName = await db
 			.select()
 			.from(eventSeries)
 			.where(sql`lower(${eventSeries.name}) = lower(${parsed.data.name})`)
 			.limit(1);
 
-		if (existingName.length > 0 && existingName[0]?.id !== id) {
+		if (existingName.length > 0) {
 			return c.json({ error: "Name already exists" }, 409);
 		}
+
+		// sortOrderが明示的に指定されていない場合は自動設定（最大値 + 1）
+		let sortOrder: number;
+		if (body.sortOrder === undefined || body.sortOrder === null) {
+			const maxResult = await db
+				.select({ maxOrder: max(eventSeries.sortOrder) })
+				.from(eventSeries);
+			sortOrder = (maxResult[0]?.maxOrder ?? -1) + 1;
+		} else {
+			sortOrder = parsed.data.sortOrder ?? 0;
+		}
+
+		// 作成
+		const result = await db
+			.insert(eventSeries)
+			.values({ ...parsed.data, sortOrder })
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/event-series");
 	}
+});
 
-	// 更新
-	const result = await db
-		.update(eventSeries)
-		.set(parsed.data)
-		.where(eq(eventSeries.id, id))
-		.returning();
+// ソート順序の一括更新（/:id より先に定義する必要がある）
+eventSeriesRouter.put("/reorder", async (c) => {
+	try {
+		const body = await c.req.json();
 
-	return c.json(result[0]);
+		// バリデーション: { items: [{ id: string, sortOrder: number }] }
+		if (!body.items || !Array.isArray(body.items)) {
+			return c.json({ error: "items array is required" }, 400);
+		}
+
+		// 各アイテムのソート順序を更新
+		for (const item of body.items) {
+			if (!item.id || typeof item.sortOrder !== "number") {
+				return c.json({ error: "Each item must have id and sortOrder" }, 400);
+			}
+			await db
+				.update(eventSeries)
+				.set({ sortOrder: item.sortOrder })
+				.where(eq(eventSeries.id, item.id));
+		}
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/event-series/reorder");
+	}
+});
+
+// イベントシリーズ詳細取得（所属イベント一覧を含む）
+eventSeriesRouter.get("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+
+		// イベントシリーズ取得
+		const series = await db
+			.select()
+			.from(eventSeries)
+			.where(eq(eventSeries.id, id))
+			.limit(1);
+
+		if (series.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 所属イベント一覧取得（回次順）
+		const seriesEvents = await db
+			.select()
+			.from(events)
+			.where(eq(events.eventSeriesId, id))
+			.orderBy(asc(events.edition));
+
+		return c.json({
+			...series[0],
+			events: seriesEvents,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/event-series/:id");
+	}
+});
+
+// イベントシリーズ更新
+eventSeriesRouter.put("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+		const body = await c.req.json();
+
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(eventSeries)
+			.where(eq(eventSeries.id, id))
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateEventSeriesSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 名前重複チェック（自身以外に同じ名前がある場合）
+		if (parsed.data.name) {
+			const existingName = await db
+				.select()
+				.from(eventSeries)
+				.where(sql`lower(${eventSeries.name}) = lower(${parsed.data.name})`)
+				.limit(1);
+
+			if (existingName.length > 0 && existingName[0]?.id !== id) {
+				return c.json({ error: "Name already exists" }, 409);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(eventSeries)
+			.set(parsed.data)
+			.where(eq(eventSeries.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/event-series/:id");
+	}
 });
 
 // イベントシリーズ削除
 eventSeriesRouter.delete("/:id", async (c) => {
-	const id = c.req.param("id");
+	try {
+		const id = c.req.param("id");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(eventSeries)
-		.where(eq(eventSeries.id, id))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(eventSeries)
+			.where(eq(eventSeries.id, id))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// イベント紐付きチェック（RESTRICT制約）
+		const linkedEvents = await db
+			.select({ count: count() })
+			.from(events)
+			.where(eq(events.eventSeriesId, id));
+
+		if ((linkedEvents[0]?.count ?? 0) > 0) {
+			return c.json({ error: "Cannot delete series with linked events" }, 409);
+		}
+
+		// 削除
+		await db.delete(eventSeries).where(eq(eventSeries.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/event-series/:id");
 	}
-
-	// イベント紐付きチェック（RESTRICT制約）
-	const linkedEvents = await db
-		.select({ count: count() })
-		.from(events)
-		.where(eq(events.eventSeriesId, id));
-
-	if ((linkedEvents[0]?.count ?? 0) > 0) {
-		return c.json({ error: "Cannot delete series with linked events" }, 409);
-	}
-
-	// 削除
-	await db.delete(eventSeries).where(eq(eventSeries.id, id));
-
-	return c.json({ success: true });
 });
 
 export { eventSeriesRouter };

--- a/apps/server/src/routes/admin/events/events.ts
+++ b/apps/server/src/routes/admin/events/events.ts
@@ -13,37 +13,81 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const eventsRouter = new Hono<AdminContext>();
 
 // イベント一覧取得（ページネーション、シリーズフィルタ、検索対応）
 eventsRouter.get("/", async (c) => {
-	const page = Number(c.req.query("page")) || 1;
-	const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
-	const seriesId = c.req.query("seriesId");
-	const search = c.req.query("search");
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const seriesId = c.req.query("seriesId");
+		const search = c.req.query("search");
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 条件を構築
-	const conditions = [];
+		// 条件を構築
+		const conditions = [];
 
-	if (seriesId) {
-		conditions.push(eq(events.eventSeriesId, seriesId));
+		if (seriesId) {
+			conditions.push(eq(events.eventSeriesId, seriesId));
+		}
+
+		if (search) {
+			const searchPattern = `%${search}%`;
+			conditions.push(
+				or(like(events.name, searchPattern), like(events.venue, searchPattern)),
+			);
+		}
+
+		const whereCondition =
+			conditions.length > 0 ? and(...conditions) : undefined;
+
+		// データ取得（シリーズ名を含む）
+		const [data, totalResult] = await Promise.all([
+			db
+				.select({
+					id: events.id,
+					eventSeriesId: events.eventSeriesId,
+					name: events.name,
+					edition: events.edition,
+					totalDays: events.totalDays,
+					venue: events.venue,
+					startDate: events.startDate,
+					endDate: events.endDate,
+					createdAt: events.createdAt,
+					updatedAt: events.updatedAt,
+					seriesName: eventSeries.name,
+				})
+				.from(events)
+				.leftJoin(eventSeries, eq(events.eventSeriesId, eventSeries.id))
+				.where(whereCondition)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(events.startDate, events.name),
+			db.select({ count: count() }).from(events).where(whereCondition),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/events");
 	}
+});
 
-	if (search) {
-		const searchPattern = `%${search}%`;
-		conditions.push(
-			or(like(events.name, searchPattern), like(events.venue, searchPattern)),
-		);
-	}
+// イベント個別取得（開催日情報を含む）
+eventsRouter.get("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
 
-	const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
-
-	// データ取得（シリーズ名を含む）
-	const [data, totalResult] = await Promise.all([
-		db
+		const result = await db
 			.select({
 				id: events.id,
 				eventSeriesId: events.eventSeriesId,
@@ -59,223 +103,208 @@ eventsRouter.get("/", async (c) => {
 			})
 			.from(events)
 			.leftJoin(eventSeries, eq(events.eventSeriesId, eventSeries.id))
-			.where(whereCondition)
-			.limit(limit)
-			.offset(offset)
-			.orderBy(events.startDate, events.name),
-		db.select({ count: count() }).from(events).where(whereCondition),
-	]);
+			.where(eq(events.id, id))
+			.limit(1);
 
-	const total = totalResult[0]?.count ?? 0;
+		if (result.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
 
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
-});
+		// 関連開催日を取得（日番号順）
+		const days = await db
+			.select()
+			.from(eventDays)
+			.where(eq(eventDays.eventId, id))
+			.orderBy(eventDays.dayNumber);
 
-// イベント個別取得（開催日情報を含む）
-eventsRouter.get("/:id", async (c) => {
-	const id = c.req.param("id");
-
-	const result = await db
-		.select({
-			id: events.id,
-			eventSeriesId: events.eventSeriesId,
-			name: events.name,
-			edition: events.edition,
-			totalDays: events.totalDays,
-			venue: events.venue,
-			startDate: events.startDate,
-			endDate: events.endDate,
-			createdAt: events.createdAt,
-			updatedAt: events.updatedAt,
-			seriesName: eventSeries.name,
-		})
-		.from(events)
-		.leftJoin(eventSeries, eq(events.eventSeriesId, eventSeries.id))
-		.where(eq(events.id, id))
-		.limit(1);
-
-	if (result.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		return c.json({
+			...result[0],
+			days,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/events/:id");
 	}
-
-	// 関連開催日を取得（日番号順）
-	const days = await db
-		.select()
-		.from(eventDays)
-		.where(eq(eventDays.eventId, id))
-		.orderBy(eventDays.dayNumber);
-
-	return c.json({
-		...result[0],
-		days,
-	});
 });
 
 // イベント新規作成
 eventsRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertEventSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(events)
-		.where(eq(events.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// シリーズ存在チェック（eventSeriesIdが指定されている場合のみ）
-	if (parsed.data.eventSeriesId) {
-		const existingSeries = await db
-			.select()
-			.from(eventSeries)
-			.where(eq(eventSeries.id, parsed.data.eventSeriesId))
-			.limit(1);
-
-		if (existingSeries.length === 0) {
-			return c.json({ error: "Event series not found" }, 404);
+		// バリデーション
+		const parsed = insertEventSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
 		}
 
-		// 回次重複チェック（同一シリーズ内）
-		if (parsed.data.edition !== null && parsed.data.edition !== undefined) {
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(events)
+			.where(eq(events.id, parsed.data.id))
+			.limit(1);
+
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
+
+		// シリーズ存在チェック（eventSeriesIdが指定されている場合のみ）
+		if (parsed.data.eventSeriesId) {
+			const existingSeries = await db
+				.select()
+				.from(eventSeries)
+				.where(eq(eventSeries.id, parsed.data.eventSeriesId))
+				.limit(1);
+
+			if (existingSeries.length === 0) {
+				return c.json({ error: "Event series not found" }, 404);
+			}
+
+			// 回次重複チェック（同一シリーズ内）
+			if (parsed.data.edition !== null && parsed.data.edition !== undefined) {
+				const existingEdition = await db
+					.select()
+					.from(events)
+					.where(
+						and(
+							eq(events.eventSeriesId, parsed.data.eventSeriesId),
+							eq(events.edition, parsed.data.edition),
+						),
+					)
+					.limit(1);
+
+				if (existingEdition.length > 0) {
+					return c.json(
+						{ error: "Edition already exists in this series" },
+						409,
+					);
+				}
+			}
+		}
+
+		// 作成
+		const result = await db.insert(events).values(parsed.data).returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/events");
+	}
+});
+
+// イベント更新
+eventsRouter.put("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+		const body = await c.req.json();
+
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(events)
+			.where(eq(events.id, id))
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// biome-ignore lint/style/noNonNullAssertion: existing.length > 0 is guaranteed by the check above
+		const existingEvent = existing[0]!;
+
+		// バリデーション
+		const parsed = updateEventSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// シリーズ存在チェック（変更がある場合）
+		if (parsed.data.eventSeriesId) {
+			const existingSeries = await db
+				.select()
+				.from(eventSeries)
+				.where(eq(eventSeries.id, parsed.data.eventSeriesId))
+				.limit(1);
+
+			if (existingSeries.length === 0) {
+				return c.json({ error: "Event series not found" }, 404);
+			}
+		}
+
+		// 回次重複チェック（同一シリーズ内、自身以外）
+		const targetEdition = parsed.data.edition ?? existingEvent.edition;
+		const targetSeriesId =
+			parsed.data.eventSeriesId ?? existingEvent.eventSeriesId;
+
+		// シリーズが指定されていて、回次がある場合のみ重複チェック
+		if (
+			targetSeriesId &&
+			targetEdition !== null &&
+			targetEdition !== undefined
+		) {
 			const existingEdition = await db
 				.select()
 				.from(events)
 				.where(
 					and(
-						eq(events.eventSeriesId, parsed.data.eventSeriesId),
-						eq(events.edition, parsed.data.edition),
+						eq(events.eventSeriesId, targetSeriesId),
+						eq(events.edition, targetEdition),
 					),
 				)
 				.limit(1);
 
-			if (existingEdition.length > 0) {
+			if (existingEdition.length > 0 && existingEdition[0]?.id !== id) {
 				return c.json({ error: "Edition already exists in this series" }, 409);
 			}
 		}
+
+		// 更新
+		const result = await db
+			.update(events)
+			.set(parsed.data)
+			.where(eq(events.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/events/:id");
 	}
-
-	// 作成
-	const result = await db.insert(events).values(parsed.data).returning();
-
-	return c.json(result[0], 201);
-});
-
-// イベント更新
-eventsRouter.put("/:id", async (c) => {
-	const id = c.req.param("id");
-	const body = await c.req.json();
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(events)
-		.where(eq(events.id, id))
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// biome-ignore lint/style/noNonNullAssertion: existing.length > 0 is guaranteed by the check above
-	const existingEvent = existing[0]!;
-
-	// バリデーション
-	const parsed = updateEventSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// シリーズ存在チェック（変更がある場合）
-	if (parsed.data.eventSeriesId) {
-		const existingSeries = await db
-			.select()
-			.from(eventSeries)
-			.where(eq(eventSeries.id, parsed.data.eventSeriesId))
-			.limit(1);
-
-		if (existingSeries.length === 0) {
-			return c.json({ error: "Event series not found" }, 404);
-		}
-	}
-
-	// 回次重複チェック（同一シリーズ内、自身以外）
-	const targetEdition = parsed.data.edition ?? existingEvent.edition;
-	const targetSeriesId =
-		parsed.data.eventSeriesId ?? existingEvent.eventSeriesId;
-
-	// シリーズが指定されていて、回次がある場合のみ重複チェック
-	if (targetSeriesId && targetEdition !== null && targetEdition !== undefined) {
-		const existingEdition = await db
-			.select()
-			.from(events)
-			.where(
-				and(
-					eq(events.eventSeriesId, targetSeriesId),
-					eq(events.edition, targetEdition),
-				),
-			)
-			.limit(1);
-
-		if (existingEdition.length > 0 && existingEdition[0]?.id !== id) {
-			return c.json({ error: "Edition already exists in this series" }, 409);
-		}
-	}
-
-	// 更新
-	const result = await db
-		.update(events)
-		.set(parsed.data)
-		.where(eq(events.id, id))
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // イベント削除（開催日はCASCADE削除）
 eventsRouter.delete("/:id", async (c) => {
-	const id = c.req.param("id");
+	try {
+		const id = c.req.param("id");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(events)
-		.where(eq(events.id, id))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(events)
+			.where(eq(events.id, id))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除（開催日はCASCADE削除）
+		await db.delete(events).where(eq(events.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/events/:id");
 	}
-
-	// 削除（開催日はCASCADE削除）
-	await db.delete(events).where(eq(events.id, id));
-
-	return c.json({ success: true });
 });
 
 export { eventsRouter };

--- a/apps/server/src/routes/admin/master/alias-types.ts
+++ b/apps/server/src/routes/admin/master/alias-types.ts
@@ -13,199 +13,224 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const aliasTypesRouter = new Hono<AdminContext>();
 
 // 一覧取得（ページネーション、検索、ソート対応）
 aliasTypesRouter.get("/", async (c) => {
-	const page = Number(c.req.query("page")) || 1;
-	const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
-	const search = c.req.query("search");
-	const sortBy = c.req.query("sortBy") || "sortOrder";
-	const sortOrder = c.req.query("sortOrder") || "asc";
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const search = c.req.query("search");
+		const sortBy = c.req.query("sortBy") || "sortOrder";
+		const sortOrder = c.req.query("sortOrder") || "asc";
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 条件を構築
-	const whereCondition = search
-		? or(
-				like(aliasTypes.code, `%${search}%`),
-				like(aliasTypes.label, `%${search}%`),
-			)
-		: undefined;
+		// 条件を構築
+		const whereCondition = search
+			? or(
+					like(aliasTypes.code, `%${search}%`),
+					like(aliasTypes.label, `%${search}%`),
+				)
+			: undefined;
 
-	// ソート条件を構築
-	const sortColumn =
-		sortBy === "sortOrder"
-			? aliasTypes.sortOrder
-			: sortBy === "label"
-				? aliasTypes.label
-				: aliasTypes.code;
-	const orderByClause =
-		sortOrder === "desc" ? desc(sortColumn) : asc(sortColumn);
+		// ソート条件を構築
+		const sortColumn =
+			sortBy === "sortOrder"
+				? aliasTypes.sortOrder
+				: sortBy === "label"
+					? aliasTypes.label
+					: aliasTypes.code;
+		const orderByClause =
+			sortOrder === "desc" ? desc(sortColumn) : asc(sortColumn);
 
-	// データ取得
-	const [data, totalResult] = await Promise.all([
-		db
-			.select()
-			.from(aliasTypes)
-			.where(whereCondition)
-			.limit(limit)
-			.offset(offset)
-			.orderBy(orderByClause),
-		db.select({ count: count() }).from(aliasTypes).where(whereCondition),
-	]);
+		// データ取得
+		const [data, totalResult] = await Promise.all([
+			db
+				.select()
+				.from(aliasTypes)
+				.where(whereCondition)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(orderByClause),
+			db.select({ count: count() }).from(aliasTypes).where(whereCondition),
+		]);
 
-	const total = totalResult[0]?.count ?? 0;
+		const total = totalResult[0]?.count ?? 0;
 
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/master/alias-types");
+	}
 });
 
 // 並べ替え（一括更新）
 aliasTypesRouter.put("/reorder", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	if (!body.items || !Array.isArray(body.items)) {
-		return c.json({ error: "items array is required" }, 400);
-	}
-
-	for (const item of body.items) {
-		if (!item.code || typeof item.sortOrder !== "number") {
-			return c.json({ error: "Each item must have code and sortOrder" }, 400);
+		if (!body.items || !Array.isArray(body.items)) {
+			return c.json({ error: "items array is required" }, 400);
 		}
-		await db
-			.update(aliasTypes)
-			.set({ sortOrder: item.sortOrder })
-			.where(eq(aliasTypes.code, item.code));
-	}
 
-	return c.json({ success: true });
+		for (const item of body.items) {
+			if (!item.code || typeof item.sortOrder !== "number") {
+				return c.json({ error: "Each item must have code and sortOrder" }, 400);
+			}
+			await db
+				.update(aliasTypes)
+				.set({ sortOrder: item.sortOrder })
+				.where(eq(aliasTypes.code, item.code));
+		}
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/master/alias-types/reorder");
+	}
 });
 
 // 個別取得
 aliasTypesRouter.get("/:code", async (c) => {
-	const code = c.req.param("code");
+	try {
+		const code = c.req.param("code");
 
-	const result = await db
-		.select()
-		.from(aliasTypes)
-		.where(eq(aliasTypes.code, code))
-		.limit(1);
+		const result = await db
+			.select()
+			.from(aliasTypes)
+			.where(eq(aliasTypes.code, code))
+			.limit(1);
 
-	if (result.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (result.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/master/alias-types/:code");
 	}
-
-	return c.json(result[0]);
 });
 
 // 新規作成
 aliasTypesRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertAliasTypeSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
+		// バリデーション
+		const parsed = insertAliasTypeSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 重複チェック
+		const existing = await db
+			.select()
+			.from(aliasTypes)
+			.where(eq(aliasTypes.code, parsed.data.code))
+			.limit(1);
+
+		if (existing.length > 0) {
+			return c.json({ error: "Code already exists" }, 409);
+		}
+
+		// sortOrder が未指定の場合は最大値 + 1 を設定
+		let sortOrder = parsed.data.sortOrder;
+		if (sortOrder === undefined || sortOrder === null) {
+			const maxResult = await db
+				.select({ maxOrder: max(aliasTypes.sortOrder) })
+				.from(aliasTypes);
+			sortOrder = (maxResult[0]?.maxOrder ?? -1) + 1;
+		}
+
+		// 作成
+		const result = await db
+			.insert(aliasTypes)
+			.values({ ...parsed.data, sortOrder })
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/master/alias-types");
 	}
-
-	// 重複チェック
-	const existing = await db
-		.select()
-		.from(aliasTypes)
-		.where(eq(aliasTypes.code, parsed.data.code))
-		.limit(1);
-
-	if (existing.length > 0) {
-		return c.json({ error: "Code already exists" }, 409);
-	}
-
-	// sortOrder が未指定の場合は最大値 + 1 を設定
-	let sortOrder = parsed.data.sortOrder;
-	if (sortOrder === undefined || sortOrder === null) {
-		const maxResult = await db
-			.select({ maxOrder: max(aliasTypes.sortOrder) })
-			.from(aliasTypes);
-		sortOrder = (maxResult[0]?.maxOrder ?? -1) + 1;
-	}
-
-	// 作成
-	const result = await db
-		.insert(aliasTypes)
-		.values({ ...parsed.data, sortOrder })
-		.returning();
-
-	return c.json(result[0], 201);
 });
 
 // 更新
 aliasTypesRouter.put("/:code", async (c) => {
-	const code = c.req.param("code");
-	const body = await c.req.json();
+	try {
+		const code = c.req.param("code");
+		const body = await c.req.json();
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(aliasTypes)
-		.where(eq(aliasTypes.code, code))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(aliasTypes)
+			.where(eq(aliasTypes.code, code))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateAliasTypeSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 更新
+		const result = await db
+			.update(aliasTypes)
+			.set(parsed.data)
+			.where(eq(aliasTypes.code, code))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/master/alias-types/:code");
 	}
-
-	// バリデーション
-	const parsed = updateAliasTypeSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 更新
-	const result = await db
-		.update(aliasTypes)
-		.set(parsed.data)
-		.where(eq(aliasTypes.code, code))
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // 削除
 aliasTypesRouter.delete("/:code", async (c) => {
-	const code = c.req.param("code");
+	try {
+		const code = c.req.param("code");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(aliasTypes)
-		.where(eq(aliasTypes.code, code))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(aliasTypes)
+			.where(eq(aliasTypes.code, code))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(aliasTypes).where(eq(aliasTypes.code, code));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/master/alias-types/:code");
 	}
-
-	// 削除
-	await db.delete(aliasTypes).where(eq(aliasTypes.code, code));
-
-	return c.json({ success: true });
 });
 
 export { aliasTypesRouter };

--- a/apps/server/src/routes/admin/master/credit-roles.ts
+++ b/apps/server/src/routes/admin/master/credit-roles.ts
@@ -13,178 +13,199 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const creditRolesRouter = new Hono<AdminContext>();
 
 // 一覧取得（ページネーション、検索、ソート対応）
 creditRolesRouter.get("/", async (c) => {
-	const page = Number(c.req.query("page")) || 1;
-	const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
-	const search = c.req.query("search");
-	const sortBy = c.req.query("sortBy") || "sortOrder";
-	const sortOrder = c.req.query("sortOrder") || "asc";
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const search = c.req.query("search");
+		const sortBy = c.req.query("sortBy") || "sortOrder";
+		const sortOrder = c.req.query("sortOrder") || "asc";
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 条件を構築
-	const whereCondition = search
-		? or(
-				like(creditRoles.code, `%${search}%`),
-				like(creditRoles.label, `%${search}%`),
-			)
-		: undefined;
+		// 条件を構築
+		const whereCondition = search
+			? or(
+					like(creditRoles.code, `%${search}%`),
+					like(creditRoles.label, `%${search}%`),
+				)
+			: undefined;
 
-	// ソート条件を構築
-	const sortColumn =
-		sortBy === "sortOrder"
-			? creditRoles.sortOrder
-			: sortBy === "label"
-				? creditRoles.label
-				: creditRoles.code;
-	const orderByClause =
-		sortOrder === "desc" ? desc(sortColumn) : asc(sortColumn);
+		// ソート条件を構築
+		const sortColumn =
+			sortBy === "sortOrder"
+				? creditRoles.sortOrder
+				: sortBy === "label"
+					? creditRoles.label
+					: creditRoles.code;
+		const orderByClause =
+			sortOrder === "desc" ? desc(sortColumn) : asc(sortColumn);
 
-	// データ取得
-	const [data, totalResult] = await Promise.all([
-		db
-			.select()
-			.from(creditRoles)
-			.where(whereCondition)
-			.limit(limit)
-			.offset(offset)
-			.orderBy(orderByClause),
-		db.select({ count: count() }).from(creditRoles).where(whereCondition),
-	]);
+		// データ取得
+		const [data, totalResult] = await Promise.all([
+			db
+				.select()
+				.from(creditRoles)
+				.where(whereCondition)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(orderByClause),
+			db.select({ count: count() }).from(creditRoles).where(whereCondition),
+		]);
 
-	const total = totalResult[0]?.count ?? 0;
+		const total = totalResult[0]?.count ?? 0;
 
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/master/credit-roles");
+	}
 });
 
 // 並べ替え（一括更新）
 creditRolesRouter.put("/reorder", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	if (!body.items || !Array.isArray(body.items)) {
-		return c.json({ error: "items array is required" }, 400);
-	}
-
-	for (const item of body.items) {
-		if (!item.code || typeof item.sortOrder !== "number") {
-			return c.json({ error: "Each item must have code and sortOrder" }, 400);
+		if (!body.items || !Array.isArray(body.items)) {
+			return c.json({ error: "items array is required" }, 400);
 		}
-		await db
-			.update(creditRoles)
-			.set({ sortOrder: item.sortOrder })
-			.where(eq(creditRoles.code, item.code));
-	}
 
-	return c.json({ success: true });
+		for (const item of body.items) {
+			if (!item.code || typeof item.sortOrder !== "number") {
+				return c.json({ error: "Each item must have code and sortOrder" }, 400);
+			}
+			await db
+				.update(creditRoles)
+				.set({ sortOrder: item.sortOrder })
+				.where(eq(creditRoles.code, item.code));
+		}
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/master/credit-roles/reorder");
+	}
 });
 
 // 個別取得
 creditRolesRouter.get("/:code", async (c) => {
-	const code = c.req.param("code");
+	try {
+		const code = c.req.param("code");
 
-	const result = await db
-		.select()
-		.from(creditRoles)
-		.where(eq(creditRoles.code, code))
-		.limit(1);
+		const result = await db
+			.select()
+			.from(creditRoles)
+			.where(eq(creditRoles.code, code))
+			.limit(1);
 
-	if (result.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (result.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/master/credit-roles/:code");
 	}
-
-	return c.json(result[0]);
 });
 
 // 新規作成
 creditRolesRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertCreditRoleSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
+		// バリデーション
+		const parsed = insertCreditRoleSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 重複チェック
+		const existing = await db
+			.select()
+			.from(creditRoles)
+			.where(eq(creditRoles.code, parsed.data.code))
+			.limit(1);
+
+		if (existing.length > 0) {
+			return c.json({ error: "Code already exists" }, 409);
+		}
+
+		// sortOrder が未指定の場合は最大値 + 1 を設定
+		let sortOrder = parsed.data.sortOrder;
+		if (sortOrder === undefined || sortOrder === null) {
+			const maxResult = await db
+				.select({ maxOrder: max(creditRoles.sortOrder) })
+				.from(creditRoles);
+			sortOrder = (maxResult[0]?.maxOrder ?? -1) + 1;
+		}
+
+		// 作成
+		const result = await db
+			.insert(creditRoles)
+			.values({ ...parsed.data, sortOrder })
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/master/credit-roles");
 	}
-
-	// 重複チェック
-	const existing = await db
-		.select()
-		.from(creditRoles)
-		.where(eq(creditRoles.code, parsed.data.code))
-		.limit(1);
-
-	if (existing.length > 0) {
-		return c.json({ error: "Code already exists" }, 409);
-	}
-
-	// sortOrder が未指定の場合は最大値 + 1 を設定
-	let sortOrder = parsed.data.sortOrder;
-	if (sortOrder === undefined || sortOrder === null) {
-		const maxResult = await db
-			.select({ maxOrder: max(creditRoles.sortOrder) })
-			.from(creditRoles);
-		sortOrder = (maxResult[0]?.maxOrder ?? -1) + 1;
-	}
-
-	// 作成
-	const result = await db
-		.insert(creditRoles)
-		.values({ ...parsed.data, sortOrder })
-		.returning();
-
-	return c.json(result[0], 201);
 });
 
 // 更新
 creditRolesRouter.put("/:code", async (c) => {
-	const code = c.req.param("code");
-	const body = await c.req.json();
+	try {
+		const code = c.req.param("code");
+		const body = await c.req.json();
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(creditRoles)
-		.where(eq(creditRoles.code, code))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(creditRoles)
+			.where(eq(creditRoles.code, code))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateCreditRoleSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 更新
+		const result = await db
+			.update(creditRoles)
+			.set(parsed.data)
+			.where(eq(creditRoles.code, code))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/master/credit-roles/:code");
 	}
-
-	// バリデーション
-	const parsed = updateCreditRoleSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 更新
-	const result = await db
-		.update(creditRoles)
-		.set(parsed.data)
-		.where(eq(creditRoles.code, code))
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // 削除

--- a/apps/server/src/routes/admin/master/import.ts
+++ b/apps/server/src/routes/admin/master/import.ts
@@ -11,230 +11,251 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 import { parseAndValidate } from "../../../utils/import-parser";
 
 const importRouter = new Hono<AdminContext>();
 
 // プラットフォームのインポート
 importRouter.post("/platforms/import", async (c) => {
-	const body = await c.req.parseBody();
-	const file = body.file;
+	try {
+		const body = await c.req.parseBody();
+		const file = body.file;
 
-	if (!(file instanceof File)) {
-		return c.json({ error: "ファイルが指定されていません" }, 400);
-	}
-
-	const content = await file.text();
-	const result = parseAndValidate(content, file.name, insertPlatformSchema);
-
-	if (!result.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				rows: result.errors,
-			},
-			400,
-		);
-	}
-
-	const data = result.data;
-	if (!data) {
-		return c.json({ error: "データの取得に失敗しました" }, 500);
-	}
-
-	let created = 0;
-	const updated = 0;
-
-	await db.transaction(async (tx) => {
-		for (const item of data) {
-			await tx
-				.insert(platforms)
-				.values(item)
-				.onConflictDoUpdate({
-					target: platforms.code,
-					set: {
-						name: item.name,
-						category: item.category,
-						urlPattern: item.urlPattern,
-					},
-				});
-			// 簡易的にcreatedとして扱う
-			created++;
+		if (!(file instanceof File)) {
+			return c.json({ error: "ファイルが指定されていません" }, 400);
 		}
-	});
 
-	return c.json({
-		success: true,
-		created,
-		updated,
-		total: data.length,
-	});
+		const content = await file.text();
+		const result = parseAndValidate(content, file.name, insertPlatformSchema);
+
+		if (!result.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					rows: result.errors,
+				},
+				400,
+			);
+		}
+
+		const data = result.data;
+		if (!data) {
+			return c.json({ error: "データの取得に失敗しました" }, 500);
+		}
+
+		let created = 0;
+		const updated = 0;
+
+		await db.transaction(async (tx) => {
+			for (const item of data) {
+				await tx
+					.insert(platforms)
+					.values(item)
+					.onConflictDoUpdate({
+						target: platforms.code,
+						set: {
+							name: item.name,
+							category: item.category,
+							urlPattern: item.urlPattern,
+						},
+					});
+				// 簡易的にcreatedとして扱う
+				created++;
+			}
+		});
+
+		return c.json({
+			success: true,
+			created,
+			updated,
+			total: data.length,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/master/platforms/import");
+	}
 });
 
 // 別名義種別のインポート
 importRouter.post("/alias-types/import", async (c) => {
-	const body = await c.req.parseBody();
-	const file = body.file;
+	try {
+		const body = await c.req.parseBody();
+		const file = body.file;
 
-	if (!(file instanceof File)) {
-		return c.json({ error: "ファイルが指定されていません" }, 400);
-	}
-
-	const content = await file.text();
-	const result = parseAndValidate(content, file.name, insertAliasTypeSchema);
-
-	if (!result.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				rows: result.errors,
-			},
-			400,
-		);
-	}
-
-	const data = result.data;
-	if (!data) {
-		return c.json({ error: "データの取得に失敗しました" }, 500);
-	}
-
-	let created = 0;
-	const updated = 0;
-
-	await db.transaction(async (tx) => {
-		for (const item of data) {
-			await tx
-				.insert(aliasTypes)
-				.values(item)
-				.onConflictDoUpdate({
-					target: aliasTypes.code,
-					set: {
-						label: item.label,
-						description: item.description,
-					},
-				});
-			created++;
+		if (!(file instanceof File)) {
+			return c.json({ error: "ファイルが指定されていません" }, 400);
 		}
-	});
 
-	return c.json({
-		success: true,
-		created,
-		updated,
-		total: data.length,
-	});
+		const content = await file.text();
+		const result = parseAndValidate(content, file.name, insertAliasTypeSchema);
+
+		if (!result.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					rows: result.errors,
+				},
+				400,
+			);
+		}
+
+		const data = result.data;
+		if (!data) {
+			return c.json({ error: "データの取得に失敗しました" }, 500);
+		}
+
+		let created = 0;
+		const updated = 0;
+
+		await db.transaction(async (tx) => {
+			for (const item of data) {
+				await tx
+					.insert(aliasTypes)
+					.values(item)
+					.onConflictDoUpdate({
+						target: aliasTypes.code,
+						set: {
+							label: item.label,
+							description: item.description,
+						},
+					});
+				created++;
+			}
+		});
+
+		return c.json({
+			success: true,
+			created,
+			updated,
+			total: data.length,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/master/alias-types/import");
+	}
 });
 
 // クレジット役割のインポート
 importRouter.post("/credit-roles/import", async (c) => {
-	const body = await c.req.parseBody();
-	const file = body.file;
+	try {
+		const body = await c.req.parseBody();
+		const file = body.file;
 
-	if (!(file instanceof File)) {
-		return c.json({ error: "ファイルが指定されていません" }, 400);
-	}
-
-	const content = await file.text();
-	const result = parseAndValidate(content, file.name, insertCreditRoleSchema);
-
-	if (!result.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				rows: result.errors,
-			},
-			400,
-		);
-	}
-
-	const data = result.data;
-	if (!data) {
-		return c.json({ error: "データの取得に失敗しました" }, 500);
-	}
-
-	let created = 0;
-	const updated = 0;
-
-	await db.transaction(async (tx) => {
-		for (const item of data) {
-			await tx
-				.insert(creditRoles)
-				.values(item)
-				.onConflictDoUpdate({
-					target: creditRoles.code,
-					set: {
-						label: item.label,
-						description: item.description,
-					},
-				});
-			created++;
+		if (!(file instanceof File)) {
+			return c.json({ error: "ファイルが指定されていません" }, 400);
 		}
-	});
 
-	return c.json({
-		success: true,
-		created,
-		updated,
-		total: data.length,
-	});
+		const content = await file.text();
+		const result = parseAndValidate(content, file.name, insertCreditRoleSchema);
+
+		if (!result.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					rows: result.errors,
+				},
+				400,
+			);
+		}
+
+		const data = result.data;
+		if (!data) {
+			return c.json({ error: "データの取得に失敗しました" }, 500);
+		}
+
+		let created = 0;
+		const updated = 0;
+
+		await db.transaction(async (tx) => {
+			for (const item of data) {
+				await tx
+					.insert(creditRoles)
+					.values(item)
+					.onConflictDoUpdate({
+						target: creditRoles.code,
+						set: {
+							label: item.label,
+							description: item.description,
+						},
+					});
+				created++;
+			}
+		});
+
+		return c.json({
+			success: true,
+			created,
+			updated,
+			total: data.length,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/master/credit-roles/import");
+	}
 });
 
 // 公式作品カテゴリのインポート
 importRouter.post("/official-work-categories/import", async (c) => {
-	const body = await c.req.parseBody();
-	const file = body.file;
+	try {
+		const body = await c.req.parseBody();
+		const file = body.file;
 
-	if (!(file instanceof File)) {
-		return c.json({ error: "ファイルが指定されていません" }, 400);
-	}
+		if (!(file instanceof File)) {
+			return c.json({ error: "ファイルが指定されていません" }, 400);
+		}
 
-	const content = await file.text();
-	const result = parseAndValidate(
-		content,
-		file.name,
-		insertOfficialWorkCategorySchema,
-	);
+		const content = await file.text();
+		const result = parseAndValidate(
+			content,
+			file.name,
+			insertOfficialWorkCategorySchema,
+		);
 
-	if (!result.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				rows: result.errors,
-			},
-			400,
+		if (!result.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					rows: result.errors,
+				},
+				400,
+			);
+		}
+
+		const data = result.data;
+		if (!data) {
+			return c.json({ error: "データの取得に失敗しました" }, 500);
+		}
+
+		let created = 0;
+		const updated = 0;
+
+		await db.transaction(async (tx) => {
+			for (const item of data) {
+				await tx
+					.insert(officialWorkCategories)
+					.values(item)
+					.onConflictDoUpdate({
+						target: officialWorkCategories.code,
+						set: {
+							name: item.name,
+							description: item.description,
+						},
+					});
+				created++;
+			}
+		});
+
+		return c.json({
+			success: true,
+			created,
+			updated,
+			total: data.length,
+		});
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"POST /admin/master/official-work-categories/import",
 		);
 	}
-
-	const data = result.data;
-	if (!data) {
-		return c.json({ error: "データの取得に失敗しました" }, 500);
-	}
-
-	let created = 0;
-	const updated = 0;
-
-	await db.transaction(async (tx) => {
-		for (const item of data) {
-			await tx
-				.insert(officialWorkCategories)
-				.values(item)
-				.onConflictDoUpdate({
-					target: officialWorkCategories.code,
-					set: {
-						name: item.name,
-						description: item.description,
-					},
-				});
-			created++;
-		}
-	});
-
-	return c.json({
-		success: true,
-		created,
-		updated,
-		total: data.length,
-	});
 });
 
 export { importRouter };

--- a/apps/server/src/routes/admin/master/official-work-categories.ts
+++ b/apps/server/src/routes/admin/master/official-work-categories.ts
@@ -13,204 +13,237 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const officialWorkCategoriesRouter = new Hono<AdminContext>();
 
 // 一覧取得（ページネーション、検索、ソート対応）
 officialWorkCategoriesRouter.get("/", async (c) => {
-	const page = Number(c.req.query("page")) || 1;
-	const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
-	const search = c.req.query("search");
-	const sortBy = c.req.query("sortBy") || "sortOrder";
-	const sortOrder = c.req.query("sortOrder") || "asc";
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const search = c.req.query("search");
+		const sortBy = c.req.query("sortBy") || "sortOrder";
+		const sortOrder = c.req.query("sortOrder") || "asc";
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 条件を構築
-	const whereCondition = search
-		? or(
-				like(officialWorkCategories.code, `%${search}%`),
-				like(officialWorkCategories.name, `%${search}%`),
-			)
-		: undefined;
+		// 条件を構築
+		const whereCondition = search
+			? or(
+					like(officialWorkCategories.code, `%${search}%`),
+					like(officialWorkCategories.name, `%${search}%`),
+				)
+			: undefined;
 
-	// ソート条件を構築
-	const sortColumn =
-		sortBy === "sortOrder"
-			? officialWorkCategories.sortOrder
-			: sortBy === "name"
-				? officialWorkCategories.name
-				: officialWorkCategories.code;
-	const orderByClause =
-		sortOrder === "desc" ? desc(sortColumn) : asc(sortColumn);
+		// ソート条件を構築
+		const sortColumn =
+			sortBy === "sortOrder"
+				? officialWorkCategories.sortOrder
+				: sortBy === "name"
+					? officialWorkCategories.name
+					: officialWorkCategories.code;
+		const orderByClause =
+			sortOrder === "desc" ? desc(sortColumn) : asc(sortColumn);
 
-	// データ取得
-	const [data, totalResult] = await Promise.all([
-		db
-			.select()
-			.from(officialWorkCategories)
-			.where(whereCondition)
-			.limit(limit)
-			.offset(offset)
-			.orderBy(orderByClause),
-		db
-			.select({ count: count() })
-			.from(officialWorkCategories)
-			.where(whereCondition),
-	]);
+		// データ取得
+		const [data, totalResult] = await Promise.all([
+			db
+				.select()
+				.from(officialWorkCategories)
+				.where(whereCondition)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(orderByClause),
+			db
+				.select({ count: count() })
+				.from(officialWorkCategories)
+				.where(whereCondition),
+		]);
 
-	const total = totalResult[0]?.count ?? 0;
+		const total = totalResult[0]?.count ?? 0;
 
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/official-work-categories");
+	}
 });
 
 // 並べ替え（一括更新）
 officialWorkCategoriesRouter.put("/reorder", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	if (!body.items || !Array.isArray(body.items)) {
-		return c.json({ error: "items array is required" }, 400);
-	}
-
-	for (const item of body.items) {
-		if (!item.code || typeof item.sortOrder !== "number") {
-			return c.json({ error: "Each item must have code and sortOrder" }, 400);
+		if (!body.items || !Array.isArray(body.items)) {
+			return c.json({ error: "items array is required" }, 400);
 		}
-		await db
-			.update(officialWorkCategories)
-			.set({ sortOrder: item.sortOrder })
-			.where(eq(officialWorkCategories.code, item.code));
-	}
 
-	return c.json({ success: true });
+		for (const item of body.items) {
+			if (!item.code || typeof item.sortOrder !== "number") {
+				return c.json({ error: "Each item must have code and sortOrder" }, 400);
+			}
+			await db
+				.update(officialWorkCategories)
+				.set({ sortOrder: item.sortOrder })
+				.where(eq(officialWorkCategories.code, item.code));
+		}
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/official-work-categories/reorder",
+		);
+	}
 });
 
 // 個別取得
 officialWorkCategoriesRouter.get("/:code", async (c) => {
-	const code = c.req.param("code");
+	try {
+		const code = c.req.param("code");
 
-	const result = await db
-		.select()
-		.from(officialWorkCategories)
-		.where(eq(officialWorkCategories.code, code))
-		.limit(1);
+		const result = await db
+			.select()
+			.from(officialWorkCategories)
+			.where(eq(officialWorkCategories.code, code))
+			.limit(1);
 
-	if (result.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (result.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/official-work-categories/:code");
 	}
-
-	return c.json(result[0]);
 });
 
 // 新規作成
 officialWorkCategoriesRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertOfficialWorkCategorySchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
+		// バリデーション
+		const parsed = insertOfficialWorkCategorySchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 重複チェック
+		const existing = await db
+			.select()
+			.from(officialWorkCategories)
+			.where(eq(officialWorkCategories.code, parsed.data.code))
+			.limit(1);
+
+		if (existing.length > 0) {
+			return c.json({ error: "Code already exists" }, 409);
+		}
+
+		// sortOrder が未指定の場合は最大値 + 1 を設定
+		let sortOrder = parsed.data.sortOrder;
+		if (sortOrder === undefined || sortOrder === null) {
+			const maxResult = await db
+				.select({ maxOrder: max(officialWorkCategories.sortOrder) })
+				.from(officialWorkCategories);
+			sortOrder = (maxResult[0]?.maxOrder ?? -1) + 1;
+		}
+
+		// 作成
+		const result = await db
+			.insert(officialWorkCategories)
+			.values({ ...parsed.data, sortOrder })
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/official-work-categories");
 	}
-
-	// 重複チェック
-	const existing = await db
-		.select()
-		.from(officialWorkCategories)
-		.where(eq(officialWorkCategories.code, parsed.data.code))
-		.limit(1);
-
-	if (existing.length > 0) {
-		return c.json({ error: "Code already exists" }, 409);
-	}
-
-	// sortOrder が未指定の場合は最大値 + 1 を設定
-	let sortOrder = parsed.data.sortOrder;
-	if (sortOrder === undefined || sortOrder === null) {
-		const maxResult = await db
-			.select({ maxOrder: max(officialWorkCategories.sortOrder) })
-			.from(officialWorkCategories);
-		sortOrder = (maxResult[0]?.maxOrder ?? -1) + 1;
-	}
-
-	// 作成
-	const result = await db
-		.insert(officialWorkCategories)
-		.values({ ...parsed.data, sortOrder })
-		.returning();
-
-	return c.json(result[0], 201);
 });
 
 // 更新
 officialWorkCategoriesRouter.put("/:code", async (c) => {
-	const code = c.req.param("code");
-	const body = await c.req.json();
+	try {
+		const code = c.req.param("code");
+		const body = await c.req.json();
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialWorkCategories)
-		.where(eq(officialWorkCategories.code, code))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialWorkCategories)
+			.where(eq(officialWorkCategories.code, code))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateOfficialWorkCategorySchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 更新
+		const result = await db
+			.update(officialWorkCategories)
+			.set(parsed.data)
+			.where(eq(officialWorkCategories.code, code))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/official-work-categories/:code");
 	}
-
-	// バリデーション
-	const parsed = updateOfficialWorkCategorySchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 更新
-	const result = await db
-		.update(officialWorkCategories)
-		.set(parsed.data)
-		.where(eq(officialWorkCategories.code, code))
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // 削除
 officialWorkCategoriesRouter.delete("/:code", async (c) => {
-	const code = c.req.param("code");
+	try {
+		const code = c.req.param("code");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialWorkCategories)
-		.where(eq(officialWorkCategories.code, code))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialWorkCategories)
+			.where(eq(officialWorkCategories.code, code))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db
+			.delete(officialWorkCategories)
+			.where(eq(officialWorkCategories.code, code));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/official-work-categories/:code",
+		);
 	}
-
-	// 削除
-	await db
-		.delete(officialWorkCategories)
-		.where(eq(officialWorkCategories.code, code));
-
-	return c.json({ success: true });
 });
 
 export { officialWorkCategoriesRouter };

--- a/apps/server/src/routes/admin/master/platforms.ts
+++ b/apps/server/src/routes/admin/master/platforms.ts
@@ -14,213 +14,239 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const platformsRouter = new Hono<AdminContext>();
 
 // 一覧取得（ページネーション、カテゴリフィルタ、検索、ソート対応）
 platformsRouter.get("/", async (c) => {
-	const page = Number(c.req.query("page")) || 1;
-	const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
-	const category = c.req.query("category");
-	const search = c.req.query("search");
-	const sortBy = c.req.query("sortBy") || "code";
-	const sortOrder = c.req.query("sortOrder") || "asc";
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const category = c.req.query("category");
+		const search = c.req.query("search");
+		const sortBy = c.req.query("sortBy") || "code";
+		const sortOrder = c.req.query("sortOrder") || "asc";
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 条件を構築
-	const conditions = [];
+		// 条件を構築
+		const conditions = [];
 
-	if (category) {
-		conditions.push(eq(platforms.category, category));
+		if (category) {
+			conditions.push(eq(platforms.category, category));
+		}
+
+		if (search) {
+			const searchPattern = `%${search}%`;
+			conditions.push(
+				or(
+					like(platforms.code, searchPattern),
+					like(platforms.name, searchPattern),
+				),
+			);
+		}
+
+		const whereCondition =
+			conditions.length > 0 ? and(...conditions) : undefined;
+
+		// ソート条件を構築
+		const sortColumn =
+			sortBy === "sortOrder"
+				? platforms.sortOrder
+				: sortBy === "category"
+					? platforms.category
+					: sortBy === "name"
+						? platforms.name
+						: platforms.code;
+		const orderByClause =
+			sortOrder === "desc" ? desc(sortColumn) : asc(sortColumn);
+
+		// データ取得
+		const [data, totalResult] = await Promise.all([
+			db
+				.select()
+				.from(platforms)
+				.where(whereCondition)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(orderByClause),
+			db.select({ count: count() }).from(platforms).where(whereCondition),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/platforms");
 	}
-
-	if (search) {
-		const searchPattern = `%${search}%`;
-		conditions.push(
-			or(
-				like(platforms.code, searchPattern),
-				like(platforms.name, searchPattern),
-			),
-		);
-	}
-
-	const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
-
-	// ソート条件を構築
-	const sortColumn =
-		sortBy === "sortOrder"
-			? platforms.sortOrder
-			: sortBy === "category"
-				? platforms.category
-				: sortBy === "name"
-					? platforms.name
-					: platforms.code;
-	const orderByClause =
-		sortOrder === "desc" ? desc(sortColumn) : asc(sortColumn);
-
-	// データ取得
-	const [data, totalResult] = await Promise.all([
-		db
-			.select()
-			.from(platforms)
-			.where(whereCondition)
-			.limit(limit)
-			.offset(offset)
-			.orderBy(orderByClause),
-		db.select({ count: count() }).from(platforms).where(whereCondition),
-	]);
-
-	const total = totalResult[0]?.count ?? 0;
-
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
 });
 
 // 並べ替え（一括更新）
 platformsRouter.put("/reorder", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	if (!body.items || !Array.isArray(body.items)) {
-		return c.json({ error: "items array is required" }, 400);
-	}
-
-	for (const item of body.items) {
-		if (!item.code || typeof item.sortOrder !== "number") {
-			return c.json({ error: "Each item must have code and sortOrder" }, 400);
+		if (!body.items || !Array.isArray(body.items)) {
+			return c.json({ error: "items array is required" }, 400);
 		}
-		await db
-			.update(platforms)
-			.set({ sortOrder: item.sortOrder })
-			.where(eq(platforms.code, item.code));
-	}
 
-	return c.json({ success: true });
+		for (const item of body.items) {
+			if (!item.code || typeof item.sortOrder !== "number") {
+				return c.json({ error: "Each item must have code and sortOrder" }, 400);
+			}
+			await db
+				.update(platforms)
+				.set({ sortOrder: item.sortOrder })
+				.where(eq(platforms.code, item.code));
+		}
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/platforms/reorder");
+	}
 });
 
 // 個別取得
 platformsRouter.get("/:code", async (c) => {
-	const code = c.req.param("code");
+	try {
+		const code = c.req.param("code");
 
-	const result = await db
-		.select()
-		.from(platforms)
-		.where(eq(platforms.code, code))
-		.limit(1);
+		const result = await db
+			.select()
+			.from(platforms)
+			.where(eq(platforms.code, code))
+			.limit(1);
 
-	if (result.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (result.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/platforms/:code");
 	}
-
-	return c.json(result[0]);
 });
 
 // 新規作成
 platformsRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertPlatformSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
+		// バリデーション
+		const parsed = insertPlatformSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 重複チェック
+		const existing = await db
+			.select()
+			.from(platforms)
+			.where(eq(platforms.code, parsed.data.code))
+			.limit(1);
+
+		if (existing.length > 0) {
+			return c.json({ error: "Code already exists" }, 409);
+		}
+
+		// sortOrder が未指定の場合は最大値 + 1 を設定
+		let sortOrder = parsed.data.sortOrder;
+		if (sortOrder === undefined || sortOrder === null) {
+			const maxResult = await db
+				.select({ maxOrder: max(platforms.sortOrder) })
+				.from(platforms);
+			sortOrder = (maxResult[0]?.maxOrder ?? -1) + 1;
+		}
+
+		// 作成
+		const result = await db
+			.insert(platforms)
+			.values({ ...parsed.data, sortOrder })
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/platforms");
 	}
-
-	// 重複チェック
-	const existing = await db
-		.select()
-		.from(platforms)
-		.where(eq(platforms.code, parsed.data.code))
-		.limit(1);
-
-	if (existing.length > 0) {
-		return c.json({ error: "Code already exists" }, 409);
-	}
-
-	// sortOrder が未指定の場合は最大値 + 1 を設定
-	let sortOrder = parsed.data.sortOrder;
-	if (sortOrder === undefined || sortOrder === null) {
-		const maxResult = await db
-			.select({ maxOrder: max(platforms.sortOrder) })
-			.from(platforms);
-		sortOrder = (maxResult[0]?.maxOrder ?? -1) + 1;
-	}
-
-	// 作成
-	const result = await db
-		.insert(platforms)
-		.values({ ...parsed.data, sortOrder })
-		.returning();
-
-	return c.json(result[0], 201);
 });
 
 // 更新
 platformsRouter.put("/:code", async (c) => {
-	const code = c.req.param("code");
-	const body = await c.req.json();
+	try {
+		const code = c.req.param("code");
+		const body = await c.req.json();
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(platforms)
-		.where(eq(platforms.code, code))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(platforms)
+			.where(eq(platforms.code, code))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updatePlatformSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 更新
+		const result = await db
+			.update(platforms)
+			.set(parsed.data)
+			.where(eq(platforms.code, code))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/platforms/:code");
 	}
-
-	// バリデーション
-	const parsed = updatePlatformSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 更新
-	const result = await db
-		.update(platforms)
-		.set(parsed.data)
-		.where(eq(platforms.code, code))
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // 削除
 platformsRouter.delete("/:code", async (c) => {
-	const code = c.req.param("code");
+	try {
+		const code = c.req.param("code");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(platforms)
-		.where(eq(platforms.code, code))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(platforms)
+			.where(eq(platforms.code, code))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(platforms).where(eq(platforms.code, code));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/platforms/:code");
 	}
-
-	// 削除
-	await db.delete(platforms).where(eq(platforms.code, code));
-
-	return c.json({ success: true });
 });
 
 export { platformsRouter };

--- a/apps/server/src/routes/admin/official/songs.ts
+++ b/apps/server/src/routes/admin/official/songs.ts
@@ -17,42 +17,99 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 import { parseAndValidate } from "../../../utils/import-parser";
 
 const songsRouter = new Hono<AdminContext>();
 
 // 一覧取得（ページネーション、作品フィルタ、検索対応）
 songsRouter.get("/", async (c) => {
-	const page = Number(c.req.query("page")) || 1;
-	const limit = Math.min(Number(c.req.query("limit")) || 20, 5000);
-	const workId = c.req.query("workId");
-	const search = c.req.query("search");
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 5000);
+		const workId = c.req.query("workId");
+		const search = c.req.query("search");
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 条件を構築
-	const conditions = [];
+		// 条件を構築
+		const conditions = [];
 
-	if (workId) {
-		conditions.push(eq(officialSongs.officialWorkId, workId));
+		if (workId) {
+			conditions.push(eq(officialSongs.officialWorkId, workId));
+		}
+
+		if (search) {
+			const searchPattern = `%${search}%`;
+			conditions.push(
+				or(
+					like(officialSongs.name, searchPattern),
+					like(officialSongs.nameJa, searchPattern),
+					like(officialSongs.nameEn, searchPattern),
+				),
+			);
+		}
+
+		const whereCondition =
+			conditions.length > 0 ? and(...conditions) : undefined;
+
+		// データ取得（作品情報・カテゴリ情報を結合）
+		const [data, totalResult] = await Promise.all([
+			db
+				.select({
+					id: officialSongs.id,
+					officialWorkId: officialSongs.officialWorkId,
+					trackNumber: officialSongs.trackNumber,
+					name: officialSongs.name,
+					nameJa: officialSongs.nameJa,
+					nameEn: officialSongs.nameEn,
+					composerName: officialSongs.composerName,
+					arrangerName: officialSongs.arrangerName,
+					isOriginal: officialSongs.isOriginal,
+					sourceSongId: officialSongs.sourceSongId,
+					notes: officialSongs.notes,
+					createdAt: officialSongs.createdAt,
+					updatedAt: officialSongs.updatedAt,
+					workName: officialWorks.nameJa,
+					workCategoryCode: officialWorks.categoryCode,
+					workCategoryName: officialWorkCategories.name,
+					workCategorySortOrder: officialWorkCategories.sortOrder,
+				})
+				.from(officialSongs)
+				.leftJoin(
+					officialWorks,
+					eq(officialSongs.officialWorkId, officialWorks.id),
+				)
+				.leftJoin(
+					officialWorkCategories,
+					eq(officialWorks.categoryCode, officialWorkCategories.code),
+				)
+				.where(whereCondition)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(officialSongs.name),
+			db.select({ count: count() }).from(officialSongs).where(whereCondition),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/official/songs");
 	}
+});
 
-	if (search) {
-		const searchPattern = `%${search}%`;
-		conditions.push(
-			or(
-				like(officialSongs.name, searchPattern),
-				like(officialSongs.nameJa, searchPattern),
-				like(officialSongs.nameEn, searchPattern),
-			),
-		);
-	}
+// 個別取得（作品情報を含む）
+songsRouter.get("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
 
-	const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
-
-	// データ取得（作品情報・カテゴリ情報を結合）
-	const [data, totalResult] = await Promise.all([
-		db
+		const result = await db
 			.select({
 				id: officialSongs.id,
 				officialWorkId: officialSongs.officialWorkId,
@@ -68,401 +125,318 @@ songsRouter.get("/", async (c) => {
 				createdAt: officialSongs.createdAt,
 				updatedAt: officialSongs.updatedAt,
 				workName: officialWorks.nameJa,
-				workCategoryCode: officialWorks.categoryCode,
-				workCategoryName: officialWorkCategories.name,
-				workCategorySortOrder: officialWorkCategories.sortOrder,
 			})
 			.from(officialSongs)
 			.leftJoin(
 				officialWorks,
 				eq(officialSongs.officialWorkId, officialWorks.id),
 			)
-			.leftJoin(
-				officialWorkCategories,
-				eq(officialWorks.categoryCode, officialWorkCategories.code),
-			)
-			.where(whereCondition)
-			.limit(limit)
-			.offset(offset)
-			.orderBy(officialSongs.name),
-		db.select({ count: count() }).from(officialSongs).where(whereCondition),
-	]);
+			.where(eq(officialSongs.id, id))
+			.limit(1);
 
-	const total = totalResult[0]?.count ?? 0;
+		if (result.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
 
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
-});
-
-// 個別取得（作品情報を含む）
-songsRouter.get("/:id", async (c) => {
-	const id = c.req.param("id");
-
-	const result = await db
-		.select({
-			id: officialSongs.id,
-			officialWorkId: officialSongs.officialWorkId,
-			trackNumber: officialSongs.trackNumber,
-			name: officialSongs.name,
-			nameJa: officialSongs.nameJa,
-			nameEn: officialSongs.nameEn,
-			composerName: officialSongs.composerName,
-			arrangerName: officialSongs.arrangerName,
-			isOriginal: officialSongs.isOriginal,
-			sourceSongId: officialSongs.sourceSongId,
-			notes: officialSongs.notes,
-			createdAt: officialSongs.createdAt,
-			updatedAt: officialSongs.updatedAt,
-			workName: officialWorks.nameJa,
-		})
-		.from(officialSongs)
-		.leftJoin(officialWorks, eq(officialSongs.officialWorkId, officialWorks.id))
-		.where(eq(officialSongs.id, id))
-		.limit(1);
-
-	if (result.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/official/songs/:id");
 	}
-
-	return c.json(result[0]);
 });
 
 // 新規作成
 songsRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertOfficialSongSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
+		// バリデーション
+		const parsed = insertOfficialSongSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(officialSongs)
+			.where(eq(officialSongs.id, parsed.data.id))
+			.limit(1);
+
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
+
+		// sourceSongIdの自己参照チェック
+		if (parsed.data.sourceSongId === parsed.data.id) {
+			return c.json({ error: "Source song cannot reference itself" }, 400);
+		}
+
+		// 作成
+		const result = await db
+			.insert(officialSongs)
+			.values(parsed.data)
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/official/songs");
 	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(officialSongs)
-		.where(eq(officialSongs.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// sourceSongIdの自己参照チェック
-	if (parsed.data.sourceSongId === parsed.data.id) {
-		return c.json({ error: "Source song cannot reference itself" }, 400);
-	}
-
-	// 作成
-	const result = await db.insert(officialSongs).values(parsed.data).returning();
-
-	return c.json(result[0], 201);
 });
 
 // 更新
 songsRouter.put("/:id", async (c) => {
-	const id = c.req.param("id");
-	const body = await c.req.json();
+	try {
+		const id = c.req.param("id");
+		const body = await c.req.json();
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialSongs)
-		.where(eq(officialSongs.id, id))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialSongs)
+			.where(eq(officialSongs.id, id))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateOfficialSongSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// sourceSongIdの自己参照チェック
+		if (parsed.data.sourceSongId === id) {
+			return c.json({ error: "Source song cannot reference itself" }, 400);
+		}
+
+		// 更新
+		const result = await db
+			.update(officialSongs)
+			.set(parsed.data)
+			.where(eq(officialSongs.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/official/songs/:id");
 	}
-
-	// バリデーション
-	const parsed = updateOfficialSongSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// sourceSongIdの自己参照チェック
-	if (parsed.data.sourceSongId === id) {
-		return c.json({ error: "Source song cannot reference itself" }, 400);
-	}
-
-	// 更新
-	const result = await db
-		.update(officialSongs)
-		.set(parsed.data)
-		.where(eq(officialSongs.id, id))
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // 削除
 songsRouter.delete("/:id", async (c) => {
-	const id = c.req.param("id");
+	try {
+		const id = c.req.param("id");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialSongs)
-		.where(eq(officialSongs.id, id))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialSongs)
+			.where(eq(officialSongs.id, id))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(officialSongs).where(eq(officialSongs.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/official/songs/:id");
 	}
-
-	// 削除
-	await db.delete(officialSongs).where(eq(officialSongs.id, id));
-
-	return c.json({ success: true });
 });
 
 // インポート
 songsRouter.post("/import", async (c) => {
-	const body = await c.req.parseBody();
-	const file = body.file;
+	try {
+		const body = await c.req.parseBody();
+		const file = body.file;
 
-	if (!(file instanceof File)) {
-		return c.json({ error: "ファイルが指定されていません" }, 400);
-	}
-
-	const content = await file.text();
-	const result = parseAndValidate(content, file.name, insertOfficialSongSchema);
-
-	if (!result.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				rows: result.errors,
-			},
-			400,
-		);
-	}
-
-	const data = result.data;
-	if (!data) {
-		return c.json({ error: "データの取得に失敗しました" }, 500);
-	}
-
-	// 自己参照チェック
-	const selfRefErrors = [];
-	for (let i = 0; i < data.length; i++) {
-		const item = data[i];
-		if (item && item.sourceSongId === item.id) {
-			selfRefErrors.push({
-				row: i + 1,
-				errors: ["Source song cannot reference itself"],
-			});
+		if (!(file instanceof File)) {
+			return c.json({ error: "ファイルが指定されていません" }, 400);
 		}
-	}
 
-	if (selfRefErrors.length > 0) {
-		return c.json(
-			{
-				error: "Validation failed",
-				rows: selfRefErrors,
-			},
-			400,
+		const content = await file.text();
+		const result = parseAndValidate(
+			content,
+			file.name,
+			insertOfficialSongSchema,
 		);
-	}
 
-	let created = 0;
-	const updated = 0;
+		if (!result.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					rows: result.errors,
+				},
+				400,
+			);
+		}
 
-	await db.transaction(async (tx) => {
-		for (const item of data) {
-			await tx
-				.insert(officialSongs)
-				.values(item)
-				.onConflictDoUpdate({
-					target: officialSongs.id,
-					set: {
-						officialWorkId: item.officialWorkId,
-						trackNumber: item.trackNumber,
-						name: item.name,
-						nameJa: item.nameJa,
-						nameEn: item.nameEn,
-						composerName: item.composerName,
-						arrangerName: item.arrangerName,
-						isOriginal: item.isOriginal,
-						sourceSongId: item.sourceSongId,
-						notes: item.notes,
-					},
+		const data = result.data;
+		if (!data) {
+			return c.json({ error: "データの取得に失敗しました" }, 500);
+		}
+
+		// 自己参照チェック
+		const selfRefErrors = [];
+		for (let i = 0; i < data.length; i++) {
+			const item = data[i];
+			if (item && item.sourceSongId === item.id) {
+				selfRefErrors.push({
+					row: i + 1,
+					errors: ["Source song cannot reference itself"],
 				});
-			created++;
+			}
 		}
-	});
 
-	return c.json({
-		success: true,
-		created,
-		updated,
-		total: data.length,
-	});
+		if (selfRefErrors.length > 0) {
+			return c.json(
+				{
+					error: "Validation failed",
+					rows: selfRefErrors,
+				},
+				400,
+			);
+		}
+
+		let created = 0;
+		const updated = 0;
+
+		await db.transaction(async (tx) => {
+			for (const item of data) {
+				await tx
+					.insert(officialSongs)
+					.values(item)
+					.onConflictDoUpdate({
+						target: officialSongs.id,
+						set: {
+							officialWorkId: item.officialWorkId,
+							trackNumber: item.trackNumber,
+							name: item.name,
+							nameJa: item.nameJa,
+							nameEn: item.nameEn,
+							composerName: item.composerName,
+							arrangerName: item.arrangerName,
+							isOriginal: item.isOriginal,
+							sourceSongId: item.sourceSongId,
+							notes: item.notes,
+						},
+					});
+				created++;
+			}
+		});
+
+		return c.json({
+			success: true,
+			created,
+			updated,
+			total: data.length,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/official/songs/import");
+	}
 });
 
 // ===== 楽曲リンク関連エンドポイント =====
 
 // 楽曲のリンク一覧取得
 songsRouter.get("/:songId/links", async (c) => {
-	const songId = c.req.param("songId");
+	try {
+		const songId = c.req.param("songId");
 
-	// 楽曲存在チェック
-	const existingSong = await db
-		.select()
-		.from(officialSongs)
-		.where(eq(officialSongs.id, songId))
-		.limit(1);
+		// 楽曲存在チェック
+		const existingSong = await db
+			.select()
+			.from(officialSongs)
+			.where(eq(officialSongs.id, songId))
+			.limit(1);
 
-	if (existingSong.length === 0) {
-		return c.json({ error: "Song not found" }, 404);
+		if (existingSong.length === 0) {
+			return c.json({ error: "Song not found" }, 404);
+		}
+
+		const links = await db
+			.select({
+				id: officialSongLinks.id,
+				officialSongId: officialSongLinks.officialSongId,
+				platformCode: officialSongLinks.platformCode,
+				url: officialSongLinks.url,
+				sortOrder: officialSongLinks.sortOrder,
+				createdAt: officialSongLinks.createdAt,
+				updatedAt: officialSongLinks.updatedAt,
+				platformName: platforms.name,
+			})
+			.from(officialSongLinks)
+			.leftJoin(platforms, eq(officialSongLinks.platformCode, platforms.code))
+			.where(eq(officialSongLinks.officialSongId, songId))
+			.orderBy(officialSongLinks.sortOrder);
+
+		return c.json(links);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/official/songs/:songId/links");
 	}
-
-	const links = await db
-		.select({
-			id: officialSongLinks.id,
-			officialSongId: officialSongLinks.officialSongId,
-			platformCode: officialSongLinks.platformCode,
-			url: officialSongLinks.url,
-			sortOrder: officialSongLinks.sortOrder,
-			createdAt: officialSongLinks.createdAt,
-			updatedAt: officialSongLinks.updatedAt,
-			platformName: platforms.name,
-		})
-		.from(officialSongLinks)
-		.leftJoin(platforms, eq(officialSongLinks.platformCode, platforms.code))
-		.where(eq(officialSongLinks.officialSongId, songId))
-		.orderBy(officialSongLinks.sortOrder);
-
-	return c.json(links);
 });
 
 // 楽曲リンク追加
 songsRouter.post("/:songId/links", async (c) => {
-	const songId = c.req.param("songId");
-	const body = await c.req.json();
-
-	// 楽曲存在チェック
-	const existingSong = await db
-		.select()
-		.from(officialSongs)
-		.where(eq(officialSongs.id, songId))
-		.limit(1);
-
-	if (existingSong.length === 0) {
-		return c.json({ error: "Song not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = insertOfficialSongLinkSchema.safeParse({
-		...body,
-		officialSongId: songId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(officialSongLinks)
-		.where(eq(officialSongLinks.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// URL重複チェック（同一楽曲内）
-	const existingUrl = await db
-		.select()
-		.from(officialSongLinks)
-		.where(
-			and(
-				eq(officialSongLinks.officialSongId, songId),
-				eq(officialSongLinks.url, parsed.data.url),
-			),
-		)
-		.limit(1);
-
-	if (existingUrl.length > 0) {
-		return c.json({ error: "URL already exists for this song" }, 409);
-	}
-
-	// 作成
 	try {
-		const result = await db
-			.insert(officialSongLinks)
-			.values(parsed.data)
-			.returning();
-		return c.json(result[0], 201);
-	} catch (e) {
-		console.error("Failed to create song link:", e);
-		return c.json(
-			{ error: e instanceof Error ? e.message : "リンクの作成に失敗しました" },
-			500,
-		);
-	}
-});
+		const songId = c.req.param("songId");
+		const body = await c.req.json();
 
-// 楽曲リンク更新
-songsRouter.put("/:songId/links/:linkId", async (c) => {
-	const songId = c.req.param("songId");
-	const linkId = c.req.param("linkId");
-	const body = await c.req.json();
+		// 楽曲存在チェック
+		const existingSong = await db
+			.select()
+			.from(officialSongs)
+			.where(eq(officialSongs.id, songId))
+			.limit(1);
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialSongLinks)
-		.where(
-			and(
-				eq(officialSongLinks.id, linkId),
-				eq(officialSongLinks.officialSongId, songId),
-			),
-		)
-		.limit(1);
+		if (existingSong.length === 0) {
+			return c.json({ error: "Song not found" }, 404);
+		}
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
+		// バリデーション
+		const parsed = insertOfficialSongLinkSchema.safeParse({
+			...body,
+			officialSongId: songId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// バリデーション
-	const parsed = updateOfficialSongLinkSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(officialSongLinks)
+			.where(eq(officialSongLinks.id, parsed.data.id))
+			.limit(1);
 
-	// URL重複チェック（同一楽曲内、自身以外）
-	if (parsed.data.url) {
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
+
+		// URL重複チェック（同一楽曲内）
 		const existingUrl = await db
 			.select()
 			.from(officialSongLinks)
@@ -474,99 +448,166 @@ songsRouter.put("/:songId/links/:linkId", async (c) => {
 			)
 			.limit(1);
 
-		if (existingUrl.length > 0 && existingUrl[0]?.id !== linkId) {
+		if (existingUrl.length > 0) {
 			return c.json({ error: "URL already exists for this song" }, 409);
 		}
-	}
 
-	// 更新
+		// 作成
+		const result = await db
+			.insert(officialSongLinks)
+			.values(parsed.data)
+			.returning();
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/official/songs/:songId/links");
+	}
+});
+
+// 楽曲リンク更新
+songsRouter.put("/:songId/links/:linkId", async (c) => {
 	try {
+		const songId = c.req.param("songId");
+		const linkId = c.req.param("linkId");
+		const body = await c.req.json();
+
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialSongLinks)
+			.where(
+				and(
+					eq(officialSongLinks.id, linkId),
+					eq(officialSongLinks.officialSongId, songId),
+				),
+			)
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateOfficialSongLinkSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// URL重複チェック（同一楽曲内、自身以外）
+		if (parsed.data.url) {
+			const existingUrl = await db
+				.select()
+				.from(officialSongLinks)
+				.where(
+					and(
+						eq(officialSongLinks.officialSongId, songId),
+						eq(officialSongLinks.url, parsed.data.url),
+					),
+				)
+				.limit(1);
+
+			if (existingUrl.length > 0 && existingUrl[0]?.id !== linkId) {
+				return c.json({ error: "URL already exists for this song" }, 409);
+			}
+		}
+
+		// 更新
 		const result = await db
 			.update(officialSongLinks)
 			.set(parsed.data)
 			.where(eq(officialSongLinks.id, linkId))
 			.returning();
 		return c.json(result[0]);
-	} catch (e) {
-		console.error("Failed to update song link:", e);
-		return c.json(
-			{ error: e instanceof Error ? e.message : "リンクの更新に失敗しました" },
-			500,
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/official/songs/:songId/links/:linkId",
 		);
 	}
 });
 
 // 楽曲リンク削除
 songsRouter.delete("/:songId/links/:linkId", async (c) => {
-	const songId = c.req.param("songId");
-	const linkId = c.req.param("linkId");
+	try {
+		const songId = c.req.param("songId");
+		const linkId = c.req.param("linkId");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialSongLinks)
-		.where(
-			and(
-				eq(officialSongLinks.id, linkId),
-				eq(officialSongLinks.officialSongId, songId),
-			),
-		)
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialSongLinks)
+			.where(
+				and(
+					eq(officialSongLinks.id, linkId),
+					eq(officialSongLinks.officialSongId, songId),
+				),
+			)
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(officialSongLinks).where(eq(officialSongLinks.id, linkId));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/official/songs/:songId/links/:linkId",
+		);
 	}
-
-	// 削除
-	await db.delete(officialSongLinks).where(eq(officialSongLinks.id, linkId));
-
-	return c.json({ success: true });
 });
 
 // 楽曲リンク並べ替え
 songsRouter.put("/:songId/links/:linkId/reorder", async (c) => {
-	const songId = c.req.param("songId");
-	const linkId = c.req.param("linkId");
-	const body = await c.req.json();
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialSongLinks)
-		.where(
-			and(
-				eq(officialSongLinks.id, linkId),
-				eq(officialSongLinks.officialSongId, songId),
-			),
-		)
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const sortOrder = Number(body.sortOrder);
-	if (Number.isNaN(sortOrder) || sortOrder < 0) {
-		return c.json({ error: "Invalid sortOrder" }, 400);
-	}
-
-	// 更新
 	try {
+		const songId = c.req.param("songId");
+		const linkId = c.req.param("linkId");
+		const body = await c.req.json();
+
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialSongLinks)
+			.where(
+				and(
+					eq(officialSongLinks.id, linkId),
+					eq(officialSongLinks.officialSongId, songId),
+				),
+			)
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const sortOrder = Number(body.sortOrder);
+		if (Number.isNaN(sortOrder) || sortOrder < 0) {
+			return c.json({ error: "Invalid sortOrder" }, 400);
+		}
+
+		// 更新
 		const result = await db
 			.update(officialSongLinks)
 			.set({ sortOrder })
 			.where(eq(officialSongLinks.id, linkId))
 			.returning();
 		return c.json(result[0]);
-	} catch (e) {
-		console.error("Failed to reorder song link:", e);
-		return c.json(
-			{
-				error:
-					e instanceof Error ? e.message : "リンクの並べ替えに失敗しました",
-			},
-			500,
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/official/songs/:songId/links/:linkId/reorder",
 		);
 	}
 });

--- a/apps/server/src/routes/admin/official/works.ts
+++ b/apps/server/src/routes/admin/official/works.ts
@@ -15,379 +15,350 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 import { parseAndValidate } from "../../../utils/import-parser";
 
 const worksRouter = new Hono<AdminContext>();
 
 // 一覧取得（ページネーション、カテゴリフィルタ、検索対応）
 worksRouter.get("/", async (c) => {
-	const page = Number(c.req.query("page")) || 1;
-	const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
-	const category = c.req.query("category");
-	const search = c.req.query("search");
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const category = c.req.query("category");
+		const search = c.req.query("search");
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 条件を構築
-	const conditions = [];
+		// 条件を構築
+		const conditions = [];
 
-	if (category) {
-		conditions.push(eq(officialWorks.categoryCode, category));
+		if (category) {
+			conditions.push(eq(officialWorks.categoryCode, category));
+		}
+
+		if (search) {
+			const searchPattern = `%${search}%`;
+			conditions.push(
+				or(
+					like(officialWorks.name, searchPattern),
+					like(officialWorks.nameJa, searchPattern),
+					like(officialWorks.nameEn, searchPattern),
+				),
+			);
+		}
+
+		const whereCondition =
+			conditions.length > 0 ? and(...conditions) : undefined;
+
+		// データ取得
+		const [data, totalResult] = await Promise.all([
+			db
+				.select()
+				.from(officialWorks)
+				.where(whereCondition)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(officialWorks.position, officialWorks.id),
+			db.select({ count: count() }).from(officialWorks).where(whereCondition),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/official/works");
 	}
-
-	if (search) {
-		const searchPattern = `%${search}%`;
-		conditions.push(
-			or(
-				like(officialWorks.name, searchPattern),
-				like(officialWorks.nameJa, searchPattern),
-				like(officialWorks.nameEn, searchPattern),
-			),
-		);
-	}
-
-	const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
-
-	// データ取得
-	const [data, totalResult] = await Promise.all([
-		db
-			.select()
-			.from(officialWorks)
-			.where(whereCondition)
-			.limit(limit)
-			.offset(offset)
-			.orderBy(officialWorks.position, officialWorks.id),
-		db.select({ count: count() }).from(officialWorks).where(whereCondition),
-	]);
-
-	const total = totalResult[0]?.count ?? 0;
-
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
 });
 
 // 個別取得
 worksRouter.get("/:id", async (c) => {
-	const id = c.req.param("id");
+	try {
+		const id = c.req.param("id");
 
-	const result = await db
-		.select()
-		.from(officialWorks)
-		.where(eq(officialWorks.id, id))
-		.limit(1);
+		const result = await db
+			.select()
+			.from(officialWorks)
+			.where(eq(officialWorks.id, id))
+			.limit(1);
 
-	if (result.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (result.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/official/works/:id");
 	}
-
-	return c.json(result[0]);
 });
 
 // 新規作成
 worksRouter.post("/", async (c) => {
-	const body = await c.req.json();
+	try {
+		const body = await c.req.json();
 
-	// バリデーション
-	const parsed = insertOfficialWorkSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
+		// バリデーション
+		const parsed = insertOfficialWorkSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(officialWorks)
+			.where(eq(officialWorks.id, parsed.data.id))
+			.limit(1);
+
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
+
+		// 作成
+		const result = await db
+			.insert(officialWorks)
+			.values(parsed.data)
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/official/works");
 	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(officialWorks)
-		.where(eq(officialWorks.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// 作成
-	const result = await db.insert(officialWorks).values(parsed.data).returning();
-
-	return c.json(result[0], 201);
 });
 
 // 更新
 worksRouter.put("/:id", async (c) => {
-	const id = c.req.param("id");
-	const body = await c.req.json();
+	try {
+		const id = c.req.param("id");
+		const body = await c.req.json();
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialWorks)
-		.where(eq(officialWorks.id, id))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialWorks)
+			.where(eq(officialWorks.id, id))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateOfficialWorkSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 更新
+		const result = await db
+			.update(officialWorks)
+			.set(parsed.data)
+			.where(eq(officialWorks.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/official/works/:id");
 	}
-
-	// バリデーション
-	const parsed = updateOfficialWorkSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 更新
-	const result = await db
-		.update(officialWorks)
-		.set(parsed.data)
-		.where(eq(officialWorks.id, id))
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // 削除
 worksRouter.delete("/:id", async (c) => {
-	const id = c.req.param("id");
+	try {
+		const id = c.req.param("id");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialWorks)
-		.where(eq(officialWorks.id, id))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialWorks)
+			.where(eq(officialWorks.id, id))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除（関連楽曲はCASCADE削除）
+		await db.delete(officialWorks).where(eq(officialWorks.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/official/works/:id");
 	}
-
-	// 削除（関連楽曲はCASCADE削除）
-	await db.delete(officialWorks).where(eq(officialWorks.id, id));
-
-	return c.json({ success: true });
 });
 
 // インポート
 worksRouter.post("/import", async (c) => {
-	const body = await c.req.parseBody();
-	const file = body.file;
+	try {
+		const body = await c.req.parseBody();
+		const file = body.file;
 
-	if (!(file instanceof File)) {
-		return c.json({ error: "ファイルが指定されていません" }, 400);
-	}
-
-	const content = await file.text();
-	const result = parseAndValidate(content, file.name, insertOfficialWorkSchema);
-
-	if (!result.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				rows: result.errors,
-			},
-			400,
-		);
-	}
-
-	const data = result.data;
-	if (!data) {
-		return c.json({ error: "データの取得に失敗しました" }, 500);
-	}
-
-	let created = 0;
-	const updated = 0;
-
-	await db.transaction(async (tx) => {
-		for (const item of data) {
-			await tx
-				.insert(officialWorks)
-				.values(item)
-				.onConflictDoUpdate({
-					target: officialWorks.id,
-					set: {
-						categoryCode: item.categoryCode,
-						name: item.name,
-						nameJa: item.nameJa,
-						nameEn: item.nameEn,
-						shortNameJa: item.shortNameJa,
-						shortNameEn: item.shortNameEn,
-						numberInSeries: item.numberInSeries,
-						releaseDate: item.releaseDate,
-						officialOrganization: item.officialOrganization,
-						position: item.position,
-						notes: item.notes,
-					},
-				});
-			created++;
+		if (!(file instanceof File)) {
+			return c.json({ error: "ファイルが指定されていません" }, 400);
 		}
-	});
 
-	return c.json({
-		success: true,
-		created,
-		updated,
-		total: data.length,
-	});
+		const content = await file.text();
+		const result = parseAndValidate(
+			content,
+			file.name,
+			insertOfficialWorkSchema,
+		);
+
+		if (!result.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					rows: result.errors,
+				},
+				400,
+			);
+		}
+
+		const data = result.data;
+		if (!data) {
+			return c.json({ error: "データの取得に失敗しました" }, 500);
+		}
+
+		let created = 0;
+		const updated = 0;
+
+		await db.transaction(async (tx) => {
+			for (const item of data) {
+				await tx
+					.insert(officialWorks)
+					.values(item)
+					.onConflictDoUpdate({
+						target: officialWorks.id,
+						set: {
+							categoryCode: item.categoryCode,
+							name: item.name,
+							nameJa: item.nameJa,
+							nameEn: item.nameEn,
+							shortNameJa: item.shortNameJa,
+							shortNameEn: item.shortNameEn,
+							numberInSeries: item.numberInSeries,
+							releaseDate: item.releaseDate,
+							officialOrganization: item.officialOrganization,
+							position: item.position,
+							notes: item.notes,
+						},
+					});
+				created++;
+			}
+		});
+
+		return c.json({
+			success: true,
+			created,
+			updated,
+			total: data.length,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/official/works/import");
+	}
 });
 
 // ===== 作品リンク関連エンドポイント =====
 
 // 作品のリンク一覧取得
 worksRouter.get("/:workId/links", async (c) => {
-	const workId = c.req.param("workId");
+	try {
+		const workId = c.req.param("workId");
 
-	// 作品存在チェック
-	const existingWork = await db
-		.select()
-		.from(officialWorks)
-		.where(eq(officialWorks.id, workId))
-		.limit(1);
+		// 作品存在チェック
+		const existingWork = await db
+			.select()
+			.from(officialWorks)
+			.where(eq(officialWorks.id, workId))
+			.limit(1);
 
-	if (existingWork.length === 0) {
-		return c.json({ error: "Work not found" }, 404);
+		if (existingWork.length === 0) {
+			return c.json({ error: "Work not found" }, 404);
+		}
+
+		const links = await db
+			.select({
+				id: officialWorkLinks.id,
+				officialWorkId: officialWorkLinks.officialWorkId,
+				platformCode: officialWorkLinks.platformCode,
+				url: officialWorkLinks.url,
+				sortOrder: officialWorkLinks.sortOrder,
+				createdAt: officialWorkLinks.createdAt,
+				updatedAt: officialWorkLinks.updatedAt,
+				platformName: platforms.name,
+			})
+			.from(officialWorkLinks)
+			.leftJoin(platforms, eq(officialWorkLinks.platformCode, platforms.code))
+			.where(eq(officialWorkLinks.officialWorkId, workId))
+			.orderBy(officialWorkLinks.sortOrder);
+
+		return c.json(links);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/official/works/:workId/links");
 	}
-
-	const links = await db
-		.select({
-			id: officialWorkLinks.id,
-			officialWorkId: officialWorkLinks.officialWorkId,
-			platformCode: officialWorkLinks.platformCode,
-			url: officialWorkLinks.url,
-			sortOrder: officialWorkLinks.sortOrder,
-			createdAt: officialWorkLinks.createdAt,
-			updatedAt: officialWorkLinks.updatedAt,
-			platformName: platforms.name,
-		})
-		.from(officialWorkLinks)
-		.leftJoin(platforms, eq(officialWorkLinks.platformCode, platforms.code))
-		.where(eq(officialWorkLinks.officialWorkId, workId))
-		.orderBy(officialWorkLinks.sortOrder);
-
-	return c.json(links);
 });
 
 // 作品リンク追加
 worksRouter.post("/:workId/links", async (c) => {
-	const workId = c.req.param("workId");
-	const body = await c.req.json();
-
-	// 作品存在チェック
-	const existingWork = await db
-		.select()
-		.from(officialWorks)
-		.where(eq(officialWorks.id, workId))
-		.limit(1);
-
-	if (existingWork.length === 0) {
-		return c.json({ error: "Work not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = insertOfficialWorkLinkSchema.safeParse({
-		...body,
-		officialWorkId: workId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(officialWorkLinks)
-		.where(eq(officialWorkLinks.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// URL重複チェック（同一作品内）
-	const existingUrl = await db
-		.select()
-		.from(officialWorkLinks)
-		.where(
-			and(
-				eq(officialWorkLinks.officialWorkId, workId),
-				eq(officialWorkLinks.url, parsed.data.url),
-			),
-		)
-		.limit(1);
-
-	if (existingUrl.length > 0) {
-		return c.json({ error: "URL already exists for this work" }, 409);
-	}
-
-	// 作成
 	try {
-		const result = await db
-			.insert(officialWorkLinks)
-			.values(parsed.data)
-			.returning();
-		return c.json(result[0], 201);
-	} catch (e) {
-		console.error("Failed to create work link:", e);
-		return c.json(
-			{ error: e instanceof Error ? e.message : "リンクの作成に失敗しました" },
-			500,
-		);
-	}
-});
+		const workId = c.req.param("workId");
+		const body = await c.req.json();
 
-// 作品リンク更新
-worksRouter.put("/:workId/links/:linkId", async (c) => {
-	const workId = c.req.param("workId");
-	const linkId = c.req.param("linkId");
-	const body = await c.req.json();
+		// 作品存在チェック
+		const existingWork = await db
+			.select()
+			.from(officialWorks)
+			.where(eq(officialWorks.id, workId))
+			.limit(1);
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialWorkLinks)
-		.where(
-			and(
-				eq(officialWorkLinks.id, linkId),
-				eq(officialWorkLinks.officialWorkId, workId),
-			),
-		)
-		.limit(1);
+		if (existingWork.length === 0) {
+			return c.json({ error: "Work not found" }, 404);
+		}
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
+		// バリデーション
+		const parsed = insertOfficialWorkLinkSchema.safeParse({
+			...body,
+			officialWorkId: workId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// バリデーション
-	const parsed = updateOfficialWorkLinkSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(officialWorkLinks)
+			.where(eq(officialWorkLinks.id, parsed.data.id))
+			.limit(1);
 
-	// URL重複チェック（同一作品内、自身以外）
-	if (parsed.data.url) {
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
+
+		// URL重複チェック（同一作品内）
 		const existingUrl = await db
 			.select()
 			.from(officialWorkLinks)
@@ -399,99 +370,166 @@ worksRouter.put("/:workId/links/:linkId", async (c) => {
 			)
 			.limit(1);
 
-		if (existingUrl.length > 0 && existingUrl[0]?.id !== linkId) {
+		if (existingUrl.length > 0) {
 			return c.json({ error: "URL already exists for this work" }, 409);
 		}
-	}
 
-	// 更新
+		// 作成
+		const result = await db
+			.insert(officialWorkLinks)
+			.values(parsed.data)
+			.returning();
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/official/works/:workId/links");
+	}
+});
+
+// 作品リンク更新
+worksRouter.put("/:workId/links/:linkId", async (c) => {
 	try {
+		const workId = c.req.param("workId");
+		const linkId = c.req.param("linkId");
+		const body = await c.req.json();
+
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialWorkLinks)
+			.where(
+				and(
+					eq(officialWorkLinks.id, linkId),
+					eq(officialWorkLinks.officialWorkId, workId),
+				),
+			)
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateOfficialWorkLinkSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// URL重複チェック（同一作品内、自身以外）
+		if (parsed.data.url) {
+			const existingUrl = await db
+				.select()
+				.from(officialWorkLinks)
+				.where(
+					and(
+						eq(officialWorkLinks.officialWorkId, workId),
+						eq(officialWorkLinks.url, parsed.data.url),
+					),
+				)
+				.limit(1);
+
+			if (existingUrl.length > 0 && existingUrl[0]?.id !== linkId) {
+				return c.json({ error: "URL already exists for this work" }, 409);
+			}
+		}
+
+		// 更新
 		const result = await db
 			.update(officialWorkLinks)
 			.set(parsed.data)
 			.where(eq(officialWorkLinks.id, linkId))
 			.returning();
 		return c.json(result[0]);
-	} catch (e) {
-		console.error("Failed to update work link:", e);
-		return c.json(
-			{ error: e instanceof Error ? e.message : "リンクの更新に失敗しました" },
-			500,
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/official/works/:workId/links/:linkId",
 		);
 	}
 });
 
 // 作品リンク削除
 worksRouter.delete("/:workId/links/:linkId", async (c) => {
-	const workId = c.req.param("workId");
-	const linkId = c.req.param("linkId");
+	try {
+		const workId = c.req.param("workId");
+		const linkId = c.req.param("linkId");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialWorkLinks)
-		.where(
-			and(
-				eq(officialWorkLinks.id, linkId),
-				eq(officialWorkLinks.officialWorkId, workId),
-			),
-		)
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialWorkLinks)
+			.where(
+				and(
+					eq(officialWorkLinks.id, linkId),
+					eq(officialWorkLinks.officialWorkId, workId),
+				),
+			)
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(officialWorkLinks).where(eq(officialWorkLinks.id, linkId));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/official/works/:workId/links/:linkId",
+		);
 	}
-
-	// 削除
-	await db.delete(officialWorkLinks).where(eq(officialWorkLinks.id, linkId));
-
-	return c.json({ success: true });
 });
 
 // 作品リンク並べ替え
 worksRouter.put("/:workId/links/:linkId/reorder", async (c) => {
-	const workId = c.req.param("workId");
-	const linkId = c.req.param("linkId");
-	const body = await c.req.json();
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(officialWorkLinks)
-		.where(
-			and(
-				eq(officialWorkLinks.id, linkId),
-				eq(officialWorkLinks.officialWorkId, workId),
-			),
-		)
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const sortOrder = Number(body.sortOrder);
-	if (Number.isNaN(sortOrder) || sortOrder < 0) {
-		return c.json({ error: "Invalid sortOrder" }, 400);
-	}
-
-	// 更新
 	try {
+		const workId = c.req.param("workId");
+		const linkId = c.req.param("linkId");
+		const body = await c.req.json();
+
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(officialWorkLinks)
+			.where(
+				and(
+					eq(officialWorkLinks.id, linkId),
+					eq(officialWorkLinks.officialWorkId, workId),
+				),
+			)
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const sortOrder = Number(body.sortOrder);
+		if (Number.isNaN(sortOrder) || sortOrder < 0) {
+			return c.json({ error: "Invalid sortOrder" }, 400);
+		}
+
+		// 更新
 		const result = await db
 			.update(officialWorkLinks)
 			.set({ sortOrder })
 			.where(eq(officialWorkLinks.id, linkId))
 			.returning();
 		return c.json(result[0]);
-	} catch (e) {
-		console.error("Failed to reorder work link:", e);
-		return c.json(
-			{
-				error:
-					e instanceof Error ? e.message : "リンクの並べ替えに失敗しました",
-			},
-			500,
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/official/works/:workId/links/:linkId/reorder",
 		);
 	}
 });

--- a/apps/server/src/routes/admin/releases/discs.ts
+++ b/apps/server/src/routes/admin/releases/discs.ts
@@ -9,131 +9,82 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const discsRouter = new Hono<AdminContext>();
 
 // リリースのディスク一覧取得（ディスク番号順）
 discsRouter.get("/:releaseId/discs", async (c) => {
-	const releaseId = c.req.param("releaseId");
+	try {
+		const releaseId = c.req.param("releaseId");
 
-	// リリース存在チェック
-	const existingRelease = await db
-		.select()
-		.from(releases)
-		.where(eq(releases.id, releaseId))
-		.limit(1);
+		// リリース存在チェック
+		const existingRelease = await db
+			.select()
+			.from(releases)
+			.where(eq(releases.id, releaseId))
+			.limit(1);
 
-	if (existingRelease.length === 0) {
-		return c.json({ error: "Release not found" }, 404);
+		if (existingRelease.length === 0) {
+			return c.json({ error: "Release not found" }, 404);
+		}
+
+		const releaseDiscs = await db
+			.select()
+			.from(discs)
+			.where(eq(discs.releaseId, releaseId))
+			.orderBy(discs.discNumber);
+
+		return c.json(releaseDiscs);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/releases/:releaseId/discs");
 	}
-
-	const releaseDiscs = await db
-		.select()
-		.from(discs)
-		.where(eq(discs.releaseId, releaseId))
-		.orderBy(discs.discNumber);
-
-	return c.json(releaseDiscs);
 });
 
 // ディスク追加
 discsRouter.post("/:releaseId/discs", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const body = await c.req.json();
+	try {
+		const releaseId = c.req.param("releaseId");
+		const body = await c.req.json();
 
-	// リリース存在チェック
-	const existingRelease = await db
-		.select()
-		.from(releases)
-		.where(eq(releases.id, releaseId))
-		.limit(1);
+		// リリース存在チェック
+		const existingRelease = await db
+			.select()
+			.from(releases)
+			.where(eq(releases.id, releaseId))
+			.limit(1);
 
-	if (existingRelease.length === 0) {
-		return c.json({ error: "Release not found" }, 404);
-	}
+		if (existingRelease.length === 0) {
+			return c.json({ error: "Release not found" }, 404);
+		}
 
-	// バリデーション
-	const parsed = insertDiscSchema.safeParse({
-		...body,
-		releaseId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		// バリデーション
+		const parsed = insertDiscSchema.safeParse({
+			...body,
+			releaseId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(discs)
-		.where(eq(discs.id, parsed.data.id))
-		.limit(1);
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(discs)
+			.where(eq(discs.id, parsed.data.id))
+			.limit(1);
 
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
 
-	// ディスク番号重複チェック（同一リリース内）
-	const existingDiscNumber = await db
-		.select()
-		.from(discs)
-		.where(
-			and(
-				eq(discs.releaseId, releaseId),
-				eq(discs.discNumber, parsed.data.discNumber),
-			),
-		)
-		.limit(1);
-
-	if (existingDiscNumber.length > 0) {
-		return c.json(
-			{ error: "Disc number already exists for this release" },
-			409,
-		);
-	}
-
-	// 作成
-	const result = await db.insert(discs).values(parsed.data).returning();
-
-	return c.json(result[0], 201);
-});
-
-// ディスク更新
-discsRouter.put("/:releaseId/discs/:discId", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const discId = c.req.param("discId");
-	const body = await c.req.json();
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(discs)
-		.where(and(eq(discs.id, discId), eq(discs.releaseId, releaseId)))
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateDiscSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// ディスク番号重複チェック（同一リリース内、自身以外）
-	if (parsed.data.discNumber !== undefined) {
+		// ディスク番号重複チェック（同一リリース内）
 		const existingDiscNumber = await db
 			.select()
 			.from(discs)
@@ -145,44 +96,121 @@ discsRouter.put("/:releaseId/discs/:discId", async (c) => {
 			)
 			.limit(1);
 
-		if (existingDiscNumber.length > 0 && existingDiscNumber[0]?.id !== discId) {
+		if (existingDiscNumber.length > 0) {
 			return c.json(
 				{ error: "Disc number already exists for this release" },
 				409,
 			);
 		}
+
+		// 作成
+		const result = await db.insert(discs).values(parsed.data).returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/releases/:releaseId/discs");
 	}
+});
 
-	// 更新
-	const result = await db
-		.update(discs)
-		.set(parsed.data)
-		.where(eq(discs.id, discId))
-		.returning();
+// ディスク更新
+discsRouter.put("/:releaseId/discs/:discId", async (c) => {
+	try {
+		const releaseId = c.req.param("releaseId");
+		const discId = c.req.param("discId");
+		const body = await c.req.json();
 
-	return c.json(result[0]);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(discs)
+			.where(and(eq(discs.id, discId), eq(discs.releaseId, releaseId)))
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateDiscSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// ディスク番号重複チェック（同一リリース内、自身以外）
+		if (parsed.data.discNumber !== undefined) {
+			const existingDiscNumber = await db
+				.select()
+				.from(discs)
+				.where(
+					and(
+						eq(discs.releaseId, releaseId),
+						eq(discs.discNumber, parsed.data.discNumber),
+					),
+				)
+				.limit(1);
+
+			if (
+				existingDiscNumber.length > 0 &&
+				existingDiscNumber[0]?.id !== discId
+			) {
+				return c.json(
+					{ error: "Disc number already exists for this release" },
+					409,
+				);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(discs)
+			.set(parsed.data)
+			.where(eq(discs.id, discId))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/releases/:releaseId/discs/:discId",
+		);
+	}
 });
 
 // ディスク削除
 discsRouter.delete("/:releaseId/discs/:discId", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const discId = c.req.param("discId");
+	try {
+		const releaseId = c.req.param("releaseId");
+		const discId = c.req.param("discId");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(discs)
-		.where(and(eq(discs.id, discId), eq(discs.releaseId, releaseId)))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(discs)
+			.where(and(eq(discs.id, discId), eq(discs.releaseId, releaseId)))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(discs).where(eq(discs.id, discId));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/releases/:releaseId/discs/:discId",
+		);
 	}
-
-	// 削除
-	await db.delete(discs).where(eq(discs.id, discId));
-
-	return c.json({ success: true });
 });
 
 export { discsRouter };

--- a/apps/server/src/routes/admin/releases/jan-codes.ts
+++ b/apps/server/src/routes/admin/releases/jan-codes.ts
@@ -9,200 +9,231 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const releaseJanCodesRouter = new Hono<AdminContext>();
 
 // リリースのJANコード一覧取得
 releaseJanCodesRouter.get("/:releaseId/jan-codes", async (c) => {
-	const releaseId = c.req.param("releaseId");
+	try {
+		const releaseId = c.req.param("releaseId");
 
-	// リリース存在チェック
-	const existingRelease = await db
-		.select()
-		.from(releases)
-		.where(eq(releases.id, releaseId))
-		.limit(1);
+		// リリース存在チェック
+		const existingRelease = await db
+			.select()
+			.from(releases)
+			.where(eq(releases.id, releaseId))
+			.limit(1);
 
-	if (existingRelease.length === 0) {
-		return c.json({ error: "Release not found" }, 404);
+		if (existingRelease.length === 0) {
+			return c.json({ error: "Release not found" }, 404);
+		}
+
+		// JANコード一覧取得
+		const janCodes = await db
+			.select()
+			.from(releaseJanCodes)
+			.where(eq(releaseJanCodes.releaseId, releaseId));
+
+		return c.json(janCodes);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/releases/:releaseId/jan-codes");
 	}
-
-	// JANコード一覧取得
-	const janCodes = await db
-		.select()
-		.from(releaseJanCodes)
-		.where(eq(releaseJanCodes.releaseId, releaseId));
-
-	return c.json(janCodes);
 });
 
 // JANコード追加
 releaseJanCodesRouter.post("/:releaseId/jan-codes", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const body = await c.req.json();
+	try {
+		const releaseId = c.req.param("releaseId");
+		const body = await c.req.json();
 
-	// リリース存在チェック
-	const existingRelease = await db
-		.select()
-		.from(releases)
-		.where(eq(releases.id, releaseId))
-		.limit(1);
-
-	if (existingRelease.length === 0) {
-		return c.json({ error: "Release not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = insertReleaseJanCodeSchema.safeParse({
-		...body,
-		releaseId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(releaseJanCodes)
-		.where(eq(releaseJanCodes.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// JANコードのグローバル一意性チェック
-	const janDuplicateCheck = await db
-		.select()
-		.from(releaseJanCodes)
-		.where(eq(releaseJanCodes.janCode, parsed.data.janCode))
-		.limit(1);
-
-	if (janDuplicateCheck.length > 0) {
-		return c.json({ error: "JAN code already exists" }, 409);
-	}
-
-	// isPrimary制約チェック（同一リリース内でisPrimaryは1件のみ）
-	if (parsed.data.isPrimary) {
-		const primaryCheck = await db
+		// リリース存在チェック
+		const existingRelease = await db
 			.select()
-			.from(releaseJanCodes)
-			.where(
-				and(
-					eq(releaseJanCodes.releaseId, releaseId),
-					eq(releaseJanCodes.isPrimary, true),
-				),
-			)
+			.from(releases)
+			.where(eq(releases.id, releaseId))
 			.limit(1);
 
-		if (primaryCheck.length > 0) {
+		if (existingRelease.length === 0) {
+			return c.json({ error: "Release not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = insertReleaseJanCodeSchema.safeParse({
+			...body,
+			releaseId,
+		});
+		if (!parsed.success) {
 			return c.json(
-				{ error: "Primary JAN code already exists for this release" },
-				409,
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
 			);
 		}
+
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(releaseJanCodes)
+			.where(eq(releaseJanCodes.id, parsed.data.id))
+			.limit(1);
+
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
+
+		// JANコードのグローバル一意性チェック
+		const janDuplicateCheck = await db
+			.select()
+			.from(releaseJanCodes)
+			.where(eq(releaseJanCodes.janCode, parsed.data.janCode))
+			.limit(1);
+
+		if (janDuplicateCheck.length > 0) {
+			return c.json({ error: "JAN code already exists" }, 409);
+		}
+
+		// isPrimary制約チェック（同一リリース内でisPrimaryは1件のみ）
+		if (parsed.data.isPrimary) {
+			const primaryCheck = await db
+				.select()
+				.from(releaseJanCodes)
+				.where(
+					and(
+						eq(releaseJanCodes.releaseId, releaseId),
+						eq(releaseJanCodes.isPrimary, true),
+					),
+				)
+				.limit(1);
+
+			if (primaryCheck.length > 0) {
+				return c.json(
+					{ error: "Primary JAN code already exists for this release" },
+					409,
+				);
+			}
+		}
+
+		// 作成
+		const result = await db
+			.insert(releaseJanCodes)
+			.values(parsed.data)
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/releases/:releaseId/jan-codes");
 	}
-
-	// 作成
-	const result = await db
-		.insert(releaseJanCodes)
-		.values(parsed.data)
-		.returning();
-
-	return c.json(result[0], 201);
 });
 
 // JANコード更新
 releaseJanCodesRouter.put("/:releaseId/jan-codes/:id", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const id = c.req.param("id");
-	const body = await c.req.json();
+	try {
+		const releaseId = c.req.param("releaseId");
+		const id = c.req.param("id");
+		const body = await c.req.json();
 
-	// JANコード存在チェック
-	const existingJanCode = await db
-		.select()
-		.from(releaseJanCodes)
-		.where(
-			and(eq(releaseJanCodes.id, id), eq(releaseJanCodes.releaseId, releaseId)),
-		)
-		.limit(1);
-
-	if (existingJanCode.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateReleaseJanCodeSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// isPrimary変更時の制約チェック
-	if (parsed.data.isPrimary) {
-		const primaryCheck = await db
+		// JANコード存在チェック
+		const existingJanCode = await db
 			.select()
 			.from(releaseJanCodes)
 			.where(
 				and(
+					eq(releaseJanCodes.id, id),
 					eq(releaseJanCodes.releaseId, releaseId),
-					eq(releaseJanCodes.isPrimary, true),
 				),
 			)
 			.limit(1);
 
-		if (primaryCheck.length > 0 && primaryCheck[0]?.id !== id) {
+		if (existingJanCode.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateReleaseJanCodeSchema.safeParse(body);
+		if (!parsed.success) {
 			return c.json(
-				{ error: "Primary JAN code already exists for this release" },
-				409,
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
 			);
 		}
+
+		// isPrimary変更時の制約チェック
+		if (parsed.data.isPrimary) {
+			const primaryCheck = await db
+				.select()
+				.from(releaseJanCodes)
+				.where(
+					and(
+						eq(releaseJanCodes.releaseId, releaseId),
+						eq(releaseJanCodes.isPrimary, true),
+					),
+				)
+				.limit(1);
+
+			if (primaryCheck.length > 0 && primaryCheck[0]?.id !== id) {
+				return c.json(
+					{ error: "Primary JAN code already exists for this release" },
+					409,
+				);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(releaseJanCodes)
+			.set(parsed.data)
+			.where(eq(releaseJanCodes.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/releases/:releaseId/jan-codes/:id",
+		);
 	}
-
-	// 更新
-	const result = await db
-		.update(releaseJanCodes)
-		.set(parsed.data)
-		.where(eq(releaseJanCodes.id, id))
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // JANコード削除
 releaseJanCodesRouter.delete("/:releaseId/jan-codes/:id", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const id = c.req.param("id");
+	try {
+		const releaseId = c.req.param("releaseId");
+		const id = c.req.param("id");
 
-	// JANコード存在チェック
-	const existingJanCode = await db
-		.select()
-		.from(releaseJanCodes)
-		.where(
-			and(eq(releaseJanCodes.id, id), eq(releaseJanCodes.releaseId, releaseId)),
-		)
-		.limit(1);
+		// JANコード存在チェック
+		const existingJanCode = await db
+			.select()
+			.from(releaseJanCodes)
+			.where(
+				and(
+					eq(releaseJanCodes.id, id),
+					eq(releaseJanCodes.releaseId, releaseId),
+				),
+			)
+			.limit(1);
 
-	if (existingJanCode.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existingJanCode.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(releaseJanCodes).where(eq(releaseJanCodes.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/releases/:releaseId/jan-codes/:id",
+		);
 	}
-
-	// 削除
-	await db.delete(releaseJanCodes).where(eq(releaseJanCodes.id, id));
-
-	return c.json({ success: true });
 });
 
 export { releaseJanCodesRouter };

--- a/apps/server/src/routes/admin/releases/publications.ts
+++ b/apps/server/src/routes/admin/releases/publications.ts
@@ -10,197 +10,230 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const releasePublicationsRouter = new Hono<AdminContext>();
 
 // リリースの公開リンク一覧取得
 releasePublicationsRouter.get("/:releaseId/publications", async (c) => {
-	const releaseId = c.req.param("releaseId");
+	try {
+		const releaseId = c.req.param("releaseId");
 
-	// リリース存在チェック
-	const existingRelease = await db
-		.select()
-		.from(releases)
-		.where(eq(releases.id, releaseId))
-		.limit(1);
+		// リリース存在チェック
+		const existingRelease = await db
+			.select()
+			.from(releases)
+			.where(eq(releases.id, releaseId))
+			.limit(1);
 
-	if (existingRelease.length === 0) {
-		return c.json({ error: "Release not found" }, 404);
+		if (existingRelease.length === 0) {
+			return c.json({ error: "Release not found" }, 404);
+		}
+
+		// 公開リンク一覧取得（プラットフォーム情報を結合）
+		const publications = await db
+			.select({
+				publication: releasePublications,
+				platform: platforms,
+			})
+			.from(releasePublications)
+			.leftJoin(platforms, eq(releasePublications.platformCode, platforms.code))
+			.where(eq(releasePublications.releaseId, releaseId));
+
+		return c.json(
+			publications.map((row) => ({
+				...row.publication,
+				platform: row.platform,
+			})),
+		);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"GET /admin/releases/:releaseId/publications",
+		);
 	}
-
-	// 公開リンク一覧取得（プラットフォーム情報を結合）
-	const publications = await db
-		.select({
-			publication: releasePublications,
-			platform: platforms,
-		})
-		.from(releasePublications)
-		.leftJoin(platforms, eq(releasePublications.platformCode, platforms.code))
-		.where(eq(releasePublications.releaseId, releaseId));
-
-	return c.json(
-		publications.map((row) => ({
-			...row.publication,
-			platform: row.platform,
-		})),
-	);
 });
 
 // 公開リンク追加
 releasePublicationsRouter.post("/:releaseId/publications", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const body = await c.req.json();
+	try {
+		const releaseId = c.req.param("releaseId");
+		const body = await c.req.json();
 
-	// リリース存在チェック
-	const existingRelease = await db
-		.select()
-		.from(releases)
-		.where(eq(releases.id, releaseId))
-		.limit(1);
+		// リリース存在チェック
+		const existingRelease = await db
+			.select()
+			.from(releases)
+			.where(eq(releases.id, releaseId))
+			.limit(1);
 
-	if (existingRelease.length === 0) {
-		return c.json({ error: "Release not found" }, 404);
-	}
+		if (existingRelease.length === 0) {
+			return c.json({ error: "Release not found" }, 404);
+		}
 
-	// プラットフォーム存在チェック
-	const existingPlatform = await db
-		.select()
-		.from(platforms)
-		.where(eq(platforms.code, body.platformCode))
-		.limit(1);
+		// プラットフォーム存在チェック
+		const existingPlatform = await db
+			.select()
+			.from(platforms)
+			.where(eq(platforms.code, body.platformCode))
+			.limit(1);
 
-	if (existingPlatform.length === 0) {
-		return c.json({ error: "Platform not found" }, 404);
-	}
+		if (existingPlatform.length === 0) {
+			return c.json({ error: "Platform not found" }, 404);
+		}
 
-	// バリデーション
-	const parsed = insertReleasePublicationSchema.safeParse({
-		...body,
-		releaseId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		// バリデーション
+		const parsed = insertReleasePublicationSchema.safeParse({
+			...body,
+			releaseId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(releasePublications)
-		.where(eq(releasePublications.id, parsed.data.id))
-		.limit(1);
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(releasePublications)
+			.where(eq(releasePublications.id, parsed.data.id))
+			.limit(1);
 
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
 
-	// URL重複チェック
-	const urlDuplicateCheck = await db
-		.select()
-		.from(releasePublications)
-		.where(eq(releasePublications.url, parsed.data.url))
-		.limit(1);
-
-	if (urlDuplicateCheck.length > 0) {
-		return c.json({ error: "URL already exists" }, 409);
-	}
-
-	// 作成
-	const result = await db
-		.insert(releasePublications)
-		.values(parsed.data)
-		.returning();
-
-	return c.json(result[0], 201);
-});
-
-// 公開リンク更新
-releasePublicationsRouter.put("/:releaseId/publications/:id", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const id = c.req.param("id");
-	const body = await c.req.json();
-
-	// 公開リンク存在チェック
-	const existingPublication = await db
-		.select()
-		.from(releasePublications)
-		.where(
-			and(
-				eq(releasePublications.id, id),
-				eq(releasePublications.releaseId, releaseId),
-			),
-		)
-		.limit(1);
-
-	if (existingPublication.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateReleasePublicationSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// URL重複チェック（自分自身以外で）
-	if (parsed.data.url) {
+		// URL重複チェック
 		const urlDuplicateCheck = await db
 			.select()
 			.from(releasePublications)
 			.where(eq(releasePublications.url, parsed.data.url))
 			.limit(1);
 
-		if (urlDuplicateCheck.length > 0 && urlDuplicateCheck[0]?.id !== id) {
+		if (urlDuplicateCheck.length > 0) {
 			return c.json({ error: "URL already exists" }, 409);
 		}
+
+		// 作成
+		const result = await db
+			.insert(releasePublications)
+			.values(parsed.data)
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"POST /admin/releases/:releaseId/publications",
+		);
 	}
+});
 
-	// 更新
-	const result = await db
-		.update(releasePublications)
-		.set(parsed.data)
-		.where(eq(releasePublications.id, id))
-		.returning();
+// 公開リンク更新
+releasePublicationsRouter.put("/:releaseId/publications/:id", async (c) => {
+	try {
+		const releaseId = c.req.param("releaseId");
+		const id = c.req.param("id");
+		const body = await c.req.json();
 
-	return c.json(result[0]);
+		// 公開リンク存在チェック
+		const existingPublication = await db
+			.select()
+			.from(releasePublications)
+			.where(
+				and(
+					eq(releasePublications.id, id),
+					eq(releasePublications.releaseId, releaseId),
+				),
+			)
+			.limit(1);
+
+		if (existingPublication.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateReleasePublicationSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// URL重複チェック（自分自身以外で）
+		if (parsed.data.url) {
+			const urlDuplicateCheck = await db
+				.select()
+				.from(releasePublications)
+				.where(eq(releasePublications.url, parsed.data.url))
+				.limit(1);
+
+			if (urlDuplicateCheck.length > 0 && urlDuplicateCheck[0]?.id !== id) {
+				return c.json({ error: "URL already exists" }, 409);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(releasePublications)
+			.set(parsed.data)
+			.where(eq(releasePublications.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/releases/:releaseId/publications/:id",
+		);
+	}
 });
 
 // 公開リンク削除
 releasePublicationsRouter.delete("/:releaseId/publications/:id", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const id = c.req.param("id");
+	try {
+		const releaseId = c.req.param("releaseId");
+		const id = c.req.param("id");
 
-	// 公開リンク存在チェック
-	const existingPublication = await db
-		.select()
-		.from(releasePublications)
-		.where(
-			and(
-				eq(releasePublications.id, id),
-				eq(releasePublications.releaseId, releaseId),
-			),
-		)
-		.limit(1);
+		// 公開リンク存在チェック
+		const existingPublication = await db
+			.select()
+			.from(releasePublications)
+			.where(
+				and(
+					eq(releasePublications.id, id),
+					eq(releasePublications.releaseId, releaseId),
+				),
+			)
+			.limit(1);
 
-	if (existingPublication.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existingPublication.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(releasePublications).where(eq(releasePublications.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/releases/:releaseId/publications/:id",
+		);
 	}
-
-	// 削除
-	await db.delete(releasePublications).where(eq(releasePublications.id, id));
-
-	return c.json({ success: true });
 });
 
 export { releasePublicationsRouter };

--- a/apps/server/src/routes/admin/releases/release-circles.ts
+++ b/apps/server/src/routes/admin/releases/release-circles.ts
@@ -10,234 +10,259 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const releaseCirclesRouter = new Hono<AdminContext>();
 
 // 作品の関連サークル一覧取得（position順）
 releaseCirclesRouter.get("/:releaseId/circles", async (c) => {
-	const releaseId = c.req.param("releaseId");
+	try {
+		const releaseId = c.req.param("releaseId");
 
-	// 作品存在チェック
-	const existingRelease = await db
-		.select()
-		.from(releases)
-		.where(eq(releases.id, releaseId))
-		.limit(1);
+		// 作品存在チェック
+		const existingRelease = await db
+			.select()
+			.from(releases)
+			.where(eq(releases.id, releaseId))
+			.limit(1);
 
-	if (existingRelease.length === 0) {
-		return c.json({ error: "Release not found" }, 404);
+		if (existingRelease.length === 0) {
+			return c.json({ error: "Release not found" }, 404);
+		}
+
+		// 関連サークル一覧取得（サークル情報を含む）
+		const releaseCirclesList = await db
+			.select({
+				releaseId: releaseCircles.releaseId,
+				circleId: releaseCircles.circleId,
+				participationType: releaseCircles.participationType,
+				position: releaseCircles.position,
+				circle: {
+					id: circles.id,
+					name: circles.name,
+					nameJa: circles.nameJa,
+					nameEn: circles.nameEn,
+				},
+			})
+			.from(releaseCircles)
+			.innerJoin(circles, eq(releaseCircles.circleId, circles.id))
+			.where(eq(releaseCircles.releaseId, releaseId))
+			.orderBy(releaseCircles.position);
+
+		return c.json(releaseCirclesList);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/releases/:releaseId/circles");
 	}
-
-	// 関連サークル一覧取得（サークル情報を含む）
-	const releaseCirclesList = await db
-		.select({
-			releaseId: releaseCircles.releaseId,
-			circleId: releaseCircles.circleId,
-			participationType: releaseCircles.participationType,
-			position: releaseCircles.position,
-			circle: {
-				id: circles.id,
-				name: circles.name,
-				nameJa: circles.nameJa,
-				nameEn: circles.nameEn,
-			},
-		})
-		.from(releaseCircles)
-		.innerJoin(circles, eq(releaseCircles.circleId, circles.id))
-		.where(eq(releaseCircles.releaseId, releaseId))
-		.orderBy(releaseCircles.position);
-
-	return c.json(releaseCirclesList);
 });
 
 // サークル関連付け追加
 releaseCirclesRouter.post("/:releaseId/circles", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const body = await c.req.json();
+	try {
+		const releaseId = c.req.param("releaseId");
+		const body = await c.req.json();
 
-	// 作品存在チェック
-	const existingRelease = await db
-		.select()
-		.from(releases)
-		.where(eq(releases.id, releaseId))
-		.limit(1);
-
-	if (existingRelease.length === 0) {
-		return c.json({ error: "Release not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = insertReleaseCircleSchema.safeParse({
-		...body,
-		releaseId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// サークル存在チェック
-	const existingCircle = await db
-		.select()
-		.from(circles)
-		.where(eq(circles.id, parsed.data.circleId))
-		.limit(1);
-
-	if (existingCircle.length === 0) {
-		return c.json({ error: "Circle not found" }, 404);
-	}
-
-	// 重複チェック（同一作品・同一サークル・同一参加形態）
-	const existingAssociation = await db
-		.select()
-		.from(releaseCircles)
-		.where(
-			and(
-				eq(releaseCircles.releaseId, releaseId),
-				eq(releaseCircles.circleId, parsed.data.circleId),
-				eq(releaseCircles.participationType, parsed.data.participationType),
-			),
-		)
-		.limit(1);
-
-	if (existingAssociation.length > 0) {
-		return c.json({ error: "Association already exists" }, 409);
-	}
-
-	// positionが未指定の場合、最大値+1を設定
-	let position = parsed.data.position;
-	if (position === undefined) {
-		const maxPositionResult = await db
-			.select({ maxPos: releaseCircles.position })
-			.from(releaseCircles)
-			.where(eq(releaseCircles.releaseId, releaseId))
-			.orderBy(releaseCircles.position)
+		// 作品存在チェック
+		const existingRelease = await db
+			.select()
+			.from(releases)
+			.where(eq(releases.id, releaseId))
 			.limit(1);
 
-		const maxPos = maxPositionResult[0]?.maxPos ?? 0;
-		position = (maxPos ?? 0) + 1;
+		if (existingRelease.length === 0) {
+			return c.json({ error: "Release not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = insertReleaseCircleSchema.safeParse({
+			...body,
+			releaseId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// サークル存在チェック
+		const existingCircle = await db
+			.select()
+			.from(circles)
+			.where(eq(circles.id, parsed.data.circleId))
+			.limit(1);
+
+		if (existingCircle.length === 0) {
+			return c.json({ error: "Circle not found" }, 404);
+		}
+
+		// 重複チェック（同一作品・同一サークル・同一参加形態）
+		const existingAssociation = await db
+			.select()
+			.from(releaseCircles)
+			.where(
+				and(
+					eq(releaseCircles.releaseId, releaseId),
+					eq(releaseCircles.circleId, parsed.data.circleId),
+					eq(releaseCircles.participationType, parsed.data.participationType),
+				),
+			)
+			.limit(1);
+
+		if (existingAssociation.length > 0) {
+			return c.json({ error: "Association already exists" }, 409);
+		}
+
+		// positionが未指定の場合、最大値+1を設定
+		let position = parsed.data.position;
+		if (position === undefined) {
+			const maxPositionResult = await db
+				.select({ maxPos: releaseCircles.position })
+				.from(releaseCircles)
+				.where(eq(releaseCircles.releaseId, releaseId))
+				.orderBy(releaseCircles.position)
+				.limit(1);
+
+			const maxPos = maxPositionResult[0]?.maxPos ?? 0;
+			position = (maxPos ?? 0) + 1;
+		}
+
+		// 作成
+		const result = await db
+			.insert(releaseCircles)
+			.values({
+				...parsed.data,
+				position,
+			})
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/releases/:releaseId/circles");
 	}
-
-	// 作成
-	const result = await db
-		.insert(releaseCircles)
-		.values({
-			...parsed.data,
-			position,
-		})
-		.returning();
-
-	return c.json(result[0], 201);
 });
 
 // 関連付け更新（参加形態・順序）
 releaseCirclesRouter.patch("/:releaseId/circles/:circleId", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const circleId = c.req.param("circleId");
-	const participationType = c.req.query("participationType");
-	const body = await c.req.json();
+	try {
+		const releaseId = c.req.param("releaseId");
+		const circleId = c.req.param("circleId");
+		const participationType = c.req.query("participationType");
+		const body = await c.req.json();
 
-	// 参加形態が指定されていない場合はエラー
-	if (!participationType) {
-		return c.json(
-			{ error: "participationType query parameter is required" },
-			400,
+		// 参加形態が指定されていない場合はエラー
+		if (!participationType) {
+			return c.json(
+				{ error: "participationType query parameter is required" },
+				400,
+			);
+		}
+
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(releaseCircles)
+			.where(
+				and(
+					eq(releaseCircles.releaseId, releaseId),
+					eq(releaseCircles.circleId, circleId),
+					eq(releaseCircles.participationType, participationType),
+				),
+			)
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateReleaseCircleSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 更新
+		const result = await db
+			.update(releaseCircles)
+			.set(parsed.data)
+			.where(
+				and(
+					eq(releaseCircles.releaseId, releaseId),
+					eq(releaseCircles.circleId, circleId),
+					eq(releaseCircles.participationType, participationType),
+				),
+			)
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PATCH /admin/releases/:releaseId/circles/:circleId",
 		);
 	}
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(releaseCircles)
-		.where(
-			and(
-				eq(releaseCircles.releaseId, releaseId),
-				eq(releaseCircles.circleId, circleId),
-				eq(releaseCircles.participationType, participationType),
-			),
-		)
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateReleaseCircleSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 更新
-	const result = await db
-		.update(releaseCircles)
-		.set(parsed.data)
-		.where(
-			and(
-				eq(releaseCircles.releaseId, releaseId),
-				eq(releaseCircles.circleId, circleId),
-				eq(releaseCircles.participationType, participationType),
-			),
-		)
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // 関連付け解除
 releaseCirclesRouter.delete("/:releaseId/circles/:circleId", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const circleId = c.req.param("circleId");
-	const participationType = c.req.query("participationType");
+	try {
+		const releaseId = c.req.param("releaseId");
+		const circleId = c.req.param("circleId");
+		const participationType = c.req.query("participationType");
 
-	// 参加形態が指定されていない場合はエラー
-	if (!participationType) {
-		return c.json(
-			{ error: "participationType query parameter is required" },
-			400,
+		// 参加形態が指定されていない場合はエラー
+		if (!participationType) {
+			return c.json(
+				{ error: "participationType query parameter is required" },
+				400,
+			);
+		}
+
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(releaseCircles)
+			.where(
+				and(
+					eq(releaseCircles.releaseId, releaseId),
+					eq(releaseCircles.circleId, circleId),
+					eq(releaseCircles.participationType, participationType),
+				),
+			)
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db
+			.delete(releaseCircles)
+			.where(
+				and(
+					eq(releaseCircles.releaseId, releaseId),
+					eq(releaseCircles.circleId, circleId),
+					eq(releaseCircles.participationType, participationType),
+				),
+			);
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/releases/:releaseId/circles/:circleId",
 		);
 	}
-
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(releaseCircles)
-		.where(
-			and(
-				eq(releaseCircles.releaseId, releaseId),
-				eq(releaseCircles.circleId, circleId),
-				eq(releaseCircles.participationType, participationType),
-			),
-		)
-		.limit(1);
-
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// 削除
-	await db
-		.delete(releaseCircles)
-		.where(
-			and(
-				eq(releaseCircles.releaseId, releaseId),
-				eq(releaseCircles.circleId, circleId),
-				eq(releaseCircles.participationType, participationType),
-			),
-		);
-
-	return c.json({ success: true });
 });
 
 export { releaseCirclesRouter };

--- a/apps/server/src/routes/admin/releases/track-credit-roles.ts
+++ b/apps/server/src/routes/admin/releases/track-credit-roles.ts
@@ -10,6 +10,7 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const trackCreditRolesRouter = new Hono<AdminContext>();
 
@@ -17,101 +18,109 @@ const trackCreditRolesRouter = new Hono<AdminContext>();
 trackCreditRolesRouter.post(
 	"/:releaseId/tracks/:trackId/credits/:creditId/roles",
 	async (c) => {
-		const releaseId = c.req.param("releaseId");
-		const trackId = c.req.param("trackId");
-		const creditId = c.req.param("creditId");
-		const body = await c.req.json();
+		try {
+			const releaseId = c.req.param("releaseId");
+			const trackId = c.req.param("trackId");
+			const creditId = c.req.param("creditId");
+			const body = await c.req.json();
 
-		// クレジット存在チェック（トラック・リリースとの関連確認含む）
-		const existingCredit = await db
-			.select()
-			.from(trackCredits)
-			.innerJoin(tracks, eq(trackCredits.trackId, tracks.id))
-			.where(
-				and(
-					eq(trackCredits.id, creditId),
-					eq(trackCredits.trackId, trackId),
-					eq(tracks.releaseId, releaseId),
-				),
-			)
-			.limit(1);
+			// クレジット存在チェック（トラック・リリースとの関連確認含む）
+			const existingCredit = await db
+				.select()
+				.from(trackCredits)
+				.innerJoin(tracks, eq(trackCredits.trackId, tracks.id))
+				.where(
+					and(
+						eq(trackCredits.id, creditId),
+						eq(trackCredits.trackId, trackId),
+						eq(tracks.releaseId, releaseId),
+					),
+				)
+				.limit(1);
 
-		if (existingCredit.length === 0) {
-			return c.json({ error: "Credit not found" }, 404);
-		}
+			if (existingCredit.length === 0) {
+				return c.json({ error: "Credit not found" }, 404);
+			}
 
-		// 役割マスター存在チェック
-		const existingRole = await db
-			.select()
-			.from(creditRoles)
-			.where(eq(creditRoles.code, body.roleCode))
-			.limit(1);
+			// 役割マスター存在チェック
+			const existingRole = await db
+				.select()
+				.from(creditRoles)
+				.where(eq(creditRoles.code, body.roleCode))
+				.limit(1);
 
-		if (existingRole.length === 0) {
-			return c.json({ error: "Role not found in master data" }, 400);
-		}
+			if (existingRole.length === 0) {
+				return c.json({ error: "Role not found in master data" }, 400);
+			}
 
-		// バリデーション
-		const parsed = insertTrackCreditRoleSchema.safeParse({
-			...body,
-			trackCreditId: creditId,
-		});
-		if (!parsed.success) {
-			return c.json(
-				{
-					error: "Validation failed",
-					details: parsed.error.flatten().fieldErrors,
-				},
-				400,
+			// バリデーション
+			const parsed = insertTrackCreditRoleSchema.safeParse({
+				...body,
+				trackCreditId: creditId,
+			});
+			if (!parsed.success) {
+				return c.json(
+					{
+						error: "Validation failed",
+						details: parsed.error.flatten().fieldErrors,
+					},
+					400,
+				);
+			}
+
+			// 重複チェック（同一クレジット・同一役割・同一表示順）
+			const existingRoleAssignment = await db
+				.select()
+				.from(trackCreditRoles)
+				.where(
+					and(
+						eq(trackCreditRoles.trackCreditId, creditId),
+						eq(trackCreditRoles.roleCode, parsed.data.roleCode),
+						eq(trackCreditRoles.rolePosition, parsed.data.rolePosition),
+					),
+				)
+				.limit(1);
+
+			if (existingRoleAssignment.length > 0) {
+				return c.json(
+					{
+						error:
+							"This role with the same position already exists for this credit",
+					},
+					409,
+				);
+			}
+
+			// 作成
+			await db.insert(trackCreditRoles).values(parsed.data);
+
+			// 役割情報を含めて返却
+			const roleWithInfo = await db
+				.select({
+					trackCreditId: trackCreditRoles.trackCreditId,
+					roleCode: trackCreditRoles.roleCode,
+					rolePosition: trackCreditRoles.rolePosition,
+					role: creditRoles,
+				})
+				.from(trackCreditRoles)
+				.leftJoin(creditRoles, eq(trackCreditRoles.roleCode, creditRoles.code))
+				.where(
+					and(
+						eq(trackCreditRoles.trackCreditId, creditId),
+						eq(trackCreditRoles.roleCode, parsed.data.roleCode),
+						eq(trackCreditRoles.rolePosition, parsed.data.rolePosition),
+					),
+				)
+				.limit(1);
+
+			return c.json(roleWithInfo[0], 201);
+		} catch (error) {
+			return handleDbError(
+				c,
+				error,
+				"POST /admin/releases/:releaseId/tracks/:trackId/credits/:creditId/roles",
 			);
 		}
-
-		// 重複チェック（同一クレジット・同一役割・同一表示順）
-		const existingRoleAssignment = await db
-			.select()
-			.from(trackCreditRoles)
-			.where(
-				and(
-					eq(trackCreditRoles.trackCreditId, creditId),
-					eq(trackCreditRoles.roleCode, parsed.data.roleCode),
-					eq(trackCreditRoles.rolePosition, parsed.data.rolePosition),
-				),
-			)
-			.limit(1);
-
-		if (existingRoleAssignment.length > 0) {
-			return c.json(
-				{
-					error:
-						"This role with the same position already exists for this credit",
-				},
-				409,
-			);
-		}
-
-		// 作成
-		await db.insert(trackCreditRoles).values(parsed.data);
-
-		// 役割情報を含めて返却
-		const roleWithInfo = await db
-			.select({
-				trackCreditId: trackCreditRoles.trackCreditId,
-				roleCode: trackCreditRoles.roleCode,
-				rolePosition: trackCreditRoles.rolePosition,
-				role: creditRoles,
-			})
-			.from(trackCreditRoles)
-			.leftJoin(creditRoles, eq(trackCreditRoles.roleCode, creditRoles.code))
-			.where(
-				and(
-					eq(trackCreditRoles.trackCreditId, creditId),
-					eq(trackCreditRoles.roleCode, parsed.data.roleCode),
-					eq(trackCreditRoles.rolePosition, parsed.data.rolePosition),
-				),
-			)
-			.limit(1);
-
-		return c.json(roleWithInfo[0], 201);
 	},
 );
 
@@ -119,63 +128,71 @@ trackCreditRolesRouter.post(
 trackCreditRolesRouter.delete(
 	"/:releaseId/tracks/:trackId/credits/:creditId/roles/:roleCode/:rolePosition",
 	async (c) => {
-		const releaseId = c.req.param("releaseId");
-		const trackId = c.req.param("trackId");
-		const creditId = c.req.param("creditId");
-		const roleCode = c.req.param("roleCode");
-		const rolePosition = Number.parseInt(c.req.param("rolePosition"), 10);
+		try {
+			const releaseId = c.req.param("releaseId");
+			const trackId = c.req.param("trackId");
+			const creditId = c.req.param("creditId");
+			const roleCode = c.req.param("roleCode");
+			const rolePosition = Number.parseInt(c.req.param("rolePosition"), 10);
 
-		if (Number.isNaN(rolePosition)) {
-			return c.json({ error: "Invalid role position" }, 400);
-		}
+			if (Number.isNaN(rolePosition)) {
+				return c.json({ error: "Invalid role position" }, 400);
+			}
 
-		// クレジット存在チェック（トラック・リリースとの関連確認含む）
-		const existingCredit = await db
-			.select()
-			.from(trackCredits)
-			.innerJoin(tracks, eq(trackCredits.trackId, tracks.id))
-			.where(
-				and(
-					eq(trackCredits.id, creditId),
-					eq(trackCredits.trackId, trackId),
-					eq(tracks.releaseId, releaseId),
-				),
-			)
-			.limit(1);
+			// クレジット存在チェック（トラック・リリースとの関連確認含む）
+			const existingCredit = await db
+				.select()
+				.from(trackCredits)
+				.innerJoin(tracks, eq(trackCredits.trackId, tracks.id))
+				.where(
+					and(
+						eq(trackCredits.id, creditId),
+						eq(trackCredits.trackId, trackId),
+						eq(tracks.releaseId, releaseId),
+					),
+				)
+				.limit(1);
 
-		if (existingCredit.length === 0) {
-			return c.json({ error: "Credit not found" }, 404);
-		}
+			if (existingCredit.length === 0) {
+				return c.json({ error: "Credit not found" }, 404);
+			}
 
-		// 役割存在チェック
-		const existingRoleAssignment = await db
-			.select()
-			.from(trackCreditRoles)
-			.where(
-				and(
-					eq(trackCreditRoles.trackCreditId, creditId),
-					eq(trackCreditRoles.roleCode, roleCode),
-					eq(trackCreditRoles.rolePosition, rolePosition),
-				),
-			)
-			.limit(1);
+			// 役割存在チェック
+			const existingRoleAssignment = await db
+				.select()
+				.from(trackCreditRoles)
+				.where(
+					and(
+						eq(trackCreditRoles.trackCreditId, creditId),
+						eq(trackCreditRoles.roleCode, roleCode),
+						eq(trackCreditRoles.rolePosition, rolePosition),
+					),
+				)
+				.limit(1);
 
-		if (existingRoleAssignment.length === 0) {
-			return c.json({ error: "Role not found" }, 404);
-		}
+			if (existingRoleAssignment.length === 0) {
+				return c.json({ error: "Role not found" }, 404);
+			}
 
-		// 削除
-		await db
-			.delete(trackCreditRoles)
-			.where(
-				and(
-					eq(trackCreditRoles.trackCreditId, creditId),
-					eq(trackCreditRoles.roleCode, roleCode),
-					eq(trackCreditRoles.rolePosition, rolePosition),
-				),
+			// 削除
+			await db
+				.delete(trackCreditRoles)
+				.where(
+					and(
+						eq(trackCreditRoles.trackCreditId, creditId),
+						eq(trackCreditRoles.roleCode, roleCode),
+						eq(trackCreditRoles.rolePosition, rolePosition),
+					),
+				);
+
+			return c.json({ success: true });
+		} catch (error) {
+			return handleDbError(
+				c,
+				error,
+				"DELETE /admin/releases/:releaseId/tracks/:trackId/credits/:creditId/roles/:roleCode/:rolePosition",
 			);
-
-		return c.json({ success: true });
+		}
 	},
 );
 

--- a/apps/server/src/routes/admin/releases/track-credits.ts
+++ b/apps/server/src/routes/admin/releases/track-credits.ts
@@ -16,261 +16,115 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const trackCreditsRouter = new Hono<AdminContext>();
 
 // トラックのクレジット一覧取得（役割情報を含む）
 trackCreditsRouter.get("/:releaseId/tracks/:trackId/credits", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const trackId = c.req.param("trackId");
+	try {
+		const releaseId = c.req.param("releaseId");
+		const trackId = c.req.param("trackId");
 
-	// トラック存在チェック
-	const existingTrack = await db
-		.select()
-		.from(tracks)
-		.where(and(eq(tracks.id, trackId), eq(tracks.releaseId, releaseId)))
-		.limit(1);
+		// トラック存在チェック
+		const existingTrack = await db
+			.select()
+			.from(tracks)
+			.where(and(eq(tracks.id, trackId), eq(tracks.releaseId, releaseId)))
+			.limit(1);
 
-	if (existingTrack.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
+		if (existingTrack.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
+		}
+
+		// クレジット一覧取得（アーティスト・別名義・役割情報を結合）
+		const credits = await db
+			.select({
+				credit: trackCredits,
+				artist: artists,
+				artistAlias: artistAliases,
+			})
+			.from(trackCredits)
+			.leftJoin(artists, eq(trackCredits.artistId, artists.id))
+			.leftJoin(artistAliases, eq(trackCredits.artistAliasId, artistAliases.id))
+			.where(eq(trackCredits.trackId, trackId))
+			.orderBy(trackCredits.creditPosition);
+
+		// 各クレジットの役割を取得
+		const creditsWithRoles = await Promise.all(
+			credits.map(async (row) => {
+				const roles = await db
+					.select({
+						trackCreditId: trackCreditRoles.trackCreditId,
+						roleCode: trackCreditRoles.roleCode,
+						rolePosition: trackCreditRoles.rolePosition,
+						role: creditRoles,
+					})
+					.from(trackCreditRoles)
+					.leftJoin(
+						creditRoles,
+						eq(trackCreditRoles.roleCode, creditRoles.code),
+					)
+					.where(eq(trackCreditRoles.trackCreditId, row.credit.id))
+					.orderBy(trackCreditRoles.rolePosition);
+
+				return {
+					...row.credit,
+					artist: row.artist,
+					artistAlias: row.artistAlias,
+					roles,
+				};
+			}),
+		);
+
+		return c.json(creditsWithRoles);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"GET /admin/releases/:releaseId/tracks/:trackId/credits",
+		);
 	}
-
-	// クレジット一覧取得（アーティスト・別名義・役割情報を結合）
-	const credits = await db
-		.select({
-			credit: trackCredits,
-			artist: artists,
-			artistAlias: artistAliases,
-		})
-		.from(trackCredits)
-		.leftJoin(artists, eq(trackCredits.artistId, artists.id))
-		.leftJoin(artistAliases, eq(trackCredits.artistAliasId, artistAliases.id))
-		.where(eq(trackCredits.trackId, trackId))
-		.orderBy(trackCredits.creditPosition);
-
-	// 各クレジットの役割を取得
-	const creditsWithRoles = await Promise.all(
-		credits.map(async (row) => {
-			const roles = await db
-				.select({
-					trackCreditId: trackCreditRoles.trackCreditId,
-					roleCode: trackCreditRoles.roleCode,
-					rolePosition: trackCreditRoles.rolePosition,
-					role: creditRoles,
-				})
-				.from(trackCreditRoles)
-				.leftJoin(creditRoles, eq(trackCreditRoles.roleCode, creditRoles.code))
-				.where(eq(trackCreditRoles.trackCreditId, row.credit.id))
-				.orderBy(trackCreditRoles.rolePosition);
-
-			return {
-				...row.credit,
-				artist: row.artist,
-				artistAlias: row.artistAlias,
-				roles,
-			};
-		}),
-	);
-
-	return c.json(creditsWithRoles);
 });
 
 // クレジット追加
 trackCreditsRouter.post("/:releaseId/tracks/:trackId/credits", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const trackId = c.req.param("trackId");
-	const body = await c.req.json();
-
-	// トラック存在チェック
-	const existingTrack = await db
-		.select()
-		.from(tracks)
-		.where(and(eq(tracks.id, trackId), eq(tracks.releaseId, releaseId)))
-		.limit(1);
-
-	if (existingTrack.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
-	}
-
-	// アーティスト存在チェック
-	const existingArtist = await db
-		.select()
-		.from(artists)
-		.where(eq(artists.id, body.artistId))
-		.limit(1);
-
-	if (existingArtist.length === 0) {
-		return c.json({ error: "Artist not found" }, 404);
-	}
-
-	// 別名義存在チェック（指定された場合）
-	if (body.artistAliasId) {
-		const existingAlias = await db
-			.select()
-			.from(artistAliases)
-			.where(
-				and(
-					eq(artistAliases.id, body.artistAliasId),
-					eq(artistAliases.artistId, body.artistId),
-				),
-			)
-			.limit(1);
-
-		if (existingAlias.length === 0) {
-			return c.json(
-				{ error: "Artist alias not found or does not belong to the artist" },
-				404,
-			);
-		}
-	}
-
-	// バリデーション
-	const parsed = insertTrackCreditSchema.safeParse({
-		...body,
-		trackId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(trackCredits)
-		.where(eq(trackCredits.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// 同一アーティスト・同一別名義の重複チェック
-	let duplicateCheck: TrackCredit[];
-	if (parsed.data.artistAliasId) {
-		duplicateCheck = await db
-			.select()
-			.from(trackCredits)
-			.where(
-				and(
-					eq(trackCredits.trackId, trackId),
-					eq(trackCredits.artistId, parsed.data.artistId),
-					eq(trackCredits.artistAliasId, parsed.data.artistAliasId),
-				),
-			)
-			.limit(1);
-	} else {
-		duplicateCheck = await db
-			.select()
-			.from(trackCredits)
-			.where(
-				and(
-					eq(trackCredits.trackId, trackId),
-					eq(trackCredits.artistId, parsed.data.artistId),
-					isNull(trackCredits.artistAliasId),
-				),
-			)
-			.limit(1);
-	}
-
-	if (duplicateCheck.length > 0) {
-		return c.json(
-			{
-				error:
-					"Credit for this artist (with same alias) already exists on this track",
-			},
-			409,
-		);
-	}
-
-	// 作成
-	const result = await db.insert(trackCredits).values(parsed.data).returning();
-	const creditId = result[0]?.id;
-
-	// 役割の登録（rolesCodes が指定されている場合）
-	if (creditId && body.rolesCodes && Array.isArray(body.rolesCodes)) {
-		const rolesCodes = body.rolesCodes as string[];
-		if (rolesCodes.length > 0) {
-			// 役割マスター存在チェック
-			const existingRoles = await db
-				.select()
-				.from(creditRoles)
-				.where(inArray(creditRoles.code, rolesCodes));
-
-			const validRoleCodes = existingRoles.map((r) => r.code);
-
-			// 有効な役割のみ登録
-			const roleInserts = validRoleCodes.map((roleCode, index) => ({
-				trackCreditId: creditId,
-				roleCode,
-				rolePosition: index + 1,
-			}));
-
-			if (roleInserts.length > 0) {
-				await db.insert(trackCreditRoles).values(roleInserts);
-			}
-		}
-	}
-
-	return c.json(result[0], 201);
-});
-
-// クレジット更新
-trackCreditsRouter.put(
-	"/:releaseId/tracks/:trackId/credits/:creditId",
-	async (c) => {
+	try {
 		const releaseId = c.req.param("releaseId");
 		const trackId = c.req.param("trackId");
-		const creditId = c.req.param("creditId");
 		const body = await c.req.json();
 
-		// クレジット存在チェック（トラック・リリースとの関連確認含む）
-		const existingCredit = await db
+		// トラック存在チェック
+		const existingTrack = await db
 			.select()
-			.from(trackCredits)
-			.innerJoin(tracks, eq(trackCredits.trackId, tracks.id))
-			.where(
-				and(
-					eq(trackCredits.id, creditId),
-					eq(trackCredits.trackId, trackId),
-					eq(tracks.releaseId, releaseId),
-				),
-			)
+			.from(tracks)
+			.where(and(eq(tracks.id, trackId), eq(tracks.releaseId, releaseId)))
 			.limit(1);
 
-		if (existingCredit.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+		if (existingTrack.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
 		}
 
-		// アーティスト存在チェック（変更される場合）
-		if (body.artistId) {
-			const existingArtist = await db
-				.select()
-				.from(artists)
-				.where(eq(artists.id, body.artistId))
-				.limit(1);
+		// アーティスト存在チェック
+		const existingArtist = await db
+			.select()
+			.from(artists)
+			.where(eq(artists.id, body.artistId))
+			.limit(1);
 
-			if (existingArtist.length === 0) {
-				return c.json({ error: "Artist not found" }, 404);
-			}
+		if (existingArtist.length === 0) {
+			return c.json({ error: "Artist not found" }, 404);
 		}
 
-		// 別名義存在チェック（変更される場合）
-		if (body.artistAliasId !== undefined && body.artistAliasId !== null) {
-			const artistIdToCheck =
-				body.artistId || existingCredit[0]?.track_credits.artistId;
+		// 別名義存在チェック（指定された場合）
+		if (body.artistAliasId) {
 			const existingAlias = await db
 				.select()
 				.from(artistAliases)
 				.where(
 					and(
 						eq(artistAliases.id, body.artistAliasId),
-						eq(artistAliases.artistId, artistIdToCheck),
+						eq(artistAliases.artistId, body.artistId),
 					),
 				)
 				.limit(1);
@@ -284,7 +138,10 @@ trackCreditsRouter.put(
 		}
 
 		// バリデーション
-		const parsed = updateTrackCreditSchema.safeParse(body);
+		const parsed = insertTrackCreditSchema.safeParse({
+			...body,
+			trackId,
+		});
 		if (!parsed.success) {
 			return c.json(
 				{
@@ -295,68 +152,64 @@ trackCreditsRouter.put(
 			);
 		}
 
-		// 同一アーティスト・同一別名義の重複チェック（自身以外）
-		const currentCredit = existingCredit[0]?.track_credits;
-		const newArtistId = parsed.data.artistId ?? currentCredit?.artistId;
-		const newAliasId =
-			parsed.data.artistAliasId !== undefined
-				? parsed.data.artistAliasId
-				: currentCredit?.artistAliasId;
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(trackCredits)
+			.where(eq(trackCredits.id, parsed.data.id))
+			.limit(1);
 
-		if (newArtistId) {
-			let duplicateCheck: TrackCredit[];
-			if (newAliasId) {
-				duplicateCheck = await db
-					.select()
-					.from(trackCredits)
-					.where(
-						and(
-							eq(trackCredits.trackId, trackId),
-							eq(trackCredits.artistId, newArtistId),
-							eq(trackCredits.artistAliasId, newAliasId),
-						),
-					)
-					.limit(1);
-			} else {
-				duplicateCheck = await db
-					.select()
-					.from(trackCredits)
-					.where(
-						and(
-							eq(trackCredits.trackId, trackId),
-							eq(trackCredits.artistId, newArtistId),
-							isNull(trackCredits.artistAliasId),
-						),
-					)
-					.limit(1);
-			}
-
-			if (duplicateCheck.length > 0 && duplicateCheck[0]?.id !== creditId) {
-				return c.json(
-					{
-						error:
-							"Credit for this artist (with same alias) already exists on this track",
-					},
-					409,
-				);
-			}
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
 		}
 
-		// 更新
+		// 同一アーティスト・同一別名義の重複チェック
+		let duplicateCheck: TrackCredit[];
+		if (parsed.data.artistAliasId) {
+			duplicateCheck = await db
+				.select()
+				.from(trackCredits)
+				.where(
+					and(
+						eq(trackCredits.trackId, trackId),
+						eq(trackCredits.artistId, parsed.data.artistId),
+						eq(trackCredits.artistAliasId, parsed.data.artistAliasId),
+					),
+				)
+				.limit(1);
+		} else {
+			duplicateCheck = await db
+				.select()
+				.from(trackCredits)
+				.where(
+					and(
+						eq(trackCredits.trackId, trackId),
+						eq(trackCredits.artistId, parsed.data.artistId),
+						isNull(trackCredits.artistAliasId),
+					),
+				)
+				.limit(1);
+		}
+
+		if (duplicateCheck.length > 0) {
+			return c.json(
+				{
+					error:
+						"Credit for this artist (with same alias) already exists on this track",
+				},
+				409,
+			);
+		}
+
+		// 作成
 		const result = await db
-			.update(trackCredits)
-			.set(parsed.data)
-			.where(eq(trackCredits.id, creditId))
+			.insert(trackCredits)
+			.values(parsed.data)
 			.returning();
+		const creditId = result[0]?.id;
 
-		// 役割の更新（rolesCodes が指定されている場合）
-		if (body.rolesCodes !== undefined && Array.isArray(body.rolesCodes)) {
-			// 既存の役割を削除
-			await db
-				.delete(trackCreditRoles)
-				.where(eq(trackCreditRoles.trackCreditId, creditId));
-
-			// 新しい役割を登録
+		// 役割の登録（rolesCodes が指定されている場合）
+		if (creditId && body.rolesCodes && Array.isArray(body.rolesCodes)) {
 			const rolesCodes = body.rolesCodes as string[];
 			if (rolesCodes.length > 0) {
 				// 役割マスター存在チェック
@@ -380,7 +233,187 @@ trackCreditsRouter.put(
 			}
 		}
 
-		return c.json(result[0]);
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"POST /admin/releases/:releaseId/tracks/:trackId/credits",
+		);
+	}
+});
+
+// クレジット更新
+trackCreditsRouter.put(
+	"/:releaseId/tracks/:trackId/credits/:creditId",
+	async (c) => {
+		try {
+			const releaseId = c.req.param("releaseId");
+			const trackId = c.req.param("trackId");
+			const creditId = c.req.param("creditId");
+			const body = await c.req.json();
+
+			// クレジット存在チェック（トラック・リリースとの関連確認含む）
+			const existingCredit = await db
+				.select()
+				.from(trackCredits)
+				.innerJoin(tracks, eq(trackCredits.trackId, tracks.id))
+				.where(
+					and(
+						eq(trackCredits.id, creditId),
+						eq(trackCredits.trackId, trackId),
+						eq(tracks.releaseId, releaseId),
+					),
+				)
+				.limit(1);
+
+			if (existingCredit.length === 0) {
+				return c.json({ error: "Not found" }, 404);
+			}
+
+			// アーティスト存在チェック（変更される場合）
+			if (body.artistId) {
+				const existingArtist = await db
+					.select()
+					.from(artists)
+					.where(eq(artists.id, body.artistId))
+					.limit(1);
+
+				if (existingArtist.length === 0) {
+					return c.json({ error: "Artist not found" }, 404);
+				}
+			}
+
+			// 別名義存在チェック（変更される場合）
+			if (body.artistAliasId !== undefined && body.artistAliasId !== null) {
+				const artistIdToCheck =
+					body.artistId || existingCredit[0]?.track_credits.artistId;
+				const existingAlias = await db
+					.select()
+					.from(artistAliases)
+					.where(
+						and(
+							eq(artistAliases.id, body.artistAliasId),
+							eq(artistAliases.artistId, artistIdToCheck),
+						),
+					)
+					.limit(1);
+
+				if (existingAlias.length === 0) {
+					return c.json(
+						{
+							error: "Artist alias not found or does not belong to the artist",
+						},
+						404,
+					);
+				}
+			}
+
+			// バリデーション
+			const parsed = updateTrackCreditSchema.safeParse(body);
+			if (!parsed.success) {
+				return c.json(
+					{
+						error: "Validation failed",
+						details: parsed.error.flatten().fieldErrors,
+					},
+					400,
+				);
+			}
+
+			// 同一アーティスト・同一別名義の重複チェック（自身以外）
+			const currentCredit = existingCredit[0]?.track_credits;
+			const newArtistId = parsed.data.artistId ?? currentCredit?.artistId;
+			const newAliasId =
+				parsed.data.artistAliasId !== undefined
+					? parsed.data.artistAliasId
+					: currentCredit?.artistAliasId;
+
+			if (newArtistId) {
+				let duplicateCheck: TrackCredit[];
+				if (newAliasId) {
+					duplicateCheck = await db
+						.select()
+						.from(trackCredits)
+						.where(
+							and(
+								eq(trackCredits.trackId, trackId),
+								eq(trackCredits.artistId, newArtistId),
+								eq(trackCredits.artistAliasId, newAliasId),
+							),
+						)
+						.limit(1);
+				} else {
+					duplicateCheck = await db
+						.select()
+						.from(trackCredits)
+						.where(
+							and(
+								eq(trackCredits.trackId, trackId),
+								eq(trackCredits.artistId, newArtistId),
+								isNull(trackCredits.artistAliasId),
+							),
+						)
+						.limit(1);
+				}
+
+				if (duplicateCheck.length > 0 && duplicateCheck[0]?.id !== creditId) {
+					return c.json(
+						{
+							error:
+								"Credit for this artist (with same alias) already exists on this track",
+						},
+						409,
+					);
+				}
+			}
+
+			// 更新
+			const result = await db
+				.update(trackCredits)
+				.set(parsed.data)
+				.where(eq(trackCredits.id, creditId))
+				.returning();
+
+			// 役割の更新（rolesCodes が指定されている場合）
+			if (body.rolesCodes !== undefined && Array.isArray(body.rolesCodes)) {
+				// 既存の役割を削除
+				await db
+					.delete(trackCreditRoles)
+					.where(eq(trackCreditRoles.trackCreditId, creditId));
+
+				// 新しい役割を登録
+				const rolesCodes = body.rolesCodes as string[];
+				if (rolesCodes.length > 0) {
+					// 役割マスター存在チェック
+					const existingRoles = await db
+						.select()
+						.from(creditRoles)
+						.where(inArray(creditRoles.code, rolesCodes));
+
+					const validRoleCodes = existingRoles.map((r) => r.code);
+
+					// 有効な役割のみ登録
+					const roleInserts = validRoleCodes.map((roleCode, index) => ({
+						trackCreditId: creditId,
+						roleCode,
+						rolePosition: index + 1,
+					}));
+
+					if (roleInserts.length > 0) {
+						await db.insert(trackCreditRoles).values(roleInserts);
+					}
+				}
+			}
+
+			return c.json(result[0]);
+		} catch (error) {
+			return handleDbError(
+				c,
+				error,
+				"PUT /admin/releases/:releaseId/tracks/:trackId/credits/:creditId",
+			);
+		}
 	},
 );
 
@@ -388,32 +421,40 @@ trackCreditsRouter.put(
 trackCreditsRouter.delete(
 	"/:releaseId/tracks/:trackId/credits/:creditId",
 	async (c) => {
-		const releaseId = c.req.param("releaseId");
-		const trackId = c.req.param("trackId");
-		const creditId = c.req.param("creditId");
+		try {
+			const releaseId = c.req.param("releaseId");
+			const trackId = c.req.param("trackId");
+			const creditId = c.req.param("creditId");
 
-		// クレジット存在チェック（トラック・リリースとの関連確認含む）
-		const existingCredit = await db
-			.select()
-			.from(trackCredits)
-			.innerJoin(tracks, eq(trackCredits.trackId, tracks.id))
-			.where(
-				and(
-					eq(trackCredits.id, creditId),
-					eq(trackCredits.trackId, trackId),
-					eq(tracks.releaseId, releaseId),
-				),
-			)
-			.limit(1);
+			// クレジット存在チェック（トラック・リリースとの関連確認含む）
+			const existingCredit = await db
+				.select()
+				.from(trackCredits)
+				.innerJoin(tracks, eq(trackCredits.trackId, tracks.id))
+				.where(
+					and(
+						eq(trackCredits.id, creditId),
+						eq(trackCredits.trackId, trackId),
+						eq(tracks.releaseId, releaseId),
+					),
+				)
+				.limit(1);
 
-		if (existingCredit.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			if (existingCredit.length === 0) {
+				return c.json({ error: "Not found" }, 404);
+			}
+
+			// 削除（役割はCASCADEで自動削除）
+			await db.delete(trackCredits).where(eq(trackCredits.id, creditId));
+
+			return c.json({ success: true });
+		} catch (error) {
+			return handleDbError(
+				c,
+				error,
+				"DELETE /admin/releases/:releaseId/tracks/:trackId/credits/:creditId",
+			);
 		}
-
-		// 削除（役割はCASCADEで自動削除）
-		await db.delete(trackCredits).where(eq(trackCredits.id, creditId));
-
-		return c.json({ success: true });
 	},
 );
 

--- a/apps/server/src/routes/admin/releases/tracks.ts
+++ b/apps/server/src/routes/admin/releases/tracks.ts
@@ -17,485 +17,521 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const tracksRouter = new Hono<AdminContext>();
 
 // リリースのトラック一覧取得（ディスク・トラック番号順）
 tracksRouter.get("/:releaseId/tracks", async (c) => {
-	const releaseId = c.req.param("releaseId");
+	try {
+		const releaseId = c.req.param("releaseId");
 
-	// リリース存在チェック
-	const existingRelease = await db
-		.select()
-		.from(releases)
-		.where(eq(releases.id, releaseId))
-		.limit(1);
-
-	if (existingRelease.length === 0) {
-		return c.json({ error: "Release not found" }, 404);
-	}
-
-	// トラック一覧取得（クレジット数を含む）
-	const releaseTracks = await db
-		.select({
-			track: tracks,
-			creditCount: db.$count(trackCredits, eq(trackCredits.trackId, tracks.id)),
-		})
-		.from(tracks)
-		.where(eq(tracks.releaseId, releaseId))
-		.orderBy(tracks.discId, tracks.trackNumber);
-
-	// 全トラックIDを取得
-	const trackIds = releaseTracks.map((row) => row.track.id);
-
-	// 役割別クレジット取得用のヘルパー
-	const getCreditsByRole = async (roleCode: string) => {
-		if (trackIds.length === 0) return new Map<string, string[]>();
-
-		const credits = await db
-			.select({
-				trackId: trackCredits.trackId,
-				creditName: trackCredits.creditName,
-			})
-			.from(trackCredits)
-			.innerJoin(
-				trackCreditRoles,
-				eq(trackCredits.id, trackCreditRoles.trackCreditId),
-			)
-			.where(
-				and(
-					inArray(trackCredits.trackId, trackIds),
-					eq(trackCreditRoles.roleCode, roleCode),
-				),
-			)
-			.orderBy(trackCredits.creditPosition);
-
-		const map = new Map<string, string[]>();
-		for (const c of credits) {
-			const existing = map.get(c.trackId) ?? [];
-			existing.push(c.creditName);
-			map.set(c.trackId, existing);
-		}
-		return map;
-	};
-
-	// 原曲取得
-	const getOriginalSongs = async () => {
-		if (trackIds.length === 0) return new Map<string, string[]>();
-
-		const songs = await db
-			.select({
-				trackId: trackOfficialSongs.trackId,
-				songName: officialSongs.name,
-				customSongName: trackOfficialSongs.customSongName,
-			})
-			.from(trackOfficialSongs)
-			.leftJoin(
-				officialSongs,
-				eq(trackOfficialSongs.officialSongId, officialSongs.id),
-			)
-			.where(inArray(trackOfficialSongs.trackId, trackIds))
-			.orderBy(trackOfficialSongs.partPosition);
-
-		const map = new Map<string, string[]>();
-		for (const s of songs) {
-			const name = s.songName ?? s.customSongName ?? "";
-			if (name) {
-				const existing = map.get(s.trackId) ?? [];
-				existing.push(name);
-				map.set(s.trackId, existing);
-			}
-		}
-		return map;
-	};
-
-	// 並列で取得
-	const [vocalistsMap, arrangersMap, lyricistsMap, originalSongsMap] =
-		await Promise.all([
-			getCreditsByRole("vocalist"),
-			getCreditsByRole("arranger"),
-			getCreditsByRole("lyricist"),
-			getOriginalSongs(),
-		]);
-
-	// レスポンス形式に変換
-	const result = releaseTracks.map((row) => ({
-		...row.track,
-		creditCount: row.creditCount,
-		vocalists: vocalistsMap.get(row.track.id)?.join(" / ") ?? null,
-		arrangers: arrangersMap.get(row.track.id)?.join(" / ") ?? null,
-		lyricists: lyricistsMap.get(row.track.id)?.join(" / ") ?? null,
-		originalSongs: originalSongsMap.get(row.track.id)?.join(" / ") ?? null,
-	}));
-
-	return c.json(result);
-});
-
-// トラック追加
-tracksRouter.post("/:releaseId/tracks", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const body = await c.req.json();
-
-	// バリデーション（releaseIdはoptionalなので、bodyに含まれていればそれを使用、なければパスパラメータ）
-	const parsed = insertTrackSchema.safeParse({
-		...body,
-		releaseId: body.releaseId || releaseId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// リリース存在チェック（releaseIdが指定されている場合のみ）
-	if (parsed.data.releaseId) {
+		// リリース存在チェック
 		const existingRelease = await db
 			.select()
 			.from(releases)
-			.where(eq(releases.id, parsed.data.releaseId))
+			.where(eq(releases.id, releaseId))
 			.limit(1);
 
 		if (existingRelease.length === 0) {
 			return c.json({ error: "Release not found" }, 404);
 		}
-	}
 
-	// ディスク存在チェック（指定された場合）
-	if (parsed.data.discId) {
-		if (!parsed.data.releaseId) {
-			return c.json({ error: "Disc cannot be set without a release" }, 400);
-		}
-		const existingDisc = await db
-			.select()
-			.from(discs)
-			.where(
-				and(
-					eq(discs.id, parsed.data.discId),
-					eq(discs.releaseId, parsed.data.releaseId),
+		// トラック一覧取得（クレジット数を含む）
+		const releaseTracks = await db
+			.select({
+				track: tracks,
+				creditCount: db.$count(
+					trackCredits,
+					eq(trackCredits.trackId, tracks.id),
 				),
-			)
-			.limit(1);
-
-		if (existingDisc.length === 0) {
-			return c.json({ error: "Disc not found" }, 404);
-		}
-	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(tracks)
-		.where(eq(tracks.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// トラック番号重複チェック（ディスク有無で分岐）
-	const discId = parsed.data.discId;
-	let duplicateCheck: Track[];
-
-	if (discId) {
-		// ディスク内でトラック番号の一意性チェック
-		duplicateCheck = await db
-			.select()
+			})
 			.from(tracks)
-			.where(
-				and(
-					eq(tracks.discId, discId),
-					eq(tracks.trackNumber, parsed.data.trackNumber),
-				),
-			)
-			.limit(1);
-	} else if (parsed.data.releaseId) {
-		// ディスクなし（単曲）の場合、リリース内でトラック番号の一意性チェック
-		duplicateCheck = await db
-			.select()
-			.from(tracks)
-			.where(
-				and(
-					eq(tracks.releaseId, parsed.data.releaseId),
-					isNull(tracks.discId),
-					eq(tracks.trackNumber, parsed.data.trackNumber),
-				),
-			)
-			.limit(1);
-	} else {
-		// releaseIdもdiscIdもない場合は重複チェック不要
-		duplicateCheck = [];
+			.where(eq(tracks.releaseId, releaseId))
+			.orderBy(tracks.discId, tracks.trackNumber);
+
+		// 全トラックIDを取得
+		const trackIds = releaseTracks.map((row) => row.track.id);
+
+		// 役割別クレジット取得用のヘルパー
+		const getCreditsByRole = async (roleCode: string) => {
+			if (trackIds.length === 0) return new Map<string, string[]>();
+
+			const credits = await db
+				.select({
+					trackId: trackCredits.trackId,
+					creditName: trackCredits.creditName,
+				})
+				.from(trackCredits)
+				.innerJoin(
+					trackCreditRoles,
+					eq(trackCredits.id, trackCreditRoles.trackCreditId),
+				)
+				.where(
+					and(
+						inArray(trackCredits.trackId, trackIds),
+						eq(trackCreditRoles.roleCode, roleCode),
+					),
+				)
+				.orderBy(trackCredits.creditPosition);
+
+			const map = new Map<string, string[]>();
+			for (const c of credits) {
+				const existing = map.get(c.trackId) ?? [];
+				existing.push(c.creditName);
+				map.set(c.trackId, existing);
+			}
+			return map;
+		};
+
+		// 原曲取得
+		const getOriginalSongs = async () => {
+			if (trackIds.length === 0) return new Map<string, string[]>();
+
+			const songs = await db
+				.select({
+					trackId: trackOfficialSongs.trackId,
+					songName: officialSongs.name,
+					customSongName: trackOfficialSongs.customSongName,
+				})
+				.from(trackOfficialSongs)
+				.leftJoin(
+					officialSongs,
+					eq(trackOfficialSongs.officialSongId, officialSongs.id),
+				)
+				.where(inArray(trackOfficialSongs.trackId, trackIds))
+				.orderBy(trackOfficialSongs.partPosition);
+
+			const map = new Map<string, string[]>();
+			for (const s of songs) {
+				const name = s.songName ?? s.customSongName ?? "";
+				if (name) {
+					const existing = map.get(s.trackId) ?? [];
+					existing.push(name);
+					map.set(s.trackId, existing);
+				}
+			}
+			return map;
+		};
+
+		// 並列で取得
+		const [vocalistsMap, arrangersMap, lyricistsMap, originalSongsMap] =
+			await Promise.all([
+				getCreditsByRole("vocalist"),
+				getCreditsByRole("arranger"),
+				getCreditsByRole("lyricist"),
+				getOriginalSongs(),
+			]);
+
+		// レスポンス形式に変換
+		const result = releaseTracks.map((row) => ({
+			...row.track,
+			creditCount: row.creditCount,
+			vocalists: vocalistsMap.get(row.track.id)?.join(" / ") ?? null,
+			arrangers: arrangersMap.get(row.track.id)?.join(" / ") ?? null,
+			lyricists: lyricistsMap.get(row.track.id)?.join(" / ") ?? null,
+			originalSongs: originalSongsMap.get(row.track.id)?.join(" / ") ?? null,
+		}));
+
+		return c.json(result);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/releases/:releaseId/tracks");
 	}
-
-	if (duplicateCheck.length > 0) {
-		return c.json(
-			{
-				error: discId
-					? "Track number already exists for this disc"
-					: "Track number already exists for this release",
-			},
-			409,
-		);
-	}
-
-	// 親リリースから日付・イベント情報を取得して自動設定（releaseIdがある場合のみ）
-	let insertData = { ...parsed.data };
-	if (parsed.data.releaseId) {
-		const release = await db
-			.select()
-			.from(releases)
-			.where(eq(releases.id, parsed.data.releaseId))
-			.limit(1);
-
-		if (release.length > 0 && release[0]) {
-			insertData = {
-				...insertData,
-				releaseDate: release[0].releaseDate,
-				releaseYear: release[0].releaseYear,
-				releaseMonth: release[0].releaseMonth,
-				releaseDay: release[0].releaseDay,
-				eventId: release[0].eventId,
-				eventDayId: release[0].eventDayId,
-			};
-		}
-	}
-
-	// 作成
-	const result = await db.insert(tracks).values(insertData).returning();
-
-	return c.json(result[0], 201);
 });
 
-// トラック更新
-tracksRouter.put("/:releaseId/tracks/:trackId", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const trackId = c.req.param("trackId");
-	const body = await c.req.json();
+// トラック追加
+tracksRouter.post("/:releaseId/tracks", async (c) => {
+	try {
+		const releaseId = c.req.param("releaseId");
+		const body = await c.req.json();
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(tracks)
-		.where(and(eq(tracks.id, trackId), eq(tracks.releaseId, releaseId)))
-		.limit(1);
+		// バリデーション（releaseIdはoptionalなので、bodyに含まれていればそれを使用、なければパスパラメータ）
+		const parsed = insertTrackSchema.safeParse({
+			...body,
+			releaseId: body.releaseId || releaseId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
+		// リリース存在チェック（releaseIdが指定されている場合のみ）
+		if (parsed.data.releaseId) {
+			const existingRelease = await db
+				.select()
+				.from(releases)
+				.where(eq(releases.id, parsed.data.releaseId))
+				.limit(1);
 
-	// ディスク存在チェック（指定された場合）
-	if (body.discId !== undefined && body.discId !== null) {
-		const existingDisc = await db
+			if (existingRelease.length === 0) {
+				return c.json({ error: "Release not found" }, 404);
+			}
+		}
+
+		// ディスク存在チェック（指定された場合）
+		if (parsed.data.discId) {
+			if (!parsed.data.releaseId) {
+				return c.json({ error: "Disc cannot be set without a release" }, 400);
+			}
+			const existingDisc = await db
+				.select()
+				.from(discs)
+				.where(
+					and(
+						eq(discs.id, parsed.data.discId),
+						eq(discs.releaseId, parsed.data.releaseId),
+					),
+				)
+				.limit(1);
+
+			if (existingDisc.length === 0) {
+				return c.json({ error: "Disc not found" }, 404);
+			}
+		}
+
+		// ID重複チェック
+		const existingId = await db
 			.select()
-			.from(discs)
-			.where(and(eq(discs.id, body.discId), eq(discs.releaseId, releaseId)))
+			.from(tracks)
+			.where(eq(tracks.id, parsed.data.id))
 			.limit(1);
 
-		if (existingDisc.length === 0) {
-			return c.json({ error: "Disc not found" }, 404);
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
 		}
-	}
 
-	// バリデーション
-	const parsed = updateTrackSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// トラック番号またはディスクが変更される場合の重複チェック
-	const currentTrack = existing[0];
-	const newDiscId =
-		parsed.data.discId !== undefined
-			? parsed.data.discId
-			: currentTrack?.discId;
-	const newTrackNumber =
-		parsed.data.trackNumber !== undefined
-			? parsed.data.trackNumber
-			: currentTrack?.trackNumber;
-
-	if (newTrackNumber !== undefined) {
+		// トラック番号重複チェック（ディスク有無で分岐）
+		const discId = parsed.data.discId;
 		let duplicateCheck: Track[];
 
-		if (newDiscId) {
+		if (discId) {
+			// ディスク内でトラック番号の一意性チェック
 			duplicateCheck = await db
 				.select()
 				.from(tracks)
 				.where(
 					and(
-						eq(tracks.discId, newDiscId),
-						eq(tracks.trackNumber, newTrackNumber),
+						eq(tracks.discId, discId),
+						eq(tracks.trackNumber, parsed.data.trackNumber),
+					),
+				)
+				.limit(1);
+		} else if (parsed.data.releaseId) {
+			// ディスクなし（単曲）の場合、リリース内でトラック番号の一意性チェック
+			duplicateCheck = await db
+				.select()
+				.from(tracks)
+				.where(
+					and(
+						eq(tracks.releaseId, parsed.data.releaseId),
+						isNull(tracks.discId),
+						eq(tracks.trackNumber, parsed.data.trackNumber),
 					),
 				)
 				.limit(1);
 		} else {
-			duplicateCheck = await db
-				.select()
-				.from(tracks)
-				.where(
-					and(
-						eq(tracks.releaseId, releaseId),
-						isNull(tracks.discId),
-						eq(tracks.trackNumber, newTrackNumber),
-					),
-				)
-				.limit(1);
+			// releaseIdもdiscIdもない場合は重複チェック不要
+			duplicateCheck = [];
 		}
 
-		if (duplicateCheck.length > 0 && duplicateCheck[0]?.id !== trackId) {
+		if (duplicateCheck.length > 0) {
 			return c.json(
 				{
-					error: newDiscId
+					error: discId
 						? "Track number already exists for this disc"
 						: "Track number already exists for this release",
 				},
 				409,
 			);
 		}
+
+		// 親リリースから日付・イベント情報を取得して自動設定（releaseIdがある場合のみ）
+		let insertData = { ...parsed.data };
+		if (parsed.data.releaseId) {
+			const release = await db
+				.select()
+				.from(releases)
+				.where(eq(releases.id, parsed.data.releaseId))
+				.limit(1);
+
+			if (release.length > 0 && release[0]) {
+				insertData = {
+					...insertData,
+					releaseDate: release[0].releaseDate,
+					releaseYear: release[0].releaseYear,
+					releaseMonth: release[0].releaseMonth,
+					releaseDay: release[0].releaseDay,
+					eventId: release[0].eventId,
+					eventDayId: release[0].eventDayId,
+				};
+			}
+		}
+
+		// 作成
+		const result = await db.insert(tracks).values(insertData).returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/releases/:releaseId/tracks");
 	}
+});
 
-	// 日付フィールドが変更された場合、year/month/dayも自動設定
-	let updateData = { ...parsed.data };
-	if (parsed.data.releaseDate !== undefined) {
-		const { year, month, day } = parseDateString(parsed.data.releaseDate);
-		updateData = {
-			...updateData,
-			releaseYear: year,
-			releaseMonth: month,
-			releaseDay: day,
-		};
+// トラック更新
+tracksRouter.put("/:releaseId/tracks/:trackId", async (c) => {
+	try {
+		const releaseId = c.req.param("releaseId");
+		const trackId = c.req.param("trackId");
+		const body = await c.req.json();
+
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(tracks)
+			.where(and(eq(tracks.id, trackId), eq(tracks.releaseId, releaseId)))
+			.limit(1);
+
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// ディスク存在チェック（指定された場合）
+		if (body.discId !== undefined && body.discId !== null) {
+			const existingDisc = await db
+				.select()
+				.from(discs)
+				.where(and(eq(discs.id, body.discId), eq(discs.releaseId, releaseId)))
+				.limit(1);
+
+			if (existingDisc.length === 0) {
+				return c.json({ error: "Disc not found" }, 404);
+			}
+		}
+
+		// バリデーション
+		const parsed = updateTrackSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// トラック番号またはディスクが変更される場合の重複チェック
+		const currentTrack = existing[0];
+		const newDiscId =
+			parsed.data.discId !== undefined
+				? parsed.data.discId
+				: currentTrack?.discId;
+		const newTrackNumber =
+			parsed.data.trackNumber !== undefined
+				? parsed.data.trackNumber
+				: currentTrack?.trackNumber;
+
+		if (newTrackNumber !== undefined) {
+			let duplicateCheck: Track[];
+
+			if (newDiscId) {
+				duplicateCheck = await db
+					.select()
+					.from(tracks)
+					.where(
+						and(
+							eq(tracks.discId, newDiscId),
+							eq(tracks.trackNumber, newTrackNumber),
+						),
+					)
+					.limit(1);
+			} else {
+				duplicateCheck = await db
+					.select()
+					.from(tracks)
+					.where(
+						and(
+							eq(tracks.releaseId, releaseId),
+							isNull(tracks.discId),
+							eq(tracks.trackNumber, newTrackNumber),
+						),
+					)
+					.limit(1);
+			}
+
+			if (duplicateCheck.length > 0 && duplicateCheck[0]?.id !== trackId) {
+				return c.json(
+					{
+						error: newDiscId
+							? "Track number already exists for this disc"
+							: "Track number already exists for this release",
+					},
+					409,
+				);
+			}
+		}
+
+		// 日付フィールドが変更された場合、year/month/dayも自動設定
+		let updateData = { ...parsed.data };
+		if (parsed.data.releaseDate !== undefined) {
+			const { year, month, day } = parseDateString(parsed.data.releaseDate);
+			updateData = {
+				...updateData,
+				releaseYear: year,
+				releaseMonth: month,
+				releaseDay: day,
+			};
+		}
+
+		// 更新
+		const result = await db
+			.update(tracks)
+			.set(updateData)
+			.where(eq(tracks.id, trackId))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/releases/:releaseId/tracks/:trackId",
+		);
 	}
-
-	// 更新
-	const result = await db
-		.update(tracks)
-		.set(updateData)
-		.where(eq(tracks.id, trackId))
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // トラック削除
 tracksRouter.delete("/:releaseId/tracks/:trackId", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const trackId = c.req.param("trackId");
+	try {
+		const releaseId = c.req.param("releaseId");
+		const trackId = c.req.param("trackId");
 
-	// 存在チェック
-	const existing = await db
-		.select()
-		.from(tracks)
-		.where(and(eq(tracks.id, trackId), eq(tracks.releaseId, releaseId)))
-		.limit(1);
+		// 存在チェック
+		const existing = await db
+			.select()
+			.from(tracks)
+			.where(and(eq(tracks.id, trackId), eq(tracks.releaseId, releaseId)))
+			.limit(1);
 
-	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existing.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(tracks).where(eq(tracks.id, trackId));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/releases/:releaseId/tracks/:trackId",
+		);
 	}
-
-	// 削除
-	await db.delete(tracks).where(eq(tracks.id, trackId));
-
-	return c.json({ success: true });
 });
 
 // トラック並び順変更
 tracksRouter.patch("/:releaseId/tracks/:trackId/reorder", async (c) => {
-	const releaseId = c.req.param("releaseId");
-	const trackId = c.req.param("trackId");
-	const body = await c.req.json();
+	try {
+		const releaseId = c.req.param("releaseId");
+		const trackId = c.req.param("trackId");
+		const body = await c.req.json();
 
-	const { direction } = body as { direction: "up" | "down" };
+		const { direction } = body as { direction: "up" | "down" };
 
-	if (direction !== "up" && direction !== "down") {
-		return c.json({ error: "Invalid direction. Use 'up' or 'down'" }, 400);
-	}
+		if (direction !== "up" && direction !== "down") {
+			return c.json({ error: "Invalid direction. Use 'up' or 'down'" }, 400);
+		}
 
-	// 対象トラック取得
-	const targetTrack = await db
-		.select()
-		.from(tracks)
-		.where(and(eq(tracks.id, trackId), eq(tracks.releaseId, releaseId)))
-		.limit(1);
-
-	if (targetTrack.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	const target = targetTrack[0];
-	if (!target) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// 同じスコープ内（同じディスクまたはディスクなし）のトラック取得
-	let scopeTracks: Track[];
-	if (target.discId) {
-		scopeTracks = await db
+		// 対象トラック取得
+		const targetTrack = await db
 			.select()
 			.from(tracks)
-			.where(eq(tracks.discId, target.discId))
-			.orderBy(tracks.trackNumber);
-	} else {
-		scopeTracks = await db
-			.select()
-			.from(tracks)
-			.where(and(eq(tracks.releaseId, releaseId), isNull(tracks.discId)))
-			.orderBy(tracks.trackNumber);
-	}
+			.where(and(eq(tracks.id, trackId), eq(tracks.releaseId, releaseId)))
+			.limit(1);
 
-	// 対象トラックの位置を特定
-	const targetIndex = scopeTracks.findIndex((t) => t.id === trackId);
+		if (targetTrack.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
 
-	// 移動先トラックを特定
-	const swapIndex = direction === "up" ? targetIndex - 1 : targetIndex + 1;
+		const target = targetTrack[0];
+		if (!target) {
+			return c.json({ error: "Not found" }, 404);
+		}
 
-	if (swapIndex < 0 || swapIndex >= scopeTracks.length) {
-		return c.json(
-			{ error: direction === "up" ? "Already at top" : "Already at bottom" },
-			400,
+		// 同じスコープ内（同じディスクまたはディスクなし）のトラック取得
+		let scopeTracks: Track[];
+		if (target.discId) {
+			scopeTracks = await db
+				.select()
+				.from(tracks)
+				.where(eq(tracks.discId, target.discId))
+				.orderBy(tracks.trackNumber);
+		} else {
+			scopeTracks = await db
+				.select()
+				.from(tracks)
+				.where(and(eq(tracks.releaseId, releaseId), isNull(tracks.discId)))
+				.orderBy(tracks.trackNumber);
+		}
+
+		// 対象トラックの位置を特定
+		const targetIndex = scopeTracks.findIndex((t) => t.id === trackId);
+
+		// 移動先トラックを特定
+		const swapIndex = direction === "up" ? targetIndex - 1 : targetIndex + 1;
+
+		if (swapIndex < 0 || swapIndex >= scopeTracks.length) {
+			return c.json(
+				{ error: direction === "up" ? "Already at top" : "Already at bottom" },
+				400,
+			);
+		}
+
+		const swapTrack = scopeTracks[swapIndex];
+		if (!swapTrack) {
+			return c.json({ error: "Swap target not found" }, 400);
+		}
+
+		// トラック番号を入れ替え
+		const tempTrackNumber = target.trackNumber;
+		await db
+			.update(tracks)
+			.set({ trackNumber: swapTrack.trackNumber })
+			.where(eq(tracks.id, target.id));
+		await db
+			.update(tracks)
+			.set({ trackNumber: tempTrackNumber })
+			.where(eq(tracks.id, swapTrack.id));
+
+		// 更新後のトラック一覧を取得
+		let updatedTracks: Track[];
+		if (target.discId) {
+			updatedTracks = await db
+				.select()
+				.from(tracks)
+				.where(eq(tracks.discId, target.discId))
+				.orderBy(tracks.trackNumber);
+		} else {
+			updatedTracks = await db
+				.select()
+				.from(tracks)
+				.where(and(eq(tracks.releaseId, releaseId), isNull(tracks.discId)))
+				.orderBy(tracks.trackNumber);
+		}
+
+		return c.json(updatedTracks);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PATCH /admin/releases/:releaseId/tracks/:trackId/reorder",
 		);
 	}
-
-	const swapTrack = scopeTracks[swapIndex];
-	if (!swapTrack) {
-		return c.json({ error: "Swap target not found" }, 400);
-	}
-
-	// トラック番号を入れ替え
-	const tempTrackNumber = target.trackNumber;
-	await db
-		.update(tracks)
-		.set({ trackNumber: swapTrack.trackNumber })
-		.where(eq(tracks.id, target.id));
-	await db
-		.update(tracks)
-		.set({ trackNumber: tempTrackNumber })
-		.where(eq(tracks.id, swapTrack.id));
-
-	// 更新後のトラック一覧を取得
-	let updatedTracks: Track[];
-	if (target.discId) {
-		updatedTracks = await db
-			.select()
-			.from(tracks)
-			.where(eq(tracks.discId, target.discId))
-			.orderBy(tracks.trackNumber);
-	} else {
-		updatedTracks = await db
-			.select()
-			.from(tracks)
-			.where(and(eq(tracks.releaseId, releaseId), isNull(tracks.discId)))
-			.orderBy(tracks.trackNumber);
-	}
-
-	return c.json(updatedTracks);
 });
 
 // ユーティリティ関数: 日付文字列から年月日を抽出

--- a/apps/server/src/routes/admin/stats.ts
+++ b/apps/server/src/routes/admin/stats.ts
@@ -18,59 +18,64 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../middleware/admin-auth";
+import { handleDbError } from "../../utils/api-error";
 
 const statsRouter = new Hono<AdminContext>();
 
 // 統計情報取得
 statsRouter.get("/", async (c) => {
-	const [
-		usersResult,
-		platformsResult,
-		aliasTypesResult,
-		creditRolesResult,
-		officialWorkCategoriesResult,
-		officialWorksResult,
-		officialSongsResult,
-		artistsResult,
-		artistAliasesResult,
-		circlesResult,
-		eventsResult,
-		eventSeriesResult,
-		releasesResult,
-		tracksResult,
-	] = await Promise.all([
-		db.select({ count: count() }).from(user),
-		db.select({ count: count() }).from(platforms),
-		db.select({ count: count() }).from(aliasTypes),
-		db.select({ count: count() }).from(creditRoles),
-		db.select({ count: count() }).from(officialWorkCategories),
-		db.select({ count: count() }).from(officialWorks),
-		db.select({ count: count() }).from(officialSongs),
-		db.select({ count: count() }).from(artists),
-		db.select({ count: count() }).from(artistAliases),
-		db.select({ count: count() }).from(circles),
-		db.select({ count: count() }).from(events),
-		db.select({ count: count() }).from(eventSeries),
-		db.select({ count: count() }).from(releases),
-		db.select({ count: count() }).from(tracks),
-	]);
+	try {
+		const [
+			usersResult,
+			platformsResult,
+			aliasTypesResult,
+			creditRolesResult,
+			officialWorkCategoriesResult,
+			officialWorksResult,
+			officialSongsResult,
+			artistsResult,
+			artistAliasesResult,
+			circlesResult,
+			eventsResult,
+			eventSeriesResult,
+			releasesResult,
+			tracksResult,
+		] = await Promise.all([
+			db.select({ count: count() }).from(user),
+			db.select({ count: count() }).from(platforms),
+			db.select({ count: count() }).from(aliasTypes),
+			db.select({ count: count() }).from(creditRoles),
+			db.select({ count: count() }).from(officialWorkCategories),
+			db.select({ count: count() }).from(officialWorks),
+			db.select({ count: count() }).from(officialSongs),
+			db.select({ count: count() }).from(artists),
+			db.select({ count: count() }).from(artistAliases),
+			db.select({ count: count() }).from(circles),
+			db.select({ count: count() }).from(events),
+			db.select({ count: count() }).from(eventSeries),
+			db.select({ count: count() }).from(releases),
+			db.select({ count: count() }).from(tracks),
+		]);
 
-	return c.json({
-		users: usersResult[0]?.count ?? 0,
-		platforms: platformsResult[0]?.count ?? 0,
-		aliasTypes: aliasTypesResult[0]?.count ?? 0,
-		creditRoles: creditRolesResult[0]?.count ?? 0,
-		officialWorkCategories: officialWorkCategoriesResult[0]?.count ?? 0,
-		officialWorks: officialWorksResult[0]?.count ?? 0,
-		officialSongs: officialSongsResult[0]?.count ?? 0,
-		artists: artistsResult[0]?.count ?? 0,
-		artistAliases: artistAliasesResult[0]?.count ?? 0,
-		circles: circlesResult[0]?.count ?? 0,
-		events: eventsResult[0]?.count ?? 0,
-		eventSeries: eventSeriesResult[0]?.count ?? 0,
-		releases: releasesResult[0]?.count ?? 0,
-		tracks: tracksResult[0]?.count ?? 0,
-	});
+		return c.json({
+			users: usersResult[0]?.count ?? 0,
+			platforms: platformsResult[0]?.count ?? 0,
+			aliasTypes: aliasTypesResult[0]?.count ?? 0,
+			creditRoles: creditRolesResult[0]?.count ?? 0,
+			officialWorkCategories: officialWorkCategoriesResult[0]?.count ?? 0,
+			officialWorks: officialWorksResult[0]?.count ?? 0,
+			officialSongs: officialSongsResult[0]?.count ?? 0,
+			artists: artistsResult[0]?.count ?? 0,
+			artistAliases: artistAliasesResult[0]?.count ?? 0,
+			circles: circlesResult[0]?.count ?? 0,
+			events: eventsResult[0]?.count ?? 0,
+			eventSeries: eventSeriesResult[0]?.count ?? 0,
+			releases: releasesResult[0]?.count ?? 0,
+			tracks: tracksResult[0]?.count ?? 0,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/stats");
+	}
 });
 
 export { statsRouter };

--- a/apps/server/src/routes/admin/tracks/derivations.ts
+++ b/apps/server/src/routes/admin/tracks/derivations.ts
@@ -9,155 +9,172 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const trackDerivationsRouter = new Hono<AdminContext>();
 
 // トラックの派生関係一覧取得
 trackDerivationsRouter.get("/:trackId/derivations", async (c) => {
-	const trackId = c.req.param("trackId");
+	try {
+		const trackId = c.req.param("trackId");
 
-	// トラック存在チェック
-	const existingTrack = await db
-		.select()
-		.from(tracks)
-		.where(eq(tracks.id, trackId))
-		.limit(1);
+		// トラック存在チェック
+		const existingTrack = await db
+			.select()
+			.from(tracks)
+			.where(eq(tracks.id, trackId))
+			.limit(1);
 
-	if (existingTrack.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
+		if (existingTrack.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
+		}
+
+		// 派生関係一覧取得（派生元トラック情報・リリース情報を結合）
+		const derivations = await db
+			.select({
+				derivation: trackDerivations,
+				parentTrack: tracks,
+				parentRelease: releases,
+			})
+			.from(trackDerivations)
+			.leftJoin(tracks, eq(trackDerivations.parentTrackId, tracks.id))
+			.leftJoin(releases, eq(tracks.releaseId, releases.id))
+			.where(eq(trackDerivations.childTrackId, trackId));
+
+		return c.json(
+			derivations.map((row) => ({
+				...row.derivation,
+				parentTrack: row.parentTrack
+					? {
+							...row.parentTrack,
+							releaseName: row.parentRelease?.name ?? null,
+						}
+					: null,
+			})),
+		);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/tracks/:trackId/derivations");
 	}
-
-	// 派生関係一覧取得（派生元トラック情報・リリース情報を結合）
-	const derivations = await db
-		.select({
-			derivation: trackDerivations,
-			parentTrack: tracks,
-			parentRelease: releases,
-		})
-		.from(trackDerivations)
-		.leftJoin(tracks, eq(trackDerivations.parentTrackId, tracks.id))
-		.leftJoin(releases, eq(tracks.releaseId, releases.id))
-		.where(eq(trackDerivations.childTrackId, trackId));
-
-	return c.json(
-		derivations.map((row) => ({
-			...row.derivation,
-			parentTrack: row.parentTrack
-				? {
-						...row.parentTrack,
-						releaseName: row.parentRelease?.name ?? null,
-					}
-				: null,
-		})),
-	);
 });
 
 // 派生関係追加
 trackDerivationsRouter.post("/:trackId/derivations", async (c) => {
-	const trackId = c.req.param("trackId");
-	const body = await c.req.json();
+	try {
+		const trackId = c.req.param("trackId");
+		const body = await c.req.json();
 
-	// トラック存在チェック（子トラック）
-	const existingTrack = await db
-		.select()
-		.from(tracks)
-		.where(eq(tracks.id, trackId))
-		.limit(1);
+		// トラック存在チェック（子トラック）
+		const existingTrack = await db
+			.select()
+			.from(tracks)
+			.where(eq(tracks.id, trackId))
+			.limit(1);
 
-	if (existingTrack.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
+		if (existingTrack.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
+		}
+
+		// 親トラック存在チェック
+		const existingParentTrack = await db
+			.select()
+			.from(tracks)
+			.where(eq(tracks.id, body.parentTrackId))
+			.limit(1);
+
+		if (existingParentTrack.length === 0) {
+			return c.json({ error: "Parent track not found" }, 404);
+		}
+
+		// バリデーション（自己参照チェックを含む）
+		const parsed = insertTrackDerivationSchema.safeParse({
+			...body,
+			childTrackId: trackId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(trackDerivations)
+			.where(eq(trackDerivations.id, parsed.data.id))
+			.limit(1);
+
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
+
+		// 一意性チェック（子トラック × 親トラック）
+		const duplicateCheck = await db
+			.select()
+			.from(trackDerivations)
+			.where(
+				and(
+					eq(trackDerivations.childTrackId, trackId),
+					eq(trackDerivations.parentTrackId, parsed.data.parentTrackId),
+				),
+			)
+			.limit(1);
+
+		if (duplicateCheck.length > 0) {
+			return c.json(
+				{ error: "This derivation relationship already exists" },
+				409,
+			);
+		}
+
+		// 作成
+		const result = await db
+			.insert(trackDerivations)
+			.values(parsed.data)
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/tracks/:trackId/derivations");
 	}
-
-	// 親トラック存在チェック
-	const existingParentTrack = await db
-		.select()
-		.from(tracks)
-		.where(eq(tracks.id, body.parentTrackId))
-		.limit(1);
-
-	if (existingParentTrack.length === 0) {
-		return c.json({ error: "Parent track not found" }, 404);
-	}
-
-	// バリデーション（自己参照チェックを含む）
-	const parsed = insertTrackDerivationSchema.safeParse({
-		...body,
-		childTrackId: trackId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(trackDerivations)
-		.where(eq(trackDerivations.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// 一意性チェック（子トラック × 親トラック）
-	const duplicateCheck = await db
-		.select()
-		.from(trackDerivations)
-		.where(
-			and(
-				eq(trackDerivations.childTrackId, trackId),
-				eq(trackDerivations.parentTrackId, parsed.data.parentTrackId),
-			),
-		)
-		.limit(1);
-
-	if (duplicateCheck.length > 0) {
-		return c.json(
-			{ error: "This derivation relationship already exists" },
-			409,
-		);
-	}
-
-	// 作成
-	const result = await db
-		.insert(trackDerivations)
-		.values(parsed.data)
-		.returning();
-
-	return c.json(result[0], 201);
 });
 
 // 派生関係削除
 trackDerivationsRouter.delete("/:trackId/derivations/:id", async (c) => {
-	const trackId = c.req.param("trackId");
-	const id = c.req.param("id");
+	try {
+		const trackId = c.req.param("trackId");
+		const id = c.req.param("id");
 
-	// 派生関係存在チェック
-	const existingDerivation = await db
-		.select()
-		.from(trackDerivations)
-		.where(
-			and(
-				eq(trackDerivations.id, id),
-				eq(trackDerivations.childTrackId, trackId),
-			),
-		)
-		.limit(1);
+		// 派生関係存在チェック
+		const existingDerivation = await db
+			.select()
+			.from(trackDerivations)
+			.where(
+				and(
+					eq(trackDerivations.id, id),
+					eq(trackDerivations.childTrackId, trackId),
+				),
+			)
+			.limit(1);
 
-	if (existingDerivation.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existingDerivation.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(trackDerivations).where(eq(trackDerivations.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/tracks/:trackId/derivations/:id",
+		);
 	}
-
-	// 削除
-	await db.delete(trackDerivations).where(eq(trackDerivations.id, id));
-
-	return c.json({ success: true });
 });
 
 export { trackDerivationsRouter };

--- a/apps/server/src/routes/admin/tracks/index.ts
+++ b/apps/server/src/routes/admin/tracks/index.ts
@@ -23,6 +23,7 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 import { trackDerivationsRouter } from "./derivations";
 import { trackIsrcsRouter } from "./isrcs";
 import { trackOfficialSongsRouter } from "./official-songs";
@@ -42,402 +43,414 @@ tracksAdminRouter.route("/", trackIsrcsRouter);
 
 // ページネーション対応トラック一覧取得
 tracksAdminRouter.get("/", async (c) => {
-	const page = Number.parseInt(c.req.query("page") ?? "1", 10);
-	const limit = Number.parseInt(c.req.query("limit") ?? "20", 10);
-	const search = c.req.query("search") ?? "";
-	const releaseId = c.req.query("releaseId") ?? "";
+	try {
+		const page = Number.parseInt(c.req.query("page") ?? "1", 10);
+		const limit = Number.parseInt(c.req.query("limit") ?? "20", 10);
+		const search = c.req.query("search") ?? "";
+		const releaseId = c.req.query("releaseId") ?? "";
 
-	const offset = (page - 1) * limit;
+		const offset = (page - 1) * limit;
 
-	// 検索条件の構築
-	const searchConditions = [];
-	if (search) {
-		const searchPattern = `%${search}%`;
-		searchConditions.push(
-			or(
-				sql`${tracks.name} LIKE ${searchPattern}`,
-				sql`${tracks.nameJa} LIKE ${searchPattern}`,
-				sql`${tracks.nameEn} LIKE ${searchPattern}`,
-				sql`${releases.name} LIKE ${searchPattern}`,
-			),
-		);
-	}
-	if (releaseId) {
-		searchConditions.push(eq(tracks.releaseId, releaseId));
-	}
-
-	const whereCondition =
-		searchConditions.length > 0 ? and(...searchConditions) : undefined;
-
-	// トラック一覧取得（リリース名、ディスク番号、イベント情報付き）
-	const result = await db
-		.select({
-			track: tracks,
-			releaseName: releases.name,
-			discNumber: discs.discNumber,
-			eventName: events.name,
-			eventDayNumber: eventDays.dayNumber,
-			eventDayDate: eventDays.date,
-		})
-		.from(tracks)
-		.leftJoin(releases, eq(tracks.releaseId, releases.id))
-		.leftJoin(discs, eq(tracks.discId, discs.id))
-		.leftJoin(events, eq(tracks.eventId, events.id))
-		.leftJoin(eventDays, eq(tracks.eventDayId, eventDays.id))
-		.where(whereCondition)
-		.orderBy(releases.name, discs.discNumber, tracks.trackNumber)
-		.limit(limit)
-		.offset(offset);
-
-	// トラックIDリスト
-	const trackIds = result.map((r) => r.track.id);
-
-	// クレジット情報を一括取得（role別にグループ化）
-	const creditsData =
-		trackIds.length > 0
-			? await db
-					.select({
-						trackId: trackCredits.trackId,
-						creditName: trackCredits.creditName,
-						roleCode: trackCreditRoles.roleCode,
-					})
-					.from(trackCredits)
-					.leftJoin(
-						trackCreditRoles,
-						eq(trackCredits.id, trackCreditRoles.trackCreditId),
-					)
-					.where(
-						sql`${trackCredits.trackId} IN (${sql.join(
-							trackIds.map((id) => sql`${id}`),
-							sql`, `,
-						)})`,
-					)
-			: [];
-
-	// 原曲情報を一括取得（officialSongsテーブルと結合）
-	const officialSongsData =
-		trackIds.length > 0
-			? await db
-					.select({
-						trackId: trackOfficialSongs.trackId,
-						customSongName: trackOfficialSongs.customSongName,
-						officialSongName: officialSongs.name,
-					})
-					.from(trackOfficialSongs)
-					.leftJoin(
-						officialSongs,
-						eq(trackOfficialSongs.officialSongId, officialSongs.id),
-					)
-					.where(
-						sql`${trackOfficialSongs.trackId} IN (${sql.join(
-							trackIds.map((id) => sql`${id}`),
-							sql`, `,
-						)})`,
-					)
-			: [];
-
-	// トラックごとのクレジット情報をマップに集約
-	const creditsByTrack = new Map<
-		string,
-		{
-			vocalists: Set<string>;
-			arrangers: Set<string>;
-			lyricists: Set<string>;
-			creditCount: number;
+		// 検索条件の構築
+		const searchConditions = [];
+		if (search) {
+			const searchPattern = `%${search}%`;
+			searchConditions.push(
+				or(
+					sql`${tracks.name} LIKE ${searchPattern}`,
+					sql`${tracks.nameJa} LIKE ${searchPattern}`,
+					sql`${tracks.nameEn} LIKE ${searchPattern}`,
+					sql`${releases.name} LIKE ${searchPattern}`,
+				),
+			);
 		}
-	>();
-
-	for (const credit of creditsData) {
-		if (!creditsByTrack.has(credit.trackId)) {
-			creditsByTrack.set(credit.trackId, {
-				vocalists: new Set(),
-				arrangers: new Set(),
-				lyricists: new Set(),
-				creditCount: 0,
-			});
+		if (releaseId) {
+			searchConditions.push(eq(tracks.releaseId, releaseId));
 		}
-		const trackCreditsInfo = creditsByTrack.get(credit.trackId);
-		if (trackCreditsInfo) {
-			if (credit.roleCode === "vocalist") {
-				trackCreditsInfo.vocalists.add(credit.creditName);
-			} else if (credit.roleCode === "arranger") {
-				trackCreditsInfo.arrangers.add(credit.creditName);
-			} else if (credit.roleCode === "lyricist") {
-				trackCreditsInfo.lyricists.add(credit.creditName);
+
+		const whereCondition =
+			searchConditions.length > 0 ? and(...searchConditions) : undefined;
+
+		// トラック一覧取得（リリース名、ディスク番号、イベント情報付き）
+		const result = await db
+			.select({
+				track: tracks,
+				releaseName: releases.name,
+				discNumber: discs.discNumber,
+				eventName: events.name,
+				eventDayNumber: eventDays.dayNumber,
+				eventDayDate: eventDays.date,
+			})
+			.from(tracks)
+			.leftJoin(releases, eq(tracks.releaseId, releases.id))
+			.leftJoin(discs, eq(tracks.discId, discs.id))
+			.leftJoin(events, eq(tracks.eventId, events.id))
+			.leftJoin(eventDays, eq(tracks.eventDayId, eventDays.id))
+			.where(whereCondition)
+			.orderBy(releases.name, discs.discNumber, tracks.trackNumber)
+			.limit(limit)
+			.offset(offset);
+
+		// トラックIDリスト
+		const trackIds = result.map((r) => r.track.id);
+
+		// クレジット情報を一括取得（role別にグループ化）
+		const creditsData =
+			trackIds.length > 0
+				? await db
+						.select({
+							trackId: trackCredits.trackId,
+							creditName: trackCredits.creditName,
+							roleCode: trackCreditRoles.roleCode,
+						})
+						.from(trackCredits)
+						.leftJoin(
+							trackCreditRoles,
+							eq(trackCredits.id, trackCreditRoles.trackCreditId),
+						)
+						.where(
+							sql`${trackCredits.trackId} IN (${sql.join(
+								trackIds.map((id) => sql`${id}`),
+								sql`, `,
+							)})`,
+						)
+				: [];
+
+		// 原曲情報を一括取得（officialSongsテーブルと結合）
+		const officialSongsData =
+			trackIds.length > 0
+				? await db
+						.select({
+							trackId: trackOfficialSongs.trackId,
+							customSongName: trackOfficialSongs.customSongName,
+							officialSongName: officialSongs.name,
+						})
+						.from(trackOfficialSongs)
+						.leftJoin(
+							officialSongs,
+							eq(trackOfficialSongs.officialSongId, officialSongs.id),
+						)
+						.where(
+							sql`${trackOfficialSongs.trackId} IN (${sql.join(
+								trackIds.map((id) => sql`${id}`),
+								sql`, `,
+							)})`,
+						)
+				: [];
+
+		// トラックごとのクレジット情報をマップに集約
+		const creditsByTrack = new Map<
+			string,
+			{
+				vocalists: Set<string>;
+				arrangers: Set<string>;
+				lyricists: Set<string>;
+				creditCount: number;
+			}
+		>();
+
+		for (const credit of creditsData) {
+			if (!creditsByTrack.has(credit.trackId)) {
+				creditsByTrack.set(credit.trackId, {
+					vocalists: new Set(),
+					arrangers: new Set(),
+					lyricists: new Set(),
+					creditCount: 0,
+				});
+			}
+			const trackCreditsInfo = creditsByTrack.get(credit.trackId);
+			if (trackCreditsInfo) {
+				if (credit.roleCode === "vocalist") {
+					trackCreditsInfo.vocalists.add(credit.creditName);
+				} else if (credit.roleCode === "arranger") {
+					trackCreditsInfo.arrangers.add(credit.creditName);
+				} else if (credit.roleCode === "lyricist") {
+					trackCreditsInfo.lyricists.add(credit.creditName);
+				}
 			}
 		}
-	}
 
-	// ユニークなクレジットをカウント
-	const creditCountByTrack = new Map<string, number>();
-	const uniqueCredits = new Map<string, Set<string>>();
-	for (const credit of creditsData) {
-		if (!uniqueCredits.has(credit.trackId)) {
-			uniqueCredits.set(credit.trackId, new Set());
+		// ユニークなクレジットをカウント
+		const creditCountByTrack = new Map<string, number>();
+		const uniqueCredits = new Map<string, Set<string>>();
+		for (const credit of creditsData) {
+			if (!uniqueCredits.has(credit.trackId)) {
+				uniqueCredits.set(credit.trackId, new Set());
+			}
+			uniqueCredits.get(credit.trackId)?.add(credit.creditName);
 		}
-		uniqueCredits.get(credit.trackId)?.add(credit.creditName);
-	}
-	for (const [trackId, names] of uniqueCredits) {
-		creditCountByTrack.set(trackId, names.size);
-	}
-
-	// 原曲情報をマップに集約
-	const originalSongsByTrack = new Map<string, Set<string>>();
-	for (const song of officialSongsData) {
-		if (!originalSongsByTrack.has(song.trackId)) {
-			originalSongsByTrack.set(song.trackId, new Set());
+		for (const [trackId, names] of uniqueCredits) {
+			creditCountByTrack.set(trackId, names.size);
 		}
-		// カスタム曲名があればそれを使用、なければ公式曲名を使用
-		const songName = song.customSongName || song.officialSongName;
-		if (songName) {
-			originalSongsByTrack.get(song.trackId)?.add(songName);
+
+		// 原曲情報をマップに集約
+		const originalSongsByTrack = new Map<string, Set<string>>();
+		for (const song of officialSongsData) {
+			if (!originalSongsByTrack.has(song.trackId)) {
+				originalSongsByTrack.set(song.trackId, new Set());
+			}
+			// カスタム曲名があればそれを使用、なければ公式曲名を使用
+			const songName = song.customSongName || song.officialSongName;
+			if (songName) {
+				originalSongsByTrack.get(song.trackId)?.add(songName);
+			}
 		}
-	}
 
-	// リリースIDリスト（サークル情報取得用）
-	const releaseIds = [
-		...new Set(result.map((r) => r.track.releaseId).filter(Boolean)),
-	] as string[];
+		// リリースIDリスト（サークル情報取得用）
+		const releaseIds = [
+			...new Set(result.map((r) => r.track.releaseId).filter(Boolean)),
+		] as string[];
 
-	// サークル情報を一括取得
-	const circlesData =
-		releaseIds.length > 0
-			? await db
-					.select({
-						releaseId: releaseCircles.releaseId,
-						circleName: circles.name,
-						position: releaseCircles.position,
-					})
-					.from(releaseCircles)
-					.innerJoin(circles, eq(releaseCircles.circleId, circles.id))
-					.where(
-						sql`${releaseCircles.releaseId} IN (${sql.join(
-							releaseIds.map((id) => sql`${id}`),
-							sql`, `,
-						)})`,
-					)
-					.orderBy(releaseCircles.position)
-			: [];
+		// サークル情報を一括取得
+		const circlesData =
+			releaseIds.length > 0
+				? await db
+						.select({
+							releaseId: releaseCircles.releaseId,
+							circleName: circles.name,
+							position: releaseCircles.position,
+						})
+						.from(releaseCircles)
+						.innerJoin(circles, eq(releaseCircles.circleId, circles.id))
+						.where(
+							sql`${releaseCircles.releaseId} IN (${sql.join(
+								releaseIds.map((id) => sql`${id}`),
+								sql`, `,
+							)})`,
+						)
+						.orderBy(releaseCircles.position)
+				: [];
 
-	// リリースごとのサークル情報をマップに集約
-	const circlesByRelease = new Map<string, string[]>();
-	for (const circle of circlesData) {
-		if (!circlesByRelease.has(circle.releaseId)) {
-			circlesByRelease.set(circle.releaseId, []);
+		// リリースごとのサークル情報をマップに集約
+		const circlesByRelease = new Map<string, string[]>();
+		for (const circle of circlesData) {
+			if (!circlesByRelease.has(circle.releaseId)) {
+				circlesByRelease.set(circle.releaseId, []);
+			}
+			circlesByRelease.get(circle.releaseId)?.push(circle.circleName);
 		}
-		circlesByRelease.get(circle.releaseId)?.push(circle.circleName);
+
+		// 総件数を取得
+		const [totalResult] = await db
+			.select({ count: count() })
+			.from(tracks)
+			.leftJoin(releases, eq(tracks.releaseId, releases.id))
+			.where(whereCondition);
+
+		const total = totalResult?.count ?? 0;
+
+		// レスポンス形成
+		const data = result.map((row) => {
+			const trackCreditsInfo = creditsByTrack.get(row.track.id);
+			const originalSongs = originalSongsByTrack.get(row.track.id);
+			const releaseCircleNames = row.track.releaseId
+				? circlesByRelease.get(row.track.releaseId)
+				: null;
+			return {
+				...row.track,
+				releaseName: row.releaseName ?? null,
+				discNumber: row.discNumber ?? null,
+				eventName: row.eventName ?? null,
+				eventDayNumber: row.eventDayNumber ?? null,
+				eventDayDate: row.eventDayDate ?? null,
+				creditCount: creditCountByTrack.get(row.track.id) ?? 0,
+				vocalists: trackCreditsInfo
+					? Array.from(trackCreditsInfo.vocalists).join(", ")
+					: null,
+				arrangers: trackCreditsInfo
+					? Array.from(trackCreditsInfo.arrangers).join(", ")
+					: null,
+				lyricists: trackCreditsInfo
+					? Array.from(trackCreditsInfo.lyricists).join(", ")
+					: null,
+				originalSongs: originalSongs
+					? Array.from(originalSongs).join(", ")
+					: null,
+				circles: releaseCircleNames ? releaseCircleNames.join(" / ") : null,
+			};
+		});
+
+		return c.json({
+			data,
+			total,
+			page,
+			limit,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/tracks");
 	}
-
-	// 総件数を取得
-	const [totalResult] = await db
-		.select({ count: count() })
-		.from(tracks)
-		.leftJoin(releases, eq(tracks.releaseId, releases.id))
-		.where(whereCondition);
-
-	const total = totalResult?.count ?? 0;
-
-	// レスポンス形成
-	const data = result.map((row) => {
-		const trackCreditsInfo = creditsByTrack.get(row.track.id);
-		const originalSongs = originalSongsByTrack.get(row.track.id);
-		const releaseCircleNames = row.track.releaseId
-			? circlesByRelease.get(row.track.releaseId)
-			: null;
-		return {
-			...row.track,
-			releaseName: row.releaseName ?? null,
-			discNumber: row.discNumber ?? null,
-			eventName: row.eventName ?? null,
-			eventDayNumber: row.eventDayNumber ?? null,
-			eventDayDate: row.eventDayDate ?? null,
-			creditCount: creditCountByTrack.get(row.track.id) ?? 0,
-			vocalists: trackCreditsInfo
-				? Array.from(trackCreditsInfo.vocalists).join(", ")
-				: null,
-			arrangers: trackCreditsInfo
-				? Array.from(trackCreditsInfo.arrangers).join(", ")
-				: null,
-			lyricists: trackCreditsInfo
-				? Array.from(trackCreditsInfo.lyricists).join(", ")
-				: null,
-			originalSongs: originalSongs
-				? Array.from(originalSongs).join(", ")
-				: null,
-			circles: releaseCircleNames ? releaseCircleNames.join(" / ") : null,
-		};
-	});
-
-	return c.json({
-		data,
-		total,
-		page,
-		limit,
-	});
 });
 
 // トラック単体取得（詳細情報を含む）
 tracksAdminRouter.get("/:trackId", async (c) => {
-	const trackId = c.req.param("trackId");
+	try {
+		const trackId = c.req.param("trackId");
 
-	// トラック取得（イベント情報を含む）
-	const trackResult = await db
-		.select({
-			track: tracks,
-			release: releases,
-			disc: discs,
-			eventName: events.name,
-			eventDayNumber: eventDays.dayNumber,
-			eventDayDate: eventDays.date,
-		})
-		.from(tracks)
-		.leftJoin(releases, eq(tracks.releaseId, releases.id))
-		.leftJoin(discs, eq(tracks.discId, discs.id))
-		.leftJoin(events, eq(tracks.eventId, events.id))
-		.leftJoin(eventDays, eq(tracks.eventDayId, eventDays.id))
-		.where(eq(tracks.id, trackId))
-		.limit(1);
+		// トラック取得（イベント情報を含む）
+		const trackResult = await db
+			.select({
+				track: tracks,
+				release: releases,
+				disc: discs,
+				eventName: events.name,
+				eventDayNumber: eventDays.dayNumber,
+				eventDayDate: eventDays.date,
+			})
+			.from(tracks)
+			.leftJoin(releases, eq(tracks.releaseId, releases.id))
+			.leftJoin(discs, eq(tracks.discId, discs.id))
+			.leftJoin(events, eq(tracks.eventId, events.id))
+			.leftJoin(eventDays, eq(tracks.eventDayId, eventDays.id))
+			.where(eq(tracks.id, trackId))
+			.limit(1);
 
-	if (trackResult.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
-	}
-
-	const row = trackResult[0];
-	if (!row) {
-		return c.json({ error: "Track not found" }, 404);
-	}
-
-	// クレジット一覧取得（アーティスト・別名義・役割情報を結合）
-	const creditsResult = await db
-		.select({
-			credit: trackCredits,
-			artist: artists,
-			artistAlias: artistAliases,
-		})
-		.from(trackCredits)
-		.leftJoin(artists, eq(trackCredits.artistId, artists.id))
-		.leftJoin(artistAliases, eq(trackCredits.artistAliasId, artistAliases.id))
-		.where(eq(trackCredits.trackId, trackId))
-		.orderBy(trackCredits.creditPosition);
-
-	// クレジットIDリストを取得
-	const creditIds = creditsResult.map((r) => r.credit.id);
-
-	// 役割情報を一括取得（N+1解消）
-	const allRoles =
-		creditIds.length > 0
-			? await db
-					.select({
-						trackCreditId: trackCreditRoles.trackCreditId,
-						roleCode: trackCreditRoles.roleCode,
-						rolePosition: trackCreditRoles.rolePosition,
-						role: creditRoles,
-					})
-					.from(trackCreditRoles)
-					.leftJoin(
-						creditRoles,
-						eq(trackCreditRoles.roleCode, creditRoles.code),
-					)
-					.where(inArray(trackCreditRoles.trackCreditId, creditIds))
-					.orderBy(
-						trackCreditRoles.trackCreditId,
-						trackCreditRoles.rolePosition,
-					)
-			: [];
-
-	// 役割情報をクレジットIDごとにグループ化
-	const rolesByCredit = new Map<
-		string,
-		Array<{
-			trackCreditId: string;
-			roleCode: string;
-			rolePosition: number;
-			role: (typeof allRoles)[number]["role"];
-		}>
-	>();
-	for (const role of allRoles) {
-		if (!rolesByCredit.has(role.trackCreditId)) {
-			rolesByCredit.set(role.trackCreditId, []);
+		if (trackResult.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
 		}
-		rolesByCredit.get(role.trackCreditId)?.push(role);
+
+		const row = trackResult[0];
+		if (!row) {
+			return c.json({ error: "Track not found" }, 404);
+		}
+
+		// クレジット一覧取得（アーティスト・別名義・役割情報を結合）
+		const creditsResult = await db
+			.select({
+				credit: trackCredits,
+				artist: artists,
+				artistAlias: artistAliases,
+			})
+			.from(trackCredits)
+			.leftJoin(artists, eq(trackCredits.artistId, artists.id))
+			.leftJoin(artistAliases, eq(trackCredits.artistAliasId, artistAliases.id))
+			.where(eq(trackCredits.trackId, trackId))
+			.orderBy(trackCredits.creditPosition);
+
+		// クレジットIDリストを取得
+		const creditIds = creditsResult.map((r) => r.credit.id);
+
+		// 役割情報を一括取得（N+1解消）
+		const allRoles =
+			creditIds.length > 0
+				? await db
+						.select({
+							trackCreditId: trackCreditRoles.trackCreditId,
+							roleCode: trackCreditRoles.roleCode,
+							rolePosition: trackCreditRoles.rolePosition,
+							role: creditRoles,
+						})
+						.from(trackCreditRoles)
+						.leftJoin(
+							creditRoles,
+							eq(trackCreditRoles.roleCode, creditRoles.code),
+						)
+						.where(inArray(trackCreditRoles.trackCreditId, creditIds))
+						.orderBy(
+							trackCreditRoles.trackCreditId,
+							trackCreditRoles.rolePosition,
+						)
+				: [];
+
+		// 役割情報をクレジットIDごとにグループ化
+		const rolesByCredit = new Map<
+			string,
+			Array<{
+				trackCreditId: string;
+				roleCode: string;
+				rolePosition: number;
+				role: (typeof allRoles)[number]["role"];
+			}>
+		>();
+		for (const role of allRoles) {
+			if (!rolesByCredit.has(role.trackCreditId)) {
+				rolesByCredit.set(role.trackCreditId, []);
+			}
+			rolesByCredit.get(role.trackCreditId)?.push(role);
+		}
+
+		// クレジットに役割情報を紐付け
+		const creditsWithRoles = creditsResult.map((creditRow) => ({
+			...creditRow.credit,
+			artist: creditRow.artist,
+			artistAlias: creditRow.artistAlias,
+			roles: rolesByCredit.get(creditRow.credit.id) ?? [],
+		}));
+
+		return c.json({
+			...row.track,
+			release: row.release,
+			disc: row.disc,
+			credits: creditsWithRoles,
+			eventName: row.eventName ?? null,
+			eventDayNumber: row.eventDayNumber ?? null,
+			eventDayDate: row.eventDayDate ?? null,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/tracks/:trackId");
 	}
-
-	// クレジットに役割情報を紐付け
-	const creditsWithRoles = creditsResult.map((creditRow) => ({
-		...creditRow.credit,
-		artist: creditRow.artist,
-		artistAlias: creditRow.artistAlias,
-		roles: rolesByCredit.get(creditRow.credit.id) ?? [],
-	}));
-
-	return c.json({
-		...row.track,
-		release: row.release,
-		disc: row.disc,
-		credits: creditsWithRoles,
-		eventName: row.eventName ?? null,
-		eventDayNumber: row.eventDayNumber ?? null,
-		eventDayDate: row.eventDayDate ?? null,
-	});
 });
 
 // トラック一括削除
 tracksAdminRouter.delete("/batch", async (c) => {
-	const body = await c.req.json();
-	const { items } = body as {
-		items: Array<{ trackId: string; releaseId: string }>;
-	};
+	try {
+		const body = await c.req.json();
+		const { items } = body as {
+			items: Array<{ trackId: string; releaseId: string }>;
+		};
 
-	if (!Array.isArray(items) || items.length === 0) {
-		return c.json(
-			{ error: "items is required and must be a non-empty array" },
-			400,
-		);
-	}
-
-	// 上限チェック（一度に100件まで）
-	if (items.length > 100) {
-		return c.json({ error: "Maximum 100 items per batch" }, 400);
-	}
-
-	const deleted: string[] = [];
-	const failed: Array<{ trackId: string; error: string }> = [];
-
-	for (const item of items) {
-		try {
-			// 存在チェック
-			const existing = await db
-				.select()
-				.from(tracks)
-				.where(
-					and(
-						eq(tracks.id, item.trackId),
-						eq(tracks.releaseId, item.releaseId),
-					),
-				)
-				.limit(1);
-
-			if (existing.length === 0) {
-				failed.push({ trackId: item.trackId, error: "Not found" });
-				continue;
-			}
-
-			// 削除（カスケードでクレジット等も削除される）
-			await db.delete(tracks).where(eq(tracks.id, item.trackId));
-			deleted.push(item.trackId);
-		} catch (e) {
-			failed.push({
-				trackId: item.trackId,
-				error: e instanceof Error ? e.message : "Unknown error",
-			});
+		if (!Array.isArray(items) || items.length === 0) {
+			return c.json(
+				{ error: "items is required and must be a non-empty array" },
+				400,
+			);
 		}
-	}
 
-	return c.json({
-		success: failed.length === 0,
-		deleted: deleted.length,
-		failed,
-	});
+		// 上限チェック（一度に100件まで）
+		if (items.length > 100) {
+			return c.json({ error: "Maximum 100 items per batch" }, 400);
+		}
+
+		const deleted: string[] = [];
+		const failed: Array<{ trackId: string; error: string }> = [];
+
+		for (const item of items) {
+			try {
+				// 存在チェック
+				const existing = await db
+					.select()
+					.from(tracks)
+					.where(
+						and(
+							eq(tracks.id, item.trackId),
+							eq(tracks.releaseId, item.releaseId),
+						),
+					)
+					.limit(1);
+
+				if (existing.length === 0) {
+					failed.push({ trackId: item.trackId, error: "Not found" });
+					continue;
+				}
+
+				// 削除（カスケードでクレジット等も削除される）
+				await db.delete(tracks).where(eq(tracks.id, item.trackId));
+				deleted.push(item.trackId);
+			} catch (e) {
+				failed.push({
+					trackId: item.trackId,
+					error: e instanceof Error ? e.message : "Unknown error",
+				});
+			}
+		}
+
+		return c.json({
+			success: failed.length === 0,
+			deleted: deleted.length,
+			failed,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/tracks/batch");
+	}
 });
 
 export { tracksAdminRouter };

--- a/apps/server/src/routes/admin/tracks/isrcs.ts
+++ b/apps/server/src/routes/admin/tracks/isrcs.ts
@@ -9,192 +9,209 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const trackIsrcsRouter = new Hono<AdminContext>();
 
 // トラックのISRC一覧取得
 trackIsrcsRouter.get("/:trackId/isrcs", async (c) => {
-	const trackId = c.req.param("trackId");
+	try {
+		const trackId = c.req.param("trackId");
 
-	// トラック存在チェック
-	const existingTrack = await db
-		.select()
-		.from(tracks)
-		.where(eq(tracks.id, trackId))
-		.limit(1);
+		// トラック存在チェック
+		const existingTrack = await db
+			.select()
+			.from(tracks)
+			.where(eq(tracks.id, trackId))
+			.limit(1);
 
-	if (existingTrack.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
+		if (existingTrack.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
+		}
+
+		// ISRC一覧取得
+		const isrcs = await db
+			.select()
+			.from(trackIsrcs)
+			.where(eq(trackIsrcs.trackId, trackId));
+
+		return c.json(isrcs);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/tracks/:trackId/isrcs");
 	}
-
-	// ISRC一覧取得
-	const isrcs = await db
-		.select()
-		.from(trackIsrcs)
-		.where(eq(trackIsrcs.trackId, trackId));
-
-	return c.json(isrcs);
 });
 
 // ISRC追加
 trackIsrcsRouter.post("/:trackId/isrcs", async (c) => {
-	const trackId = c.req.param("trackId");
-	const body = await c.req.json();
+	try {
+		const trackId = c.req.param("trackId");
+		const body = await c.req.json();
 
-	// トラック存在チェック
-	const existingTrack = await db
-		.select()
-		.from(tracks)
-		.where(eq(tracks.id, trackId))
-		.limit(1);
+		// トラック存在チェック
+		const existingTrack = await db
+			.select()
+			.from(tracks)
+			.where(eq(tracks.id, trackId))
+			.limit(1);
 
-	if (existingTrack.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
-	}
+		if (existingTrack.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
+		}
 
-	// バリデーション
-	const parsed = insertTrackIsrcSchema.safeParse({
-		...body,
-		trackId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		// バリデーション
+		const parsed = insertTrackIsrcSchema.safeParse({
+			...body,
+			trackId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(trackIsrcs)
-		.where(eq(trackIsrcs.id, parsed.data.id))
-		.limit(1);
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(trackIsrcs)
+			.where(eq(trackIsrcs.id, parsed.data.id))
+			.limit(1);
 
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
 
-	// トラック×ISRCの一意性チェック
-	const isrcDuplicateCheck = await db
-		.select()
-		.from(trackIsrcs)
-		.where(
-			and(
-				eq(trackIsrcs.trackId, trackId),
-				eq(trackIsrcs.isrc, parsed.data.isrc),
-			),
-		)
-		.limit(1);
-
-	if (isrcDuplicateCheck.length > 0) {
-		return c.json({ error: "ISRC already exists for this track" }, 409);
-	}
-
-	// isPrimary制約チェック（同一トラック内でisPrimaryは1件のみ）
-	if (parsed.data.isPrimary) {
-		const primaryCheck = await db
+		// トラック×ISRCの一意性チェック
+		const isrcDuplicateCheck = await db
 			.select()
 			.from(trackIsrcs)
 			.where(
-				and(eq(trackIsrcs.trackId, trackId), eq(trackIsrcs.isPrimary, true)),
+				and(
+					eq(trackIsrcs.trackId, trackId),
+					eq(trackIsrcs.isrc, parsed.data.isrc),
+				),
 			)
 			.limit(1);
 
-		if (primaryCheck.length > 0) {
-			return c.json(
-				{ error: "Primary ISRC already exists for this track" },
-				409,
-			);
+		if (isrcDuplicateCheck.length > 0) {
+			return c.json({ error: "ISRC already exists for this track" }, 409);
 		}
+
+		// isPrimary制約チェック（同一トラック内でisPrimaryは1件のみ）
+		if (parsed.data.isPrimary) {
+			const primaryCheck = await db
+				.select()
+				.from(trackIsrcs)
+				.where(
+					and(eq(trackIsrcs.trackId, trackId), eq(trackIsrcs.isPrimary, true)),
+				)
+				.limit(1);
+
+			if (primaryCheck.length > 0) {
+				return c.json(
+					{ error: "Primary ISRC already exists for this track" },
+					409,
+				);
+			}
+		}
+
+		// 作成
+		const result = await db.insert(trackIsrcs).values(parsed.data).returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/tracks/:trackId/isrcs");
 	}
-
-	// 作成
-	const result = await db.insert(trackIsrcs).values(parsed.data).returning();
-
-	return c.json(result[0], 201);
 });
 
 // ISRC更新
 trackIsrcsRouter.put("/:trackId/isrcs/:id", async (c) => {
-	const trackId = c.req.param("trackId");
-	const id = c.req.param("id");
-	const body = await c.req.json();
+	try {
+		const trackId = c.req.param("trackId");
+		const id = c.req.param("id");
+		const body = await c.req.json();
 
-	// ISRC存在チェック
-	const existingIsrc = await db
-		.select()
-		.from(trackIsrcs)
-		.where(and(eq(trackIsrcs.id, id), eq(trackIsrcs.trackId, trackId)))
-		.limit(1);
-
-	if (existingIsrc.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateTrackIsrcSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// isPrimary変更時の制約チェック
-	if (parsed.data.isPrimary) {
-		const primaryCheck = await db
+		// ISRC存在チェック
+		const existingIsrc = await db
 			.select()
 			.from(trackIsrcs)
-			.where(
-				and(eq(trackIsrcs.trackId, trackId), eq(trackIsrcs.isPrimary, true)),
-			)
+			.where(and(eq(trackIsrcs.id, id), eq(trackIsrcs.trackId, trackId)))
 			.limit(1);
 
-		if (primaryCheck.length > 0 && primaryCheck[0]?.id !== id) {
+		if (existingIsrc.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateTrackIsrcSchema.safeParse(body);
+		if (!parsed.success) {
 			return c.json(
-				{ error: "Primary ISRC already exists for this track" },
-				409,
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
 			);
 		}
+
+		// isPrimary変更時の制約チェック
+		if (parsed.data.isPrimary) {
+			const primaryCheck = await db
+				.select()
+				.from(trackIsrcs)
+				.where(
+					and(eq(trackIsrcs.trackId, trackId), eq(trackIsrcs.isPrimary, true)),
+				)
+				.limit(1);
+
+			if (primaryCheck.length > 0 && primaryCheck[0]?.id !== id) {
+				return c.json(
+					{ error: "Primary ISRC already exists for this track" },
+					409,
+				);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(trackIsrcs)
+			.set(parsed.data)
+			.where(eq(trackIsrcs.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "PUT /admin/tracks/:trackId/isrcs/:id");
 	}
-
-	// 更新
-	const result = await db
-		.update(trackIsrcs)
-		.set(parsed.data)
-		.where(eq(trackIsrcs.id, id))
-		.returning();
-
-	return c.json(result[0]);
 });
 
 // ISRC削除
 trackIsrcsRouter.delete("/:trackId/isrcs/:id", async (c) => {
-	const trackId = c.req.param("trackId");
-	const id = c.req.param("id");
+	try {
+		const trackId = c.req.param("trackId");
+		const id = c.req.param("id");
 
-	// ISRC存在チェック
-	const existingIsrc = await db
-		.select()
-		.from(trackIsrcs)
-		.where(and(eq(trackIsrcs.id, id), eq(trackIsrcs.trackId, trackId)))
-		.limit(1);
+		// ISRC存在チェック
+		const existingIsrc = await db
+			.select()
+			.from(trackIsrcs)
+			.where(and(eq(trackIsrcs.id, id), eq(trackIsrcs.trackId, trackId)))
+			.limit(1);
 
-	if (existingIsrc.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existingIsrc.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(trackIsrcs).where(eq(trackIsrcs.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/tracks/:trackId/isrcs/:id");
 	}
-
-	// 削除
-	await db.delete(trackIsrcs).where(eq(trackIsrcs.id, id));
-
-	return c.json({ success: true });
 });
 
 export { trackIsrcsRouter };

--- a/apps/server/src/routes/admin/tracks/official-songs.ts
+++ b/apps/server/src/routes/admin/tracks/official-songs.ts
@@ -11,300 +11,28 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const trackOfficialSongsRouter = new Hono<AdminContext>();
 
 // トラックの原曲紐付け一覧取得
 trackOfficialSongsRouter.get("/:trackId/official-songs", async (c) => {
-	const trackId = c.req.param("trackId");
-
-	// トラック存在チェック
-	const existingTrack = await db
-		.select()
-		.from(tracks)
-		.where(eq(tracks.id, trackId))
-		.limit(1);
-
-	if (existingTrack.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
-	}
-
-	// 原曲紐付け一覧取得（公式楽曲情報を結合）
-	const relations = await db
-		.select({
-			relation: trackOfficialSongs,
-			officialSong: officialSongs,
-		})
-		.from(trackOfficialSongs)
-		.leftJoin(
-			officialSongs,
-			eq(trackOfficialSongs.officialSongId, officialSongs.id),
-		)
-		.where(eq(trackOfficialSongs.trackId, trackId))
-		.orderBy(trackOfficialSongs.partPosition);
-
-	return c.json(
-		relations.map((row) => ({
-			...row.relation,
-			officialSong: row.officialSong,
-		})),
-	);
-});
-
-// 原曲紐付け追加
-trackOfficialSongsRouter.post("/:trackId/official-songs", async (c) => {
-	const trackId = c.req.param("trackId");
-	const body = await c.req.json();
-
-	// トラック存在チェック
-	const existingTrack = await db
-		.select()
-		.from(tracks)
-		.where(eq(tracks.id, trackId))
-		.limit(1);
-
-	if (existingTrack.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
-	}
-
-	// 公式楽曲存在チェック（officialSongIdが指定されている場合のみ）
-	if (body.officialSongId) {
-		const existingOfficialSong = await db
-			.select()
-			.from(officialSongs)
-			.where(eq(officialSongs.id, body.officialSongId))
-			.limit(1);
-
-		if (existingOfficialSong.length === 0) {
-			return c.json({ error: "Official song not found" }, 404);
-		}
-	}
-
-	// partPositionが未指定の場合は自動付与（現在の最大値 + 1）
-	let autoPartPosition = body.partPosition;
-	if (autoPartPosition == null) {
-		const maxResult = await db
-			.select({ maxPos: max(trackOfficialSongs.partPosition) })
-			.from(trackOfficialSongs)
-			.where(eq(trackOfficialSongs.trackId, trackId));
-		autoPartPosition = (maxResult[0]?.maxPos ?? 0) + 1;
-	}
-
-	// バリデーション
-	const parsed = insertTrackOfficialSongSchema.safeParse({
-		...body,
-		trackId,
-		partPosition: autoPartPosition,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(trackOfficialSongs)
-		.where(eq(trackOfficialSongs.id, parsed.data.id))
-		.limit(1);
-
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
-
-	// 一意性チェック（トラック × 公式楽曲 × 順序、公式楽曲が指定されている場合のみ）
-	if (parsed.data.officialSongId) {
-		const duplicateCheck = await db
-			.select()
-			.from(trackOfficialSongs)
-			.where(
-				and(
-					eq(trackOfficialSongs.trackId, trackId),
-					eq(trackOfficialSongs.officialSongId, parsed.data.officialSongId),
-					parsed.data.partPosition != null
-						? eq(trackOfficialSongs.partPosition, parsed.data.partPosition)
-						: undefined,
-				),
-			)
-			.limit(1);
-
-		if (duplicateCheck.length > 0) {
-			return c.json(
-				{
-					error:
-						"This official song is already linked to the track with the same part position",
-				},
-				409,
-			);
-		}
-	}
-
-	// 作成
-	const result = await db
-		.insert(trackOfficialSongs)
-		.values(parsed.data)
-		.returning();
-
-	return c.json(result[0], 201);
-});
-
-// 原曲紐付け更新
-trackOfficialSongsRouter.put("/:trackId/official-songs/:id", async (c) => {
-	const trackId = c.req.param("trackId");
-	const id = c.req.param("id");
-	const body = await c.req.json();
-
-	// 紐付け存在チェック
-	const existingRelation = await db
-		.select()
-		.from(trackOfficialSongs)
-		.where(
-			and(
-				eq(trackOfficialSongs.id, id),
-				eq(trackOfficialSongs.trackId, trackId),
-			),
-		)
-		.limit(1);
-
-	if (existingRelation.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateTrackOfficialSongSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// 一意性チェック（partPositionを変更する場合）
-	const currentRelation = existingRelation[0];
-	const newPartPosition =
-		parsed.data.partPosition ?? currentRelation?.partPosition;
-
-	if (
-		newPartPosition !== currentRelation?.partPosition &&
-		newPartPosition != null
-	) {
-		const duplicateCheck = await db
-			.select()
-			.from(trackOfficialSongs)
-			.where(
-				and(
-					eq(trackOfficialSongs.trackId, trackId),
-					eq(
-						trackOfficialSongs.officialSongId,
-						currentRelation?.officialSongId ?? "",
-					),
-					eq(trackOfficialSongs.partPosition, newPartPosition),
-				),
-			)
-			.limit(1);
-
-		if (duplicateCheck.length > 0 && duplicateCheck[0]?.id !== id) {
-			return c.json(
-				{
-					error:
-						"This official song is already linked to the track with the same part position",
-				},
-				409,
-			);
-		}
-	}
-
-	// 更新
-	const result = await db
-		.update(trackOfficialSongs)
-		.set(parsed.data)
-		.where(eq(trackOfficialSongs.id, id))
-		.returning();
-
-	return c.json(result[0]);
-});
-
-// 原曲紐付け削除
-trackOfficialSongsRouter.delete("/:trackId/official-songs/:id", async (c) => {
-	const trackId = c.req.param("trackId");
-	const id = c.req.param("id");
-
-	// 紐付け存在チェック
-	const existingRelation = await db
-		.select()
-		.from(trackOfficialSongs)
-		.where(
-			and(
-				eq(trackOfficialSongs.id, id),
-				eq(trackOfficialSongs.trackId, trackId),
-			),
-		)
-		.limit(1);
-
-	if (existingRelation.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// 削除
-	await db.delete(trackOfficialSongs).where(eq(trackOfficialSongs.id, id));
-
-	return c.json({ success: true });
-});
-
-// 原曲紐付け並べ替え
-trackOfficialSongsRouter.patch(
-	"/:trackId/official-songs/:id/reorder",
-	async (c) => {
+	try {
 		const trackId = c.req.param("trackId");
-		const id = c.req.param("id");
-		const body = await c.req.json<{ direction: "up" | "down" }>();
 
-		// 現在の紐付け一覧を取得（順序順）
-		const relations = await db
+		// トラック存在チェック
+		const existingTrack = await db
 			.select()
-			.from(trackOfficialSongs)
-			.where(eq(trackOfficialSongs.trackId, trackId))
-			.orderBy(trackOfficialSongs.partPosition);
+			.from(tracks)
+			.where(eq(tracks.id, trackId))
+			.limit(1);
 
-		const currentIndex = relations.findIndex((r) => r.id === id);
-		if (currentIndex === -1) {
-			return c.json({ error: "Not found" }, 404);
+		if (existingTrack.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
 		}
 
-		const swapIndex =
-			body.direction === "up" ? currentIndex - 1 : currentIndex + 1;
-		if (swapIndex < 0 || swapIndex >= relations.length) {
-			return c.json({ error: "Cannot move further" }, 400);
-		}
-
-		const currentItem = relations[currentIndex];
-		const swapItem = relations[swapIndex];
-
-		if (!currentItem || !swapItem) {
-			return c.json({ error: "Invalid state" }, 500);
-		}
-
-		// 順序を入れ替え
-		await db
-			.update(trackOfficialSongs)
-			.set({ partPosition: swapItem.partPosition })
-			.where(eq(trackOfficialSongs.id, currentItem.id));
-
-		await db
-			.update(trackOfficialSongs)
-			.set({ partPosition: currentItem.partPosition })
-			.where(eq(trackOfficialSongs.id, swapItem.id));
-
-		// 更新後の一覧を返す
-		const updatedRelations = await db
+		// 原曲紐付け一覧取得（公式楽曲情報を結合）
+		const relations = await db
 			.select({
 				relation: trackOfficialSongs,
 				officialSong: officialSongs,
@@ -318,11 +46,320 @@ trackOfficialSongsRouter.patch(
 			.orderBy(trackOfficialSongs.partPosition);
 
 		return c.json(
-			updatedRelations.map((row) => ({
+			relations.map((row) => ({
 				...row.relation,
 				officialSong: row.officialSong,
 			})),
 		);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/tracks/:trackId/official-songs");
+	}
+});
+
+// 原曲紐付け追加
+trackOfficialSongsRouter.post("/:trackId/official-songs", async (c) => {
+	try {
+		const trackId = c.req.param("trackId");
+		const body = await c.req.json();
+
+		// トラック存在チェック
+		const existingTrack = await db
+			.select()
+			.from(tracks)
+			.where(eq(tracks.id, trackId))
+			.limit(1);
+
+		if (existingTrack.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
+		}
+
+		// 公式楽曲存在チェック（officialSongIdが指定されている場合のみ）
+		if (body.officialSongId) {
+			const existingOfficialSong = await db
+				.select()
+				.from(officialSongs)
+				.where(eq(officialSongs.id, body.officialSongId))
+				.limit(1);
+
+			if (existingOfficialSong.length === 0) {
+				return c.json({ error: "Official song not found" }, 404);
+			}
+		}
+
+		// partPositionが未指定の場合は自動付与（現在の最大値 + 1）
+		let autoPartPosition = body.partPosition;
+		if (autoPartPosition == null) {
+			const maxResult = await db
+				.select({ maxPos: max(trackOfficialSongs.partPosition) })
+				.from(trackOfficialSongs)
+				.where(eq(trackOfficialSongs.trackId, trackId));
+			autoPartPosition = (maxResult[0]?.maxPos ?? 0) + 1;
+		}
+
+		// バリデーション
+		const parsed = insertTrackOfficialSongSchema.safeParse({
+			...body,
+			trackId,
+			partPosition: autoPartPosition,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(trackOfficialSongs)
+			.where(eq(trackOfficialSongs.id, parsed.data.id))
+			.limit(1);
+
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
+
+		// 一意性チェック（トラック × 公式楽曲 × 順序、公式楽曲が指定されている場合のみ）
+		if (parsed.data.officialSongId) {
+			const duplicateCheck = await db
+				.select()
+				.from(trackOfficialSongs)
+				.where(
+					and(
+						eq(trackOfficialSongs.trackId, trackId),
+						eq(trackOfficialSongs.officialSongId, parsed.data.officialSongId),
+						parsed.data.partPosition != null
+							? eq(trackOfficialSongs.partPosition, parsed.data.partPosition)
+							: undefined,
+					),
+				)
+				.limit(1);
+
+			if (duplicateCheck.length > 0) {
+				return c.json(
+					{
+						error:
+							"This official song is already linked to the track with the same part position",
+					},
+					409,
+				);
+			}
+		}
+
+		// 作成
+		const result = await db
+			.insert(trackOfficialSongs)
+			.values(parsed.data)
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"POST /admin/tracks/:trackId/official-songs",
+		);
+	}
+});
+
+// 原曲紐付け更新
+trackOfficialSongsRouter.put("/:trackId/official-songs/:id", async (c) => {
+	try {
+		const trackId = c.req.param("trackId");
+		const id = c.req.param("id");
+		const body = await c.req.json();
+
+		// 紐付け存在チェック
+		const existingRelation = await db
+			.select()
+			.from(trackOfficialSongs)
+			.where(
+				and(
+					eq(trackOfficialSongs.id, id),
+					eq(trackOfficialSongs.trackId, trackId),
+				),
+			)
+			.limit(1);
+
+		if (existingRelation.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateTrackOfficialSongSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// 一意性チェック（partPositionを変更する場合）
+		const currentRelation = existingRelation[0];
+		const newPartPosition =
+			parsed.data.partPosition ?? currentRelation?.partPosition;
+
+		if (
+			newPartPosition !== currentRelation?.partPosition &&
+			newPartPosition != null
+		) {
+			const duplicateCheck = await db
+				.select()
+				.from(trackOfficialSongs)
+				.where(
+					and(
+						eq(trackOfficialSongs.trackId, trackId),
+						eq(
+							trackOfficialSongs.officialSongId,
+							currentRelation?.officialSongId ?? "",
+						),
+						eq(trackOfficialSongs.partPosition, newPartPosition),
+					),
+				)
+				.limit(1);
+
+			if (duplicateCheck.length > 0 && duplicateCheck[0]?.id !== id) {
+				return c.json(
+					{
+						error:
+							"This official song is already linked to the track with the same part position",
+					},
+					409,
+				);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(trackOfficialSongs)
+			.set(parsed.data)
+			.where(eq(trackOfficialSongs.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/tracks/:trackId/official-songs/:id",
+		);
+	}
+});
+
+// 原曲紐付け削除
+trackOfficialSongsRouter.delete("/:trackId/official-songs/:id", async (c) => {
+	try {
+		const trackId = c.req.param("trackId");
+		const id = c.req.param("id");
+
+		// 紐付け存在チェック
+		const existingRelation = await db
+			.select()
+			.from(trackOfficialSongs)
+			.where(
+				and(
+					eq(trackOfficialSongs.id, id),
+					eq(trackOfficialSongs.trackId, trackId),
+				),
+			)
+			.limit(1);
+
+		if (existingRelation.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(trackOfficialSongs).where(eq(trackOfficialSongs.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/tracks/:trackId/official-songs/:id",
+		);
+	}
+});
+
+// 原曲紐付け並べ替え
+trackOfficialSongsRouter.patch(
+	"/:trackId/official-songs/:id/reorder",
+	async (c) => {
+		try {
+			const trackId = c.req.param("trackId");
+			const id = c.req.param("id");
+			const body = await c.req.json<{ direction: "up" | "down" }>();
+
+			// 現在の紐付け一覧を取得（順序順）
+			const relations = await db
+				.select()
+				.from(trackOfficialSongs)
+				.where(eq(trackOfficialSongs.trackId, trackId))
+				.orderBy(trackOfficialSongs.partPosition);
+
+			const currentIndex = relations.findIndex((r) => r.id === id);
+			if (currentIndex === -1) {
+				return c.json({ error: "Not found" }, 404);
+			}
+
+			const swapIndex =
+				body.direction === "up" ? currentIndex - 1 : currentIndex + 1;
+			if (swapIndex < 0 || swapIndex >= relations.length) {
+				return c.json({ error: "Cannot move further" }, 400);
+			}
+
+			const currentItem = relations[currentIndex];
+			const swapItem = relations[swapIndex];
+
+			if (!currentItem || !swapItem) {
+				return c.json({ error: "Invalid state" }, 500);
+			}
+
+			// 順序を入れ替え
+			await db
+				.update(trackOfficialSongs)
+				.set({ partPosition: swapItem.partPosition })
+				.where(eq(trackOfficialSongs.id, currentItem.id));
+
+			await db
+				.update(trackOfficialSongs)
+				.set({ partPosition: currentItem.partPosition })
+				.where(eq(trackOfficialSongs.id, swapItem.id));
+
+			// 更新後の一覧を返す
+			const updatedRelations = await db
+				.select({
+					relation: trackOfficialSongs,
+					officialSong: officialSongs,
+				})
+				.from(trackOfficialSongs)
+				.leftJoin(
+					officialSongs,
+					eq(trackOfficialSongs.officialSongId, officialSongs.id),
+				)
+				.where(eq(trackOfficialSongs.trackId, trackId))
+				.orderBy(trackOfficialSongs.partPosition);
+
+			return c.json(
+				updatedRelations.map((row) => ({
+					...row.relation,
+					officialSong: row.officialSong,
+				})),
+			);
+		} catch (error) {
+			return handleDbError(
+				c,
+				error,
+				"PATCH /admin/tracks/:trackId/official-songs/:id/reorder",
+			);
+		}
 	},
 );
 

--- a/apps/server/src/routes/admin/tracks/publications.ts
+++ b/apps/server/src/routes/admin/tracks/publications.ts
@@ -10,191 +10,222 @@ import {
 } from "@thac/db";
 import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
 
 const trackPublicationsRouter = new Hono<AdminContext>();
 
 // トラックの公開リンク一覧取得
 trackPublicationsRouter.get("/:trackId/publications", async (c) => {
-	const trackId = c.req.param("trackId");
+	try {
+		const trackId = c.req.param("trackId");
 
-	// トラック存在チェック
-	const existingTrack = await db
-		.select()
-		.from(tracks)
-		.where(eq(tracks.id, trackId))
-		.limit(1);
+		// トラック存在チェック
+		const existingTrack = await db
+			.select()
+			.from(tracks)
+			.where(eq(tracks.id, trackId))
+			.limit(1);
 
-	if (existingTrack.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
+		if (existingTrack.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
+		}
+
+		// 公開リンク一覧取得（プラットフォーム情報を結合）
+		const publications = await db
+			.select({
+				publication: trackPublications,
+				platform: platforms,
+			})
+			.from(trackPublications)
+			.leftJoin(platforms, eq(trackPublications.platformCode, platforms.code))
+			.where(eq(trackPublications.trackId, trackId));
+
+		return c.json(
+			publications.map((row) => ({
+				...row.publication,
+				platform: row.platform,
+			})),
+		);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/tracks/:trackId/publications");
 	}
-
-	// 公開リンク一覧取得（プラットフォーム情報を結合）
-	const publications = await db
-		.select({
-			publication: trackPublications,
-			platform: platforms,
-		})
-		.from(trackPublications)
-		.leftJoin(platforms, eq(trackPublications.platformCode, platforms.code))
-		.where(eq(trackPublications.trackId, trackId));
-
-	return c.json(
-		publications.map((row) => ({
-			...row.publication,
-			platform: row.platform,
-		})),
-	);
 });
 
 // 公開リンク追加
 trackPublicationsRouter.post("/:trackId/publications", async (c) => {
-	const trackId = c.req.param("trackId");
-	const body = await c.req.json();
+	try {
+		const trackId = c.req.param("trackId");
+		const body = await c.req.json();
 
-	// トラック存在チェック
-	const existingTrack = await db
-		.select()
-		.from(tracks)
-		.where(eq(tracks.id, trackId))
-		.limit(1);
+		// トラック存在チェック
+		const existingTrack = await db
+			.select()
+			.from(tracks)
+			.where(eq(tracks.id, trackId))
+			.limit(1);
 
-	if (existingTrack.length === 0) {
-		return c.json({ error: "Track not found" }, 404);
-	}
+		if (existingTrack.length === 0) {
+			return c.json({ error: "Track not found" }, 404);
+		}
 
-	// プラットフォーム存在チェック
-	const existingPlatform = await db
-		.select()
-		.from(platforms)
-		.where(eq(platforms.code, body.platformCode))
-		.limit(1);
+		// プラットフォーム存在チェック
+		const existingPlatform = await db
+			.select()
+			.from(platforms)
+			.where(eq(platforms.code, body.platformCode))
+			.limit(1);
 
-	if (existingPlatform.length === 0) {
-		return c.json({ error: "Platform not found" }, 404);
-	}
+		if (existingPlatform.length === 0) {
+			return c.json({ error: "Platform not found" }, 404);
+		}
 
-	// バリデーション
-	const parsed = insertTrackPublicationSchema.safeParse({
-		...body,
-		trackId,
-	});
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
+		// バリデーション
+		const parsed = insertTrackPublicationSchema.safeParse({
+			...body,
+			trackId,
+		});
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
 
-	// ID重複チェック
-	const existingId = await db
-		.select()
-		.from(trackPublications)
-		.where(eq(trackPublications.id, parsed.data.id))
-		.limit(1);
+		// ID重複チェック
+		const existingId = await db
+			.select()
+			.from(trackPublications)
+			.where(eq(trackPublications.id, parsed.data.id))
+			.limit(1);
 
-	if (existingId.length > 0) {
-		return c.json({ error: "ID already exists" }, 409);
-	}
+		if (existingId.length > 0) {
+			return c.json({ error: "ID already exists" }, 409);
+		}
 
-	// URL重複チェック
-	const urlDuplicateCheck = await db
-		.select()
-		.from(trackPublications)
-		.where(eq(trackPublications.url, parsed.data.url))
-		.limit(1);
-
-	if (urlDuplicateCheck.length > 0) {
-		return c.json({ error: "URL already exists" }, 409);
-	}
-
-	// 作成
-	const result = await db
-		.insert(trackPublications)
-		.values(parsed.data)
-		.returning();
-
-	return c.json(result[0], 201);
-});
-
-// 公開リンク更新
-trackPublicationsRouter.put("/:trackId/publications/:id", async (c) => {
-	const trackId = c.req.param("trackId");
-	const id = c.req.param("id");
-	const body = await c.req.json();
-
-	// 公開リンク存在チェック
-	const existingPublication = await db
-		.select()
-		.from(trackPublications)
-		.where(
-			and(eq(trackPublications.id, id), eq(trackPublications.trackId, trackId)),
-		)
-		.limit(1);
-
-	if (existingPublication.length === 0) {
-		return c.json({ error: "Not found" }, 404);
-	}
-
-	// バリデーション
-	const parsed = updateTrackPublicationSchema.safeParse(body);
-	if (!parsed.success) {
-		return c.json(
-			{
-				error: "Validation failed",
-				details: parsed.error.flatten().fieldErrors,
-			},
-			400,
-		);
-	}
-
-	// URL重複チェック（自分自身以外で）
-	if (parsed.data.url) {
+		// URL重複チェック
 		const urlDuplicateCheck = await db
 			.select()
 			.from(trackPublications)
 			.where(eq(trackPublications.url, parsed.data.url))
 			.limit(1);
 
-		if (urlDuplicateCheck.length > 0 && urlDuplicateCheck[0]?.id !== id) {
+		if (urlDuplicateCheck.length > 0) {
 			return c.json({ error: "URL already exists" }, 409);
 		}
+
+		// 作成
+		const result = await db
+			.insert(trackPublications)
+			.values(parsed.data)
+			.returning();
+
+		return c.json(result[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /admin/tracks/:trackId/publications");
 	}
+});
 
-	// 更新
-	const result = await db
-		.update(trackPublications)
-		.set(parsed.data)
-		.where(eq(trackPublications.id, id))
-		.returning();
+// 公開リンク更新
+trackPublicationsRouter.put("/:trackId/publications/:id", async (c) => {
+	try {
+		const trackId = c.req.param("trackId");
+		const id = c.req.param("id");
+		const body = await c.req.json();
 
-	return c.json(result[0]);
+		// 公開リンク存在チェック
+		const existingPublication = await db
+			.select()
+			.from(trackPublications)
+			.where(
+				and(
+					eq(trackPublications.id, id),
+					eq(trackPublications.trackId, trackId),
+				),
+			)
+			.limit(1);
+
+		if (existingPublication.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// バリデーション
+		const parsed = updateTrackPublicationSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten().fieldErrors,
+				},
+				400,
+			);
+		}
+
+		// URL重複チェック（自分自身以外で）
+		if (parsed.data.url) {
+			const urlDuplicateCheck = await db
+				.select()
+				.from(trackPublications)
+				.where(eq(trackPublications.url, parsed.data.url))
+				.limit(1);
+
+			if (urlDuplicateCheck.length > 0 && urlDuplicateCheck[0]?.id !== id) {
+				return c.json({ error: "URL already exists" }, 409);
+			}
+		}
+
+		// 更新
+		const result = await db
+			.update(trackPublications)
+			.set(parsed.data)
+			.where(eq(trackPublications.id, id))
+			.returning();
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"PUT /admin/tracks/:trackId/publications/:id",
+		);
+	}
 });
 
 // 公開リンク削除
 trackPublicationsRouter.delete("/:trackId/publications/:id", async (c) => {
-	const trackId = c.req.param("trackId");
-	const id = c.req.param("id");
+	try {
+		const trackId = c.req.param("trackId");
+		const id = c.req.param("id");
 
-	// 公開リンク存在チェック
-	const existingPublication = await db
-		.select()
-		.from(trackPublications)
-		.where(
-			and(eq(trackPublications.id, id), eq(trackPublications.trackId, trackId)),
-		)
-		.limit(1);
+		// 公開リンク存在チェック
+		const existingPublication = await db
+			.select()
+			.from(trackPublications)
+			.where(
+				and(
+					eq(trackPublications.id, id),
+					eq(trackPublications.trackId, trackId),
+				),
+			)
+			.limit(1);
 
-	if (existingPublication.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		if (existingPublication.length === 0) {
+			return c.json({ error: "Not found" }, 404);
+		}
+
+		// 削除
+		await db.delete(trackPublications).where(eq(trackPublications.id, id));
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /admin/tracks/:trackId/publications/:id",
+		);
 	}
-
-	// 削除
-	await db.delete(trackPublications).where(eq(trackPublications.id, id));
-
-	return c.json({ success: true });
 });
 
 export { trackPublicationsRouter };

--- a/apps/server/src/utils/api-error.ts
+++ b/apps/server/src/utils/api-error.ts
@@ -1,0 +1,54 @@
+import type { Context } from "hono";
+
+/**
+ * 統一エラーレスポンス形式
+ */
+export interface ApiErrorResponse {
+	/** ユーザー向けメッセージ（日本語） */
+	error: string;
+	/** エラーコード（英語） */
+	code: string;
+	/** 開発環境のみの詳細情報 */
+	details?: unknown;
+}
+
+/**
+ * エラーコード定義
+ */
+export const ErrorCodes = {
+	/** データベースエラー */
+	DB_ERROR: "DB_ERROR",
+	/** バリデーションエラー */
+	VALIDATION_ERROR: "VALIDATION_ERROR",
+	/** リソースが見つからない */
+	NOT_FOUND: "NOT_FOUND",
+	/** 重複エラー */
+	DUPLICATE: "DUPLICATE",
+	/** その他のエラー */
+	INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const;
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
+
+/**
+ * DB操作時のエラーハンドリング
+ * @param c - Honoコンテキスト
+ * @param error - エラーオブジェクト
+ * @param operation - 操作名（ログ用）
+ * @returns エラーレスポンス
+ */
+export function handleDbError(c: Context, error: unknown, operation: string) {
+	console.error(`[${operation}] Database error:`, error);
+
+	const isDev = process.env.NODE_ENV === "development";
+	const response: ApiErrorResponse = {
+		error: "データベースエラーが発生しました",
+		code: ErrorCodes.DB_ERROR,
+	};
+
+	if (isDev) {
+		response.details = error instanceof Error ? error.message : String(error);
+	}
+
+	return c.json(response, 500);
+}


### PR DESCRIPTION
## 概要

管理APIの全エンドポイントに統一されたエラーハンドリングを追加し、データベースエラーや予期しない例外を適切に処理できるようにしました。

## 変更内容

* 新規ユーティリティ `apps/server/src/utils/api-error.ts` を作成
  - `handleDbError` 関数で統一的なエラーレスポンスを返却
  - エラーコード（DB_ERROR, VALIDATION_ERROR, NOT_FOUND, DUPLICATE, INTERNAL_ERROR）を標準化
  - 開発環境のみエラー詳細を返却
* 全33ファイルの管理APIエンドポイントに try-catch を追加
  - artists, artist-aliases, circles, events, releases, tracks, master, official, stats

## 影響範囲

* 管理API（`/admin/*`）の全エンドポイント
* エラー発生時のレスポンス形式が統一される

## 補足事項

* SSEストリーミングを使用する `import/legacy.ts` は独自のエラーハンドリングを維持
* ルーター集約ファイル（`*/index.ts`）はエンドポイントを持たないため対象外

Closes #96