### PR TITLE
feat: 管理APIエラーメッセージを日本語に統一

### DIFF
--- a/apps/server/src/constants/error-messages.ts
+++ b/apps/server/src/constants/error-messages.ts
@@ -1,0 +1,103 @@
+/**
+ * エラーメッセージ定数
+ * すべてのAPIエンドポイントで使用する統一されたエラーメッセージ
+ */
+export const ERROR_MESSAGES = {
+	// ===== 汎用エラー =====
+	NOT_FOUND: "データが見つかりません",
+	VALIDATION_FAILED: "入力内容に誤りがあります",
+	DB_ERROR: "データベースエラーが発生しました",
+
+	// ===== リソース別 Not Found =====
+	EVENT_NOT_FOUND: "イベントが見つかりません",
+	EVENT_SERIES_NOT_FOUND: "イベントシリーズが見つかりません",
+	EVENT_DAY_NOT_FOUND: "イベント日が見つかりません",
+	RELEASE_NOT_FOUND: "リリースが見つかりません",
+	TRACK_NOT_FOUND: "トラックが見つかりません",
+	CIRCLE_NOT_FOUND: "サークルが見つかりません",
+	ARTIST_NOT_FOUND: "アーティストが見つかりません",
+	ARTIST_ALIAS_NOT_FOUND: "アーティスト別名が見つかりません",
+	PLATFORM_NOT_FOUND: "プラットフォームが見つかりません",
+	DISC_NOT_FOUND: "ディスクが見つかりません",
+	WORK_NOT_FOUND: "公式作品が見つかりません",
+	SONG_NOT_FOUND: "公式楽曲が見つかりません",
+	CREDIT_NOT_FOUND: "クレジットが見つかりません",
+	ROLE_NOT_FOUND: "役割が見つかりません",
+	PARENT_TRACK_NOT_FOUND: "親トラックが見つかりません",
+	SWAP_TARGET_NOT_FOUND: "入れ替え対象が見つかりません",
+	DERIVATION_NOT_FOUND: "派生関係が見つかりません",
+	ISRC_NOT_FOUND: "ISRCが見つかりません",
+	PUBLICATION_NOT_FOUND: "配信情報が見つかりません",
+	JAN_CODE_NOT_FOUND: "JANコードが見つかりません",
+	ALIAS_TYPE_NOT_FOUND: "別名タイプが見つかりません",
+	CREDIT_ROLE_NOT_FOUND: "クレジット役割が見つかりません",
+	OFFICIAL_WORK_CATEGORY_NOT_FOUND: "公式作品カテゴリが見つかりません",
+	ROLE_NOT_FOUND_IN_MASTER: "役割がマスターデータに見つかりません",
+
+	// ===== 重複エラー (409) =====
+	ID_ALREADY_EXISTS: "このIDは既に使用されています",
+	NAME_ALREADY_EXISTS: "この名前は既に使用されています",
+	CODE_ALREADY_EXISTS: "このコードは既に使用されています",
+	URL_ALREADY_EXISTS: "このURLは既に登録されています",
+	URL_ALREADY_EXISTS_FOR_CIRCLE: "このURLは既にこのサークルに登録されています",
+	URL_ALREADY_EXISTS_FOR_SONG: "このURLは既にこの楽曲に登録されています",
+	URL_ALREADY_EXISTS_FOR_WORK: "このURLは既にこの作品に登録されています",
+	ISRC_ALREADY_EXISTS: "このISRCは既にこのトラックに登録されています",
+	PRIMARY_ISRC_ALREADY_EXISTS: "プライマリISRCは既にこのトラックに存在します",
+	JAN_CODE_ALREADY_EXISTS: "このJANコードは既に登録されています",
+	PRIMARY_JAN_CODE_ALREADY_EXISTS:
+		"プライマリJANコードは既にこのリリースに存在します",
+	ALIAS_ALREADY_EXISTS: "この別名は既にこのアーティストに登録されています",
+	DAY_NUMBER_ALREADY_EXISTS: "この日番号は既にこのイベントに存在します",
+	DATE_ALREADY_EXISTS: "この日付は既にこのイベントに存在します",
+	EDITION_ALREADY_EXISTS: "このエディションは既にこのシリーズに存在します",
+	ASSOCIATION_ALREADY_EXISTS: "この関連付けは既に存在します",
+	TRACK_NUMBER_ALREADY_EXISTS_FOR_DISC:
+		"このトラック番号は既にこのディスクに存在します",
+	TRACK_NUMBER_ALREADY_EXISTS_FOR_RELEASE:
+		"このトラック番号は既にこのリリースに存在します",
+	DERIVATION_ALREADY_EXISTS: "この派生関係は既に存在します",
+	DISC_NUMBER_ALREADY_EXISTS_FOR_RELEASE:
+		"このディスク番号は既にこのリリースに存在します",
+	CREDIT_ALREADY_EXISTS_FOR_TRACK:
+		"このアーティスト（同一別名義）のクレジットは既にこのトラックに存在します",
+	ROLE_ALREADY_EXISTS_FOR_CREDIT:
+		"この役割（同一位置）は既にこのクレジットに存在します",
+	OFFICIAL_SONG_ALREADY_LINKED:
+		"この公式楽曲は既に同じ順序でこのトラックに紐付けられています",
+	ITEMS_REQUIRED_NON_EMPTY: "itemsは必須で、空でない配列である必要があります",
+
+	// ===== 削除制約エラー =====
+	CANNOT_DELETE_SERIES_WITH_EVENTS:
+		"関連するイベントがあるため、このシリーズは削除できません",
+
+	// ===== バリデーションエラー (400) =====
+	INVALID_SORT_ORDER: "無効な並び順です",
+	INVALID_DIRECTION: "無効な方向です。'up' または 'down' を指定してください",
+	INVALID_ROLE_POSITION: "無効な役割位置です",
+	INVALID_STATE: "無効な状態です",
+	ITEMS_ARRAY_REQUIRED: "items配列が必要です",
+	ITEMS_MUST_HAVE_ID_AND_SORT_ORDER: "各要素にはidとsortOrderが必要です",
+	ITEMS_MUST_HAVE_CODE_AND_SORT_ORDER: "各要素にはcodeとsortOrderが必要です",
+	PARTICIPATION_TYPE_REQUIRED: "participationTypeクエリパラメータが必要です",
+	SOURCE_SONG_CANNOT_REFERENCE_ITSELF: "原曲は自身を参照できません",
+	DISC_REQUIRES_RELEASE: "ディスクを設定するにはリリースが必要です",
+	CANNOT_MOVE_FURTHER: "これ以上移動できません",
+	ALREADY_AT_TOP: "既に先頭です",
+	ALREADY_AT_BOTTOM: "既に末尾です",
+	ARTIST_ALIAS_NOT_BELONG_TO_ARTIST:
+		"アーティスト別名が見つからないか、指定されたアーティストに属していません",
+	URL_PATTERN_MISMATCH: "URLが選択されたプラットフォームの形式と一致しません",
+	EVENT_DAY_MISMATCH: "event_idとevent_day_idが整合していません",
+	MAXIMUM_BATCH_ITEMS: "一括操作は最大100件までです",
+
+	// ===== ファイルアップロード関連 =====
+	FILE_NOT_SPECIFIED: "ファイルが指定されていません",
+	FILE_NOT_UPLOADED: "ファイルがアップロードされていません",
+	ONLY_CSV_ALLOWED: "CSVファイルのみアップロード可能です",
+	FILE_SIZE_EXCEEDED: (maxSizeMB: number) =>
+		`ファイルサイズが${maxSizeMB}MBを超えています`,
+	DATA_FETCH_FAILED: "データの取得に失敗しました",
+	INVALID_REQUEST_DATA: "リクエストデータが不正です",
+	UNEXPECTED_ERROR: "予期しないエラーが発生しました",
+} as const;

--- a/apps/server/src/routes/admin/artist-aliases/index.ts
+++ b/apps/server/src/routes/admin/artist-aliases/index.ts
@@ -11,6 +11,7 @@ import {
 	updateArtistAliasSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 import { aliasCirclesRouter } from "./circles";
@@ -110,7 +111,7 @@ artistAliasesRouter.get("/:id", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ARTIST_ALIAS_NOT_FOUND }, 404);
 		}
 
 		return c.json(result[0]);
@@ -129,7 +130,7 @@ artistAliasesRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -144,7 +145,7 @@ artistAliasesRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingArtist.length === 0) {
-			return c.json({ error: "Artist not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ARTIST_NOT_FOUND }, 404);
 		}
 
 		// ID重複チェック
@@ -155,7 +156,7 @@ artistAliasesRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// 同一アーティスト内での名前重複チェック（大文字小文字無視）
@@ -171,10 +172,7 @@ artistAliasesRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingName.length > 0) {
-			return c.json(
-				{ error: "Alias name already exists for this artist" },
-				409,
-			);
+			return c.json({ error: ERROR_MESSAGES.ALIAS_ALREADY_EXISTS }, 409);
 		}
 
 		// 作成
@@ -203,7 +201,7 @@ artistAliasesRouter.put("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ARTIST_ALIAS_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -211,7 +209,7 @@ artistAliasesRouter.put("/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -234,10 +232,7 @@ artistAliasesRouter.put("/:id", async (c) => {
 				.limit(1);
 
 			if (existingName.length > 0 && existingName[0]?.id !== id) {
-				return c.json(
-					{ error: "Alias name already exists for this artist" },
-					409,
-				);
+				return c.json({ error: ERROR_MESSAGES.ALIAS_ALREADY_EXISTS }, 409);
 			}
 		}
 
@@ -267,7 +262,7 @@ artistAliasesRouter.delete("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ARTIST_ALIAS_NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/artists/index.ts
+++ b/apps/server/src/routes/admin/artists/index.ts
@@ -13,6 +13,7 @@ import {
 	updateArtistSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 import { artistCirclesRouter } from "./circles";
@@ -94,7 +95,7 @@ artistsRouter.get("/:id", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ARTIST_NOT_FOUND }, 404);
 		}
 
 		// 別名義一覧取得
@@ -123,7 +124,7 @@ artistsRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -138,7 +139,7 @@ artistsRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// 名前重複チェック（大文字小文字無視）
@@ -149,7 +150,7 @@ artistsRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingName.length > 0) {
-			return c.json({ error: "Name already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.NAME_ALREADY_EXISTS }, 409);
 		}
 
 		// 作成
@@ -175,7 +176,7 @@ artistsRouter.put("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ARTIST_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -183,7 +184,7 @@ artistsRouter.put("/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -199,7 +200,7 @@ artistsRouter.put("/:id", async (c) => {
 				.limit(1);
 
 			if (existingName.length > 0 && existingName[0]?.id !== id) {
-				return c.json({ error: "Name already exists" }, 409);
+				return c.json({ error: ERROR_MESSAGES.NAME_ALREADY_EXISTS }, 409);
 			}
 		}
 
@@ -229,7 +230,7 @@ artistsRouter.delete("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ARTIST_NOT_FOUND }, 404);
 		}
 
 		// 削除（関連別名義はCASCADE削除）

--- a/apps/server/src/routes/admin/circles/index.ts
+++ b/apps/server/src/routes/admin/circles/index.ts
@@ -15,6 +15,7 @@ import {
 	updateCircleSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 import { circleArtistsRouter } from "./artists";
@@ -94,7 +95,7 @@ circlesRouter.get("/:id", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
 		}
 
 		// 関連リンクを取得
@@ -136,7 +137,7 @@ circlesRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -151,7 +152,7 @@ circlesRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// 名前重複チェック（大文字小文字無視）
@@ -162,7 +163,7 @@ circlesRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingName.length > 0) {
-			return c.json({ error: "Name already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.NAME_ALREADY_EXISTS }, 409);
 		}
 
 		// 作成
@@ -188,7 +189,7 @@ circlesRouter.put("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -196,7 +197,7 @@ circlesRouter.put("/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -212,7 +213,7 @@ circlesRouter.put("/:id", async (c) => {
 				.limit(1);
 
 			if (existingName.length > 0 && existingName[0]?.id !== id) {
-				return c.json({ error: "Name already exists" }, 409);
+				return c.json({ error: ERROR_MESSAGES.NAME_ALREADY_EXISTS }, 409);
 			}
 		}
 
@@ -242,7 +243,7 @@ circlesRouter.delete("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
 		}
 
 		// 削除（関連リンクはCASCADE削除）
@@ -269,7 +270,7 @@ circlesRouter.get("/:circleId/links", async (c) => {
 			.limit(1);
 
 		if (existingCircle.length === 0) {
-			return c.json({ error: "Circle not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
 		}
 
 		const links = await db
@@ -311,7 +312,7 @@ circlesRouter.post("/:circleId/links", async (c) => {
 			.limit(1);
 
 		if (existingCircle.length === 0) {
-			return c.json({ error: "Circle not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -322,7 +323,7 @@ circlesRouter.post("/:circleId/links", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -337,7 +338,7 @@ circlesRouter.post("/:circleId/links", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// URL重複チェック（同一サークル内）
@@ -353,7 +354,10 @@ circlesRouter.post("/:circleId/links", async (c) => {
 			.limit(1);
 
 		if (existingUrl.length > 0) {
-			return c.json({ error: "URL already exists for this circle" }, 409);
+			return c.json(
+				{ error: ERROR_MESSAGES.URL_ALREADY_EXISTS_FOR_CIRCLE },
+				409,
+			);
 		}
 
 		// プラットフォームのURLパターンを取得してバリデーション
@@ -367,10 +371,7 @@ circlesRouter.post("/:circleId/links", async (c) => {
 			try {
 				const regex = new RegExp(platform[0].urlPattern);
 				if (!regex.test(parsed.data.url)) {
-					return c.json(
-						{ error: "URLが選択されたプラットフォームの形式と一致しません" },
-						400,
-					);
+					return c.json({ error: ERROR_MESSAGES.URL_PATTERN_MISMATCH }, 400);
 				}
 			} catch (e) {
 				// 無効な正規表現パターンの場合はスキップ
@@ -403,7 +404,7 @@ circlesRouter.put("/:circleId/links/:linkId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
 		}
 
 		// biome-ignore lint/style/noNonNullAssertion: existing.length > 0 is guaranteed by the check above
@@ -414,7 +415,7 @@ circlesRouter.put("/:circleId/links/:linkId", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -435,7 +436,10 @@ circlesRouter.put("/:circleId/links/:linkId", async (c) => {
 				.limit(1);
 
 			if (existingUrl.length > 0 && existingUrl[0]?.id !== linkId) {
-				return c.json({ error: "URL already exists for this circle" }, 409);
+				return c.json(
+					{ error: ERROR_MESSAGES.URL_ALREADY_EXISTS_FOR_CIRCLE },
+					409,
+				);
 			}
 		}
 
@@ -455,10 +459,7 @@ circlesRouter.put("/:circleId/links/:linkId", async (c) => {
 				try {
 					const regex = new RegExp(platform[0].urlPattern);
 					if (!regex.test(url)) {
-						return c.json(
-							{ error: "URLが選択されたプラットフォームの形式と一致しません" },
-							400,
-						);
+						return c.json({ error: ERROR_MESSAGES.URL_PATTERN_MISMATCH }, 400);
 					}
 				} catch (e) {
 					// 無効な正規表現パターンの場合はスキップ
@@ -499,7 +500,7 @@ circlesRouter.delete("/:circleId/links/:linkId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/circles/releases.ts
+++ b/apps/server/src/routes/admin/circles/releases.ts
@@ -7,6 +7,7 @@ import {
 	releases,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -25,7 +26,7 @@ circleReleasesRouter.get("/:circleId/releases", async (c) => {
 			.limit(1);
 
 		if (existingCircle.length === 0) {
-			return c.json({ error: "Circle not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
 		}
 
 		// リリースを参加形態別に取得

--- a/apps/server/src/routes/admin/events/event-days.ts
+++ b/apps/server/src/routes/admin/events/event-days.ts
@@ -8,6 +8,7 @@ import {
 	updateEventDaySchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -26,7 +27,7 @@ eventDaysRouter.get("/:eventId/days", async (c) => {
 			.limit(1);
 
 		if (existingEvent.length === 0) {
-			return c.json({ error: "Event not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.EVENT_NOT_FOUND }, 404);
 		}
 
 		const days = await db
@@ -55,7 +56,7 @@ eventDaysRouter.post("/:eventId/days", async (c) => {
 			.limit(1);
 
 		if (existingEvent.length === 0) {
-			return c.json({ error: "Event not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.EVENT_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -66,7 +67,7 @@ eventDaysRouter.post("/:eventId/days", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -81,7 +82,7 @@ eventDaysRouter.post("/:eventId/days", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// 日番号重複チェック（同一イベント内）
@@ -97,7 +98,7 @@ eventDaysRouter.post("/:eventId/days", async (c) => {
 			.limit(1);
 
 		if (existingDayNumber.length > 0) {
-			return c.json({ error: "Day number already exists for this event" }, 409);
+			return c.json({ error: ERROR_MESSAGES.DAY_NUMBER_ALREADY_EXISTS }, 409);
 		}
 
 		// 日付重複チェック（同一イベント内）
@@ -113,7 +114,7 @@ eventDaysRouter.post("/:eventId/days", async (c) => {
 			.limit(1);
 
 		if (existingDate.length > 0) {
-			return c.json({ error: "Date already exists for this event" }, 409);
+			return c.json({ error: ERROR_MESSAGES.DATE_ALREADY_EXISTS }, 409);
 		}
 
 		// 作成
@@ -140,7 +141,7 @@ eventDaysRouter.put("/:eventId/days/:dayId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.EVENT_DAY_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -148,7 +149,7 @@ eventDaysRouter.put("/:eventId/days/:dayId", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -169,10 +170,7 @@ eventDaysRouter.put("/:eventId/days/:dayId", async (c) => {
 				.limit(1);
 
 			if (existingDayNumber.length > 0 && existingDayNumber[0]?.id !== dayId) {
-				return c.json(
-					{ error: "Day number already exists for this event" },
-					409,
-				);
+				return c.json({ error: ERROR_MESSAGES.DAY_NUMBER_ALREADY_EXISTS }, 409);
 			}
 		}
 
@@ -190,7 +188,7 @@ eventDaysRouter.put("/:eventId/days/:dayId", async (c) => {
 				.limit(1);
 
 			if (existingDate.length > 0 && existingDate[0]?.id !== dayId) {
-				return c.json({ error: "Date already exists for this event" }, 409);
+				return c.json({ error: ERROR_MESSAGES.DATE_ALREADY_EXISTS }, 409);
 			}
 		}
 
@@ -221,7 +219,7 @@ eventDaysRouter.delete("/:eventId/days/:dayId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.EVENT_DAY_NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/events/events.ts
+++ b/apps/server/src/routes/admin/events/events.ts
@@ -12,6 +12,7 @@ import {
 	updateEventSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -107,7 +108,7 @@ eventsRouter.get("/:id", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.EVENT_NOT_FOUND }, 404);
 		}
 
 		// 関連開催日を取得（日番号順）
@@ -136,7 +137,7 @@ eventsRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -151,7 +152,7 @@ eventsRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// シリーズ存在チェック（eventSeriesIdが指定されている場合のみ）
@@ -163,7 +164,7 @@ eventsRouter.post("/", async (c) => {
 				.limit(1);
 
 			if (existingSeries.length === 0) {
-				return c.json({ error: "Event series not found" }, 404);
+				return c.json({ error: ERROR_MESSAGES.EVENT_SERIES_NOT_FOUND }, 404);
 			}
 
 			// 回次重複チェック（同一シリーズ内）
@@ -180,10 +181,7 @@ eventsRouter.post("/", async (c) => {
 					.limit(1);
 
 				if (existingEdition.length > 0) {
-					return c.json(
-						{ error: "Edition already exists in this series" },
-						409,
-					);
+					return c.json({ error: ERROR_MESSAGES.EDITION_ALREADY_EXISTS }, 409);
 				}
 			}
 		}
@@ -211,7 +209,7 @@ eventsRouter.put("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.EVENT_NOT_FOUND }, 404);
 		}
 
 		// biome-ignore lint/style/noNonNullAssertion: existing.length > 0 is guaranteed by the check above
@@ -222,7 +220,7 @@ eventsRouter.put("/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -238,7 +236,7 @@ eventsRouter.put("/:id", async (c) => {
 				.limit(1);
 
 			if (existingSeries.length === 0) {
-				return c.json({ error: "Event series not found" }, 404);
+				return c.json({ error: ERROR_MESSAGES.EVENT_SERIES_NOT_FOUND }, 404);
 			}
 		}
 
@@ -265,7 +263,7 @@ eventsRouter.put("/:id", async (c) => {
 				.limit(1);
 
 			if (existingEdition.length > 0 && existingEdition[0]?.id !== id) {
-				return c.json({ error: "Edition already exists in this series" }, 409);
+				return c.json({ error: ERROR_MESSAGES.EDITION_ALREADY_EXISTS }, 409);
 			}
 		}
 
@@ -295,7 +293,7 @@ eventsRouter.delete("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.EVENT_NOT_FOUND }, 404);
 		}
 
 		// 削除（開催日はCASCADE削除）

--- a/apps/server/src/routes/admin/import/legacy.ts
+++ b/apps/server/src/routes/admin/import/legacy.ts
@@ -4,6 +4,7 @@
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import {
 	checkNewEventsNeeded,
@@ -67,7 +68,7 @@ legacyImportRouter.post("/preview", async (c) => {
 			return c.json(
 				{
 					success: false,
-					error: "ファイルがアップロードされていません",
+					error: ERROR_MESSAGES.FILE_NOT_UPLOADED,
 				},
 				400,
 			);
@@ -78,7 +79,7 @@ legacyImportRouter.post("/preview", async (c) => {
 			return c.json(
 				{
 					success: false,
-					error: "CSVファイルのみアップロード可能です",
+					error: ERROR_MESSAGES.ONLY_CSV_ALLOWED,
 				},
 				400,
 			);
@@ -89,7 +90,7 @@ legacyImportRouter.post("/preview", async (c) => {
 			return c.json(
 				{
 					success: false,
-					error: `ファイルサイズが${MAX_FILE_SIZE / 1024 / 1024}MBを超えています`,
+					error: ERROR_MESSAGES.FILE_SIZE_EXCEEDED(MAX_FILE_SIZE / 1024 / 1024),
 				},
 				400,
 			);
@@ -158,7 +159,7 @@ legacyImportRouter.post("/preview", async (c) => {
 				error:
 					error instanceof Error
 						? error.message
-						: "予期しないエラーが発生しました",
+						: ERROR_MESSAGES.UNEXPECTED_ERROR,
 			},
 			500,
 		);
@@ -182,7 +183,7 @@ legacyImportRouter.post("/execute", async (c) => {
 			return c.json(
 				{
 					success: false,
-					error: "リクエストデータが不正です",
+					error: ERROR_MESSAGES.INVALID_REQUEST_DATA,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -255,7 +256,7 @@ legacyImportRouter.post("/execute", async (c) => {
 				error:
 					error instanceof Error
 						? error.message
-						: "予期しないエラーが発生しました",
+						: ERROR_MESSAGES.UNEXPECTED_ERROR,
 			},
 			500,
 		);

--- a/apps/server/src/routes/admin/master/alias-types.ts
+++ b/apps/server/src/routes/admin/master/alias-types.ts
@@ -12,6 +12,7 @@ import {
 	updateAliasTypeSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -77,12 +78,15 @@ aliasTypesRouter.put("/reorder", async (c) => {
 		const body = await c.req.json();
 
 		if (!body.items || !Array.isArray(body.items)) {
-			return c.json({ error: "items array is required" }, 400);
+			return c.json({ error: ERROR_MESSAGES.ITEMS_ARRAY_REQUIRED }, 400);
 		}
 
 		for (const item of body.items) {
 			if (!item.code || typeof item.sortOrder !== "number") {
-				return c.json({ error: "Each item must have code and sortOrder" }, 400);
+				return c.json(
+					{ error: ERROR_MESSAGES.ITEMS_MUST_HAVE_CODE_AND_SORT_ORDER },
+					400,
+				);
 			}
 			await db
 				.update(aliasTypes)
@@ -108,7 +112,7 @@ aliasTypesRouter.get("/:code", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ALIAS_TYPE_NOT_FOUND }, 404);
 		}
 
 		return c.json(result[0]);
@@ -127,7 +131,7 @@ aliasTypesRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -142,7 +146,7 @@ aliasTypesRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existing.length > 0) {
-			return c.json({ error: "Code already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.CODE_ALREADY_EXISTS }, 409);
 		}
 
 		// sortOrder が未指定の場合は最大値 + 1 を設定
@@ -180,7 +184,7 @@ aliasTypesRouter.put("/:code", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ALIAS_TYPE_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -188,7 +192,7 @@ aliasTypesRouter.put("/:code", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -221,7 +225,7 @@ aliasTypesRouter.delete("/:code", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ALIAS_TYPE_NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/master/credit-roles.ts
+++ b/apps/server/src/routes/admin/master/credit-roles.ts
@@ -12,6 +12,7 @@ import {
 	updateCreditRoleSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -77,12 +78,15 @@ creditRolesRouter.put("/reorder", async (c) => {
 		const body = await c.req.json();
 
 		if (!body.items || !Array.isArray(body.items)) {
-			return c.json({ error: "items array is required" }, 400);
+			return c.json({ error: ERROR_MESSAGES.ITEMS_ARRAY_REQUIRED }, 400);
 		}
 
 		for (const item of body.items) {
 			if (!item.code || typeof item.sortOrder !== "number") {
-				return c.json({ error: "Each item must have code and sortOrder" }, 400);
+				return c.json(
+					{ error: ERROR_MESSAGES.ITEMS_MUST_HAVE_CODE_AND_SORT_ORDER },
+					400,
+				);
 			}
 			await db
 				.update(creditRoles)
@@ -108,7 +112,7 @@ creditRolesRouter.get("/:code", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CREDIT_ROLE_NOT_FOUND }, 404);
 		}
 
 		return c.json(result[0]);
@@ -127,7 +131,7 @@ creditRolesRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -142,7 +146,7 @@ creditRolesRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existing.length > 0) {
-			return c.json({ error: "Code already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.CODE_ALREADY_EXISTS }, 409);
 		}
 
 		// sortOrder が未指定の場合は最大値 + 1 を設定
@@ -180,7 +184,7 @@ creditRolesRouter.put("/:code", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CREDIT_ROLE_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -188,7 +192,7 @@ creditRolesRouter.put("/:code", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -220,7 +224,7 @@ creditRolesRouter.delete("/:code", async (c) => {
 		.limit(1);
 
 	if (existing.length === 0) {
-		return c.json({ error: "Not found" }, 404);
+		return c.json({ error: ERROR_MESSAGES.CREDIT_ROLE_NOT_FOUND }, 404);
 	}
 
 	// 削除

--- a/apps/server/src/routes/admin/master/import.ts
+++ b/apps/server/src/routes/admin/master/import.ts
@@ -10,6 +10,7 @@ import {
 	platforms,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 import { parseAndValidate } from "../../../utils/import-parser";
@@ -23,7 +24,7 @@ importRouter.post("/platforms/import", async (c) => {
 		const file = body.file;
 
 		if (!(file instanceof File)) {
-			return c.json({ error: "ファイルが指定されていません" }, 400);
+			return c.json({ error: ERROR_MESSAGES.FILE_NOT_SPECIFIED }, 400);
 		}
 
 		const content = await file.text();
@@ -32,7 +33,7 @@ importRouter.post("/platforms/import", async (c) => {
 		if (!result.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					rows: result.errors,
 				},
 				400,
@@ -41,7 +42,7 @@ importRouter.post("/platforms/import", async (c) => {
 
 		const data = result.data;
 		if (!data) {
-			return c.json({ error: "データの取得に失敗しました" }, 500);
+			return c.json({ error: ERROR_MESSAGES.DATA_FETCH_FAILED }, 500);
 		}
 
 		let created = 0;
@@ -83,7 +84,7 @@ importRouter.post("/alias-types/import", async (c) => {
 		const file = body.file;
 
 		if (!(file instanceof File)) {
-			return c.json({ error: "ファイルが指定されていません" }, 400);
+			return c.json({ error: ERROR_MESSAGES.FILE_NOT_SPECIFIED }, 400);
 		}
 
 		const content = await file.text();
@@ -92,7 +93,7 @@ importRouter.post("/alias-types/import", async (c) => {
 		if (!result.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					rows: result.errors,
 				},
 				400,
@@ -101,7 +102,7 @@ importRouter.post("/alias-types/import", async (c) => {
 
 		const data = result.data;
 		if (!data) {
-			return c.json({ error: "データの取得に失敗しました" }, 500);
+			return c.json({ error: ERROR_MESSAGES.DATA_FETCH_FAILED }, 500);
 		}
 
 		let created = 0;
@@ -141,7 +142,7 @@ importRouter.post("/credit-roles/import", async (c) => {
 		const file = body.file;
 
 		if (!(file instanceof File)) {
-			return c.json({ error: "ファイルが指定されていません" }, 400);
+			return c.json({ error: ERROR_MESSAGES.FILE_NOT_SPECIFIED }, 400);
 		}
 
 		const content = await file.text();
@@ -150,7 +151,7 @@ importRouter.post("/credit-roles/import", async (c) => {
 		if (!result.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					rows: result.errors,
 				},
 				400,
@@ -159,7 +160,7 @@ importRouter.post("/credit-roles/import", async (c) => {
 
 		const data = result.data;
 		if (!data) {
-			return c.json({ error: "データの取得に失敗しました" }, 500);
+			return c.json({ error: ERROR_MESSAGES.DATA_FETCH_FAILED }, 500);
 		}
 
 		let created = 0;
@@ -199,7 +200,7 @@ importRouter.post("/official-work-categories/import", async (c) => {
 		const file = body.file;
 
 		if (!(file instanceof File)) {
-			return c.json({ error: "ファイルが指定されていません" }, 400);
+			return c.json({ error: ERROR_MESSAGES.FILE_NOT_SPECIFIED }, 400);
 		}
 
 		const content = await file.text();
@@ -212,7 +213,7 @@ importRouter.post("/official-work-categories/import", async (c) => {
 		if (!result.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					rows: result.errors,
 				},
 				400,
@@ -221,7 +222,7 @@ importRouter.post("/official-work-categories/import", async (c) => {
 
 		const data = result.data;
 		if (!data) {
-			return c.json({ error: "データの取得に失敗しました" }, 500);
+			return c.json({ error: ERROR_MESSAGES.DATA_FETCH_FAILED }, 500);
 		}
 
 		let created = 0;

--- a/apps/server/src/routes/admin/master/official-work-categories.ts
+++ b/apps/server/src/routes/admin/master/official-work-categories.ts
@@ -12,6 +12,7 @@ import {
 	updateOfficialWorkCategorySchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -80,12 +81,15 @@ officialWorkCategoriesRouter.put("/reorder", async (c) => {
 		const body = await c.req.json();
 
 		if (!body.items || !Array.isArray(body.items)) {
-			return c.json({ error: "items array is required" }, 400);
+			return c.json({ error: ERROR_MESSAGES.ITEMS_ARRAY_REQUIRED }, 400);
 		}
 
 		for (const item of body.items) {
 			if (!item.code || typeof item.sortOrder !== "number") {
-				return c.json({ error: "Each item must have code and sortOrder" }, 400);
+				return c.json(
+					{ error: ERROR_MESSAGES.ITEMS_MUST_HAVE_CODE_AND_SORT_ORDER },
+					400,
+				);
 			}
 			await db
 				.update(officialWorkCategories)
@@ -115,7 +119,10 @@ officialWorkCategoriesRouter.get("/:code", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json(
+				{ error: ERROR_MESSAGES.OFFICIAL_WORK_CATEGORY_NOT_FOUND },
+				404,
+			);
 		}
 
 		return c.json(result[0]);
@@ -134,7 +141,7 @@ officialWorkCategoriesRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -149,7 +156,7 @@ officialWorkCategoriesRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existing.length > 0) {
-			return c.json({ error: "Code already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.CODE_ALREADY_EXISTS }, 409);
 		}
 
 		// sortOrder が未指定の場合は最大値 + 1 を設定
@@ -187,7 +194,10 @@ officialWorkCategoriesRouter.put("/:code", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json(
+				{ error: ERROR_MESSAGES.OFFICIAL_WORK_CATEGORY_NOT_FOUND },
+				404,
+			);
 		}
 
 		// バリデーション
@@ -195,7 +205,7 @@ officialWorkCategoriesRouter.put("/:code", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -228,7 +238,10 @@ officialWorkCategoriesRouter.delete("/:code", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json(
+				{ error: ERROR_MESSAGES.OFFICIAL_WORK_CATEGORY_NOT_FOUND },
+				404,
+			);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/master/platforms.ts
+++ b/apps/server/src/routes/admin/master/platforms.ts
@@ -13,6 +13,7 @@ import {
 	updatePlatformSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -93,12 +94,15 @@ platformsRouter.put("/reorder", async (c) => {
 		const body = await c.req.json();
 
 		if (!body.items || !Array.isArray(body.items)) {
-			return c.json({ error: "items array is required" }, 400);
+			return c.json({ error: ERROR_MESSAGES.ITEMS_ARRAY_REQUIRED }, 400);
 		}
 
 		for (const item of body.items) {
 			if (!item.code || typeof item.sortOrder !== "number") {
-				return c.json({ error: "Each item must have code and sortOrder" }, 400);
+				return c.json(
+					{ error: ERROR_MESSAGES.ITEMS_MUST_HAVE_CODE_AND_SORT_ORDER },
+					400,
+				);
 			}
 			await db
 				.update(platforms)
@@ -124,7 +128,7 @@ platformsRouter.get("/:code", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.PLATFORM_NOT_FOUND }, 404);
 		}
 
 		return c.json(result[0]);
@@ -143,7 +147,7 @@ platformsRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -158,7 +162,7 @@ platformsRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existing.length > 0) {
-			return c.json({ error: "Code already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.CODE_ALREADY_EXISTS }, 409);
 		}
 
 		// sortOrder が未指定の場合は最大値 + 1 を設定
@@ -196,7 +200,7 @@ platformsRouter.put("/:code", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.PLATFORM_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -204,7 +208,7 @@ platformsRouter.put("/:code", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -237,7 +241,7 @@ platformsRouter.delete("/:code", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.PLATFORM_NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/official/songs.ts
+++ b/apps/server/src/routes/admin/official/songs.ts
@@ -16,6 +16,7 @@ import {
 	updateOfficialSongSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 import { parseAndValidate } from "../../../utils/import-parser";
@@ -135,7 +136,7 @@ songsRouter.get("/:id", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 		}
 
 		return c.json(result[0]);
@@ -154,7 +155,7 @@ songsRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -169,12 +170,15 @@ songsRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// sourceSongIdの自己参照チェック
 		if (parsed.data.sourceSongId === parsed.data.id) {
-			return c.json({ error: "Source song cannot reference itself" }, 400);
+			return c.json(
+				{ error: ERROR_MESSAGES.SOURCE_SONG_CANNOT_REFERENCE_ITSELF },
+				400,
+			);
 		}
 
 		// 作成
@@ -203,7 +207,7 @@ songsRouter.put("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -211,7 +215,7 @@ songsRouter.put("/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -220,7 +224,10 @@ songsRouter.put("/:id", async (c) => {
 
 		// sourceSongIdの自己参照チェック
 		if (parsed.data.sourceSongId === id) {
-			return c.json({ error: "Source song cannot reference itself" }, 400);
+			return c.json(
+				{ error: ERROR_MESSAGES.SOURCE_SONG_CANNOT_REFERENCE_ITSELF },
+				400,
+			);
 		}
 
 		// 更新
@@ -249,7 +256,7 @@ songsRouter.delete("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 		}
 
 		// 削除
@@ -268,7 +275,7 @@ songsRouter.post("/import", async (c) => {
 		const file = body.file;
 
 		if (!(file instanceof File)) {
-			return c.json({ error: "ファイルが指定されていません" }, 400);
+			return c.json({ error: ERROR_MESSAGES.FILE_NOT_SPECIFIED }, 400);
 		}
 
 		const content = await file.text();
@@ -281,7 +288,7 @@ songsRouter.post("/import", async (c) => {
 		if (!result.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					rows: result.errors,
 				},
 				400,
@@ -290,7 +297,7 @@ songsRouter.post("/import", async (c) => {
 
 		const data = result.data;
 		if (!data) {
-			return c.json({ error: "データの取得に失敗しました" }, 500);
+			return c.json({ error: ERROR_MESSAGES.DATA_FETCH_FAILED }, 500);
 		}
 
 		// 自己参照チェック
@@ -308,7 +315,7 @@ songsRouter.post("/import", async (c) => {
 		if (selfRefErrors.length > 0) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					rows: selfRefErrors,
 				},
 				400,
@@ -368,7 +375,7 @@ songsRouter.get("/:songId/links", async (c) => {
 			.limit(1);
 
 		if (existingSong.length === 0) {
-			return c.json({ error: "Song not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 		}
 
 		const links = await db
@@ -407,7 +414,7 @@ songsRouter.post("/:songId/links", async (c) => {
 			.limit(1);
 
 		if (existingSong.length === 0) {
-			return c.json({ error: "Song not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -418,7 +425,7 @@ songsRouter.post("/:songId/links", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -433,7 +440,7 @@ songsRouter.post("/:songId/links", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// URL重複チェック（同一楽曲内）
@@ -449,7 +456,7 @@ songsRouter.post("/:songId/links", async (c) => {
 			.limit(1);
 
 		if (existingUrl.length > 0) {
-			return c.json({ error: "URL already exists for this song" }, 409);
+			return c.json({ error: ERROR_MESSAGES.URL_ALREADY_EXISTS_FOR_SONG }, 409);
 		}
 
 		// 作成
@@ -483,7 +490,7 @@ songsRouter.put("/:songId/links/:linkId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -491,7 +498,7 @@ songsRouter.put("/:songId/links/:linkId", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -512,7 +519,10 @@ songsRouter.put("/:songId/links/:linkId", async (c) => {
 				.limit(1);
 
 			if (existingUrl.length > 0 && existingUrl[0]?.id !== linkId) {
-				return c.json({ error: "URL already exists for this song" }, 409);
+				return c.json(
+					{ error: ERROR_MESSAGES.URL_ALREADY_EXISTS_FOR_SONG },
+					409,
+				);
 			}
 		}
 
@@ -551,7 +561,7 @@ songsRouter.delete("/:songId/links/:linkId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 		}
 
 		// 削除
@@ -587,13 +597,13 @@ songsRouter.put("/:songId/links/:linkId/reorder", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
 		const sortOrder = Number(body.sortOrder);
 		if (Number.isNaN(sortOrder) || sortOrder < 0) {
-			return c.json({ error: "Invalid sortOrder" }, 400);
+			return c.json({ error: ERROR_MESSAGES.INVALID_SORT_ORDER }, 400);
 		}
 
 		// 更新

--- a/apps/server/src/routes/admin/official/works.ts
+++ b/apps/server/src/routes/admin/official/works.ts
@@ -14,6 +14,7 @@ import {
 	updateOfficialWorkSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 import { parseAndValidate } from "../../../utils/import-parser";
@@ -88,7 +89,7 @@ worksRouter.get("/:id", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.WORK_NOT_FOUND }, 404);
 		}
 
 		return c.json(result[0]);
@@ -107,7 +108,7 @@ worksRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -122,7 +123,7 @@ worksRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// 作成
@@ -151,7 +152,7 @@ worksRouter.put("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.WORK_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -159,7 +160,7 @@ worksRouter.put("/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -192,7 +193,7 @@ worksRouter.delete("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.WORK_NOT_FOUND }, 404);
 		}
 
 		// 削除（関連楽曲はCASCADE削除）
@@ -211,7 +212,7 @@ worksRouter.post("/import", async (c) => {
 		const file = body.file;
 
 		if (!(file instanceof File)) {
-			return c.json({ error: "ファイルが指定されていません" }, 400);
+			return c.json({ error: ERROR_MESSAGES.FILE_NOT_SPECIFIED }, 400);
 		}
 
 		const content = await file.text();
@@ -224,7 +225,7 @@ worksRouter.post("/import", async (c) => {
 		if (!result.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					rows: result.errors,
 				},
 				400,
@@ -233,7 +234,7 @@ worksRouter.post("/import", async (c) => {
 
 		const data = result.data;
 		if (!data) {
-			return c.json({ error: "データの取得に失敗しました" }, 500);
+			return c.json({ error: ERROR_MESSAGES.DATA_FETCH_FAILED }, 500);
 		}
 
 		let created = 0;
@@ -290,7 +291,7 @@ worksRouter.get("/:workId/links", async (c) => {
 			.limit(1);
 
 		if (existingWork.length === 0) {
-			return c.json({ error: "Work not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.WORK_NOT_FOUND }, 404);
 		}
 
 		const links = await db
@@ -329,7 +330,7 @@ worksRouter.post("/:workId/links", async (c) => {
 			.limit(1);
 
 		if (existingWork.length === 0) {
-			return c.json({ error: "Work not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.WORK_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -340,7 +341,7 @@ worksRouter.post("/:workId/links", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -355,7 +356,7 @@ worksRouter.post("/:workId/links", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// URL重複チェック（同一作品内）
@@ -371,7 +372,7 @@ worksRouter.post("/:workId/links", async (c) => {
 			.limit(1);
 
 		if (existingUrl.length > 0) {
-			return c.json({ error: "URL already exists for this work" }, 409);
+			return c.json({ error: ERROR_MESSAGES.URL_ALREADY_EXISTS_FOR_WORK }, 409);
 		}
 
 		// 作成
@@ -405,7 +406,7 @@ worksRouter.put("/:workId/links/:linkId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.WORK_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -413,7 +414,7 @@ worksRouter.put("/:workId/links/:linkId", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -434,7 +435,10 @@ worksRouter.put("/:workId/links/:linkId", async (c) => {
 				.limit(1);
 
 			if (existingUrl.length > 0 && existingUrl[0]?.id !== linkId) {
-				return c.json({ error: "URL already exists for this work" }, 409);
+				return c.json(
+					{ error: ERROR_MESSAGES.URL_ALREADY_EXISTS_FOR_WORK },
+					409,
+				);
 			}
 		}
 
@@ -473,7 +477,7 @@ worksRouter.delete("/:workId/links/:linkId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.WORK_NOT_FOUND }, 404);
 		}
 
 		// 削除
@@ -509,13 +513,13 @@ worksRouter.put("/:workId/links/:linkId/reorder", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.WORK_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
 		const sortOrder = Number(body.sortOrder);
 		if (Number.isNaN(sortOrder) || sortOrder < 0) {
-			return c.json({ error: "Invalid sortOrder" }, 400);
+			return c.json({ error: ERROR_MESSAGES.INVALID_SORT_ORDER }, 400);
 		}
 
 		// 更新

--- a/apps/server/src/routes/admin/releases/discs.ts
+++ b/apps/server/src/routes/admin/releases/discs.ts
@@ -8,6 +8,7 @@ import {
 	updateDiscSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -26,7 +27,7 @@ discsRouter.get("/:releaseId/discs", async (c) => {
 			.limit(1);
 
 		if (existingRelease.length === 0) {
-			return c.json({ error: "Release not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		const releaseDiscs = await db
@@ -55,7 +56,7 @@ discsRouter.post("/:releaseId/discs", async (c) => {
 			.limit(1);
 
 		if (existingRelease.length === 0) {
-			return c.json({ error: "Release not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -66,7 +67,7 @@ discsRouter.post("/:releaseId/discs", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -81,7 +82,7 @@ discsRouter.post("/:releaseId/discs", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// ディスク番号重複チェック（同一リリース内）
@@ -98,7 +99,7 @@ discsRouter.post("/:releaseId/discs", async (c) => {
 
 		if (existingDiscNumber.length > 0) {
 			return c.json(
-				{ error: "Disc number already exists for this release" },
+				{ error: ERROR_MESSAGES.DISC_NUMBER_ALREADY_EXISTS_FOR_RELEASE },
 				409,
 			);
 		}
@@ -127,7 +128,7 @@ discsRouter.put("/:releaseId/discs/:discId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.DISC_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -135,7 +136,7 @@ discsRouter.put("/:releaseId/discs/:discId", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -160,7 +161,7 @@ discsRouter.put("/:releaseId/discs/:discId", async (c) => {
 				existingDiscNumber[0]?.id !== discId
 			) {
 				return c.json(
-					{ error: "Disc number already exists for this release" },
+					{ error: ERROR_MESSAGES.DISC_NUMBER_ALREADY_EXISTS_FOR_RELEASE },
 					409,
 				);
 			}
@@ -197,7 +198,7 @@ discsRouter.delete("/:releaseId/discs/:discId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.DISC_NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/releases/jan-codes.ts
+++ b/apps/server/src/routes/admin/releases/jan-codes.ts
@@ -8,6 +8,7 @@ import {
 	updateReleaseJanCodeSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -26,7 +27,7 @@ releaseJanCodesRouter.get("/:releaseId/jan-codes", async (c) => {
 			.limit(1);
 
 		if (existingRelease.length === 0) {
-			return c.json({ error: "Release not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		// JANコード一覧取得
@@ -55,7 +56,7 @@ releaseJanCodesRouter.post("/:releaseId/jan-codes", async (c) => {
 			.limit(1);
 
 		if (existingRelease.length === 0) {
-			return c.json({ error: "Release not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -66,7 +67,7 @@ releaseJanCodesRouter.post("/:releaseId/jan-codes", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -81,7 +82,7 @@ releaseJanCodesRouter.post("/:releaseId/jan-codes", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// JANコードのグローバル一意性チェック
@@ -92,7 +93,7 @@ releaseJanCodesRouter.post("/:releaseId/jan-codes", async (c) => {
 			.limit(1);
 
 		if (janDuplicateCheck.length > 0) {
-			return c.json({ error: "JAN code already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.JAN_CODE_ALREADY_EXISTS }, 409);
 		}
 
 		// isPrimary制約チェック（同一リリース内でisPrimaryは1件のみ）
@@ -110,7 +111,7 @@ releaseJanCodesRouter.post("/:releaseId/jan-codes", async (c) => {
 
 			if (primaryCheck.length > 0) {
 				return c.json(
-					{ error: "Primary JAN code already exists for this release" },
+					{ error: ERROR_MESSAGES.PRIMARY_JAN_CODE_ALREADY_EXISTS },
 					409,
 				);
 			}
@@ -148,7 +149,7 @@ releaseJanCodesRouter.put("/:releaseId/jan-codes/:id", async (c) => {
 			.limit(1);
 
 		if (existingJanCode.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.JAN_CODE_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -156,7 +157,7 @@ releaseJanCodesRouter.put("/:releaseId/jan-codes/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -178,7 +179,7 @@ releaseJanCodesRouter.put("/:releaseId/jan-codes/:id", async (c) => {
 
 			if (primaryCheck.length > 0 && primaryCheck[0]?.id !== id) {
 				return c.json(
-					{ error: "Primary JAN code already exists for this release" },
+					{ error: ERROR_MESSAGES.PRIMARY_JAN_CODE_ALREADY_EXISTS },
 					409,
 				);
 			}
@@ -220,7 +221,7 @@ releaseJanCodesRouter.delete("/:releaseId/jan-codes/:id", async (c) => {
 			.limit(1);
 
 		if (existingJanCode.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.JAN_CODE_NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/releases/publications.ts
+++ b/apps/server/src/routes/admin/releases/publications.ts
@@ -9,6 +9,7 @@ import {
 	updateReleasePublicationSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -27,7 +28,7 @@ releasePublicationsRouter.get("/:releaseId/publications", async (c) => {
 			.limit(1);
 
 		if (existingRelease.length === 0) {
-			return c.json({ error: "Release not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		// 公開リンク一覧取得（プラットフォーム情報を結合）
@@ -69,7 +70,7 @@ releasePublicationsRouter.post("/:releaseId/publications", async (c) => {
 			.limit(1);
 
 		if (existingRelease.length === 0) {
-			return c.json({ error: "Release not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		// プラットフォーム存在チェック
@@ -80,7 +81,7 @@ releasePublicationsRouter.post("/:releaseId/publications", async (c) => {
 			.limit(1);
 
 		if (existingPlatform.length === 0) {
-			return c.json({ error: "Platform not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.PLATFORM_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -91,7 +92,7 @@ releasePublicationsRouter.post("/:releaseId/publications", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -106,7 +107,7 @@ releasePublicationsRouter.post("/:releaseId/publications", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// URL重複チェック
@@ -117,7 +118,7 @@ releasePublicationsRouter.post("/:releaseId/publications", async (c) => {
 			.limit(1);
 
 		if (urlDuplicateCheck.length > 0) {
-			return c.json({ error: "URL already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.URL_ALREADY_EXISTS }, 409);
 		}
 
 		// 作成
@@ -156,7 +157,7 @@ releasePublicationsRouter.put("/:releaseId/publications/:id", async (c) => {
 			.limit(1);
 
 		if (existingPublication.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.PUBLICATION_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -164,7 +165,7 @@ releasePublicationsRouter.put("/:releaseId/publications/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -180,7 +181,7 @@ releasePublicationsRouter.put("/:releaseId/publications/:id", async (c) => {
 				.limit(1);
 
 			if (urlDuplicateCheck.length > 0 && urlDuplicateCheck[0]?.id !== id) {
-				return c.json({ error: "URL already exists" }, 409);
+				return c.json({ error: ERROR_MESSAGES.URL_ALREADY_EXISTS }, 409);
 			}
 		}
 
@@ -220,7 +221,7 @@ releasePublicationsRouter.delete("/:releaseId/publications/:id", async (c) => {
 			.limit(1);
 
 		if (existingPublication.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.PUBLICATION_NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/releases/release-circles.ts
+++ b/apps/server/src/routes/admin/releases/release-circles.ts
@@ -9,6 +9,7 @@ import {
 	updateReleaseCircleSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -27,7 +28,7 @@ releaseCirclesRouter.get("/:releaseId/circles", async (c) => {
 			.limit(1);
 
 		if (existingRelease.length === 0) {
-			return c.json({ error: "Release not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		// 関連サークル一覧取得（サークル情報を含む）
@@ -69,7 +70,7 @@ releaseCirclesRouter.post("/:releaseId/circles", async (c) => {
 			.limit(1);
 
 		if (existingRelease.length === 0) {
-			return c.json({ error: "Release not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -80,7 +81,7 @@ releaseCirclesRouter.post("/:releaseId/circles", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -95,7 +96,7 @@ releaseCirclesRouter.post("/:releaseId/circles", async (c) => {
 			.limit(1);
 
 		if (existingCircle.length === 0) {
-			return c.json({ error: "Circle not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
 		}
 
 		// 重複チェック（同一作品・同一サークル・同一参加形態）
@@ -112,7 +113,7 @@ releaseCirclesRouter.post("/:releaseId/circles", async (c) => {
 			.limit(1);
 
 		if (existingAssociation.length > 0) {
-			return c.json({ error: "Association already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ASSOCIATION_ALREADY_EXISTS }, 409);
 		}
 
 		// positionが未指定の場合、最大値+1を設定
@@ -154,10 +155,7 @@ releaseCirclesRouter.patch("/:releaseId/circles/:circleId", async (c) => {
 
 		// 参加形態が指定されていない場合はエラー
 		if (!participationType) {
-			return c.json(
-				{ error: "participationType query parameter is required" },
-				400,
-			);
+			return c.json({ error: ERROR_MESSAGES.PARTICIPATION_TYPE_REQUIRED }, 400);
 		}
 
 		// 存在チェック
@@ -174,7 +172,7 @@ releaseCirclesRouter.patch("/:releaseId/circles/:circleId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -182,7 +180,7 @@ releaseCirclesRouter.patch("/:releaseId/circles/:circleId", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -221,10 +219,7 @@ releaseCirclesRouter.delete("/:releaseId/circles/:circleId", async (c) => {
 
 		// 参加形態が指定されていない場合はエラー
 		if (!participationType) {
-			return c.json(
-				{ error: "participationType query parameter is required" },
-				400,
-			);
+			return c.json({ error: ERROR_MESSAGES.PARTICIPATION_TYPE_REQUIRED }, 400);
 		}
 
 		// 存在チェック
@@ -241,7 +236,7 @@ releaseCirclesRouter.delete("/:releaseId/circles/:circleId", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/releases/releases.ts
+++ b/apps/server/src/routes/admin/releases/releases.ts
@@ -13,6 +13,7 @@ import {
 	updateReleaseSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -190,7 +191,7 @@ releasesRouter.get("/:id", async (c) => {
 			.limit(1);
 
 		if (result.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		// 関連ディスクを取得（ディスク番号順）
@@ -219,7 +220,7 @@ releasesRouter.post("/", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -234,7 +235,7 @@ releasesRouter.post("/", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// event_id と event_day_id の整合性チェック
@@ -283,7 +284,7 @@ releasesRouter.put("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -291,7 +292,7 @@ releasesRouter.put("/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -375,7 +376,7 @@ releasesRouter.delete("/:id", async (c) => {
 			.limit(1);
 
 		if (existing.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
 		// 削除（ディスクはCASCADE削除）

--- a/apps/server/src/routes/admin/releases/track-credit-roles.ts
+++ b/apps/server/src/routes/admin/releases/track-credit-roles.ts
@@ -9,6 +9,7 @@ import {
 	tracks,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -39,7 +40,7 @@ trackCreditRolesRouter.post(
 				.limit(1);
 
 			if (existingCredit.length === 0) {
-				return c.json({ error: "Credit not found" }, 404);
+				return c.json({ error: ERROR_MESSAGES.CREDIT_NOT_FOUND }, 404);
 			}
 
 			// 役割マスター存在チェック
@@ -50,7 +51,7 @@ trackCreditRolesRouter.post(
 				.limit(1);
 
 			if (existingRole.length === 0) {
-				return c.json({ error: "Role not found in master data" }, 400);
+				return c.json({ error: ERROR_MESSAGES.ROLE_NOT_FOUND_IN_MASTER }, 400);
 			}
 
 			// バリデーション
@@ -61,7 +62,7 @@ trackCreditRolesRouter.post(
 			if (!parsed.success) {
 				return c.json(
 					{
-						error: "Validation failed",
+						error: ERROR_MESSAGES.VALIDATION_FAILED,
 						details: parsed.error.flatten().fieldErrors,
 					},
 					400,
@@ -84,8 +85,7 @@ trackCreditRolesRouter.post(
 			if (existingRoleAssignment.length > 0) {
 				return c.json(
 					{
-						error:
-							"This role with the same position already exists for this credit",
+						error: ERROR_MESSAGES.ROLE_ALREADY_EXISTS_FOR_CREDIT,
 					},
 					409,
 				);
@@ -136,7 +136,7 @@ trackCreditRolesRouter.delete(
 			const rolePosition = Number.parseInt(c.req.param("rolePosition"), 10);
 
 			if (Number.isNaN(rolePosition)) {
-				return c.json({ error: "Invalid role position" }, 400);
+				return c.json({ error: ERROR_MESSAGES.INVALID_ROLE_POSITION }, 400);
 			}
 
 			// クレジット存在チェック（トラック・リリースとの関連確認含む）
@@ -154,7 +154,7 @@ trackCreditRolesRouter.delete(
 				.limit(1);
 
 			if (existingCredit.length === 0) {
-				return c.json({ error: "Credit not found" }, 404);
+				return c.json({ error: ERROR_MESSAGES.CREDIT_NOT_FOUND }, 404);
 			}
 
 			// 役割存在チェック
@@ -171,7 +171,7 @@ trackCreditRolesRouter.delete(
 				.limit(1);
 
 			if (existingRoleAssignment.length === 0) {
-				return c.json({ error: "Role not found" }, 404);
+				return c.json({ error: ERROR_MESSAGES.ROLE_NOT_FOUND }, 404);
 			}
 
 			// 削除

--- a/apps/server/src/routes/admin/releases/track-credits.ts
+++ b/apps/server/src/routes/admin/releases/track-credits.ts
@@ -15,6 +15,7 @@ import {
 	updateTrackCreditSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -34,7 +35,7 @@ trackCreditsRouter.get("/:releaseId/tracks/:trackId/credits", async (c) => {
 			.limit(1);
 
 		if (existingTrack.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// クレジット一覧取得（アーティスト・別名義・役割情報を結合）
@@ -102,7 +103,7 @@ trackCreditsRouter.post("/:releaseId/tracks/:trackId/credits", async (c) => {
 			.limit(1);
 
 		if (existingTrack.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// アーティスト存在チェック
@@ -113,7 +114,7 @@ trackCreditsRouter.post("/:releaseId/tracks/:trackId/credits", async (c) => {
 			.limit(1);
 
 		if (existingArtist.length === 0) {
-			return c.json({ error: "Artist not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.ARTIST_NOT_FOUND }, 404);
 		}
 
 		// 別名義存在チェック（指定された場合）
@@ -131,7 +132,7 @@ trackCreditsRouter.post("/:releaseId/tracks/:trackId/credits", async (c) => {
 
 			if (existingAlias.length === 0) {
 				return c.json(
-					{ error: "Artist alias not found or does not belong to the artist" },
+					{ error: ERROR_MESSAGES.ARTIST_ALIAS_NOT_BELONG_TO_ARTIST },
 					404,
 				);
 			}
@@ -145,7 +146,7 @@ trackCreditsRouter.post("/:releaseId/tracks/:trackId/credits", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -160,7 +161,7 @@ trackCreditsRouter.post("/:releaseId/tracks/:trackId/credits", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// 同一アーティスト・同一別名義の重複チェック
@@ -194,8 +195,7 @@ trackCreditsRouter.post("/:releaseId/tracks/:trackId/credits", async (c) => {
 		if (duplicateCheck.length > 0) {
 			return c.json(
 				{
-					error:
-						"Credit for this artist (with same alias) already exists on this track",
+					error: ERROR_MESSAGES.CREDIT_ALREADY_EXISTS_FOR_TRACK,
 				},
 				409,
 			);
@@ -268,7 +268,7 @@ trackCreditsRouter.put(
 				.limit(1);
 
 			if (existingCredit.length === 0) {
-				return c.json({ error: "Not found" }, 404);
+				return c.json({ error: ERROR_MESSAGES.CREDIT_NOT_FOUND }, 404);
 			}
 
 			// アーティスト存在チェック（変更される場合）
@@ -280,7 +280,7 @@ trackCreditsRouter.put(
 					.limit(1);
 
 				if (existingArtist.length === 0) {
-					return c.json({ error: "Artist not found" }, 404);
+					return c.json({ error: ERROR_MESSAGES.ARTIST_NOT_FOUND }, 404);
 				}
 			}
 
@@ -302,7 +302,7 @@ trackCreditsRouter.put(
 				if (existingAlias.length === 0) {
 					return c.json(
 						{
-							error: "Artist alias not found or does not belong to the artist",
+							error: ERROR_MESSAGES.ARTIST_ALIAS_NOT_BELONG_TO_ARTIST,
 						},
 						404,
 					);
@@ -314,7 +314,7 @@ trackCreditsRouter.put(
 			if (!parsed.success) {
 				return c.json(
 					{
-						error: "Validation failed",
+						error: ERROR_MESSAGES.VALIDATION_FAILED,
 						details: parsed.error.flatten().fieldErrors,
 					},
 					400,
@@ -360,8 +360,7 @@ trackCreditsRouter.put(
 				if (duplicateCheck.length > 0 && duplicateCheck[0]?.id !== creditId) {
 					return c.json(
 						{
-							error:
-								"Credit for this artist (with same alias) already exists on this track",
+							error: ERROR_MESSAGES.CREDIT_ALREADY_EXISTS_FOR_TRACK,
 						},
 						409,
 					);
@@ -441,7 +440,7 @@ trackCreditsRouter.delete(
 				.limit(1);
 
 			if (existingCredit.length === 0) {
-				return c.json({ error: "Not found" }, 404);
+				return c.json({ error: ERROR_MESSAGES.CREDIT_NOT_FOUND }, 404);
 			}
 
 			// 削除（役割はCASCADEで自動削除）

--- a/apps/server/src/routes/admin/tracks/derivations.ts
+++ b/apps/server/src/routes/admin/tracks/derivations.ts
@@ -8,6 +8,7 @@ import {
 	tracks,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -26,7 +27,7 @@ trackDerivationsRouter.get("/:trackId/derivations", async (c) => {
 			.limit(1);
 
 		if (existingTrack.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// 派生関係一覧取得（派生元トラック情報・リリース情報を結合）
@@ -71,7 +72,7 @@ trackDerivationsRouter.post("/:trackId/derivations", async (c) => {
 			.limit(1);
 
 		if (existingTrack.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// 親トラック存在チェック
@@ -82,7 +83,7 @@ trackDerivationsRouter.post("/:trackId/derivations", async (c) => {
 			.limit(1);
 
 		if (existingParentTrack.length === 0) {
-			return c.json({ error: "Parent track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.PARENT_TRACK_NOT_FOUND }, 404);
 		}
 
 		// バリデーション（自己参照チェックを含む）
@@ -93,7 +94,7 @@ trackDerivationsRouter.post("/:trackId/derivations", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -108,7 +109,7 @@ trackDerivationsRouter.post("/:trackId/derivations", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// 一意性チェック（子トラック × 親トラック）
@@ -124,10 +125,7 @@ trackDerivationsRouter.post("/:trackId/derivations", async (c) => {
 			.limit(1);
 
 		if (duplicateCheck.length > 0) {
-			return c.json(
-				{ error: "This derivation relationship already exists" },
-				409,
-			);
+			return c.json({ error: ERROR_MESSAGES.DERIVATION_ALREADY_EXISTS }, 409);
 		}
 
 		// 作成
@@ -161,7 +159,7 @@ trackDerivationsRouter.delete("/:trackId/derivations/:id", async (c) => {
 			.limit(1);
 
 		if (existingDerivation.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/tracks/index.ts
+++ b/apps/server/src/routes/admin/tracks/index.ts
@@ -22,6 +22,7 @@ import {
 	tracks,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 import { trackDerivationsRouter } from "./derivations";
@@ -305,12 +306,12 @@ tracksAdminRouter.get("/:trackId", async (c) => {
 			.limit(1);
 
 		if (trackResult.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		const row = trackResult[0];
 		if (!row) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// クレジット一覧取得（アーティスト・別名義・役割情報を結合）
@@ -399,15 +400,12 @@ tracksAdminRouter.delete("/batch", async (c) => {
 		};
 
 		if (!Array.isArray(items) || items.length === 0) {
-			return c.json(
-				{ error: "items is required and must be a non-empty array" },
-				400,
-			);
+			return c.json({ error: ERROR_MESSAGES.ITEMS_REQUIRED_NON_EMPTY }, 400);
 		}
 
 		// 上限チェック（一度に100件まで）
 		if (items.length > 100) {
-			return c.json({ error: "Maximum 100 items per batch" }, 400);
+			return c.json({ error: ERROR_MESSAGES.MAXIMUM_BATCH_ITEMS }, 400);
 		}
 
 		const deleted: string[] = [];
@@ -428,7 +426,10 @@ tracksAdminRouter.delete("/batch", async (c) => {
 					.limit(1);
 
 				if (existing.length === 0) {
-					failed.push({ trackId: item.trackId, error: "Not found" });
+					failed.push({
+						trackId: item.trackId,
+						error: ERROR_MESSAGES.TRACK_NOT_FOUND,
+					});
 					continue;
 				}
 

--- a/apps/server/src/routes/admin/tracks/isrcs.ts
+++ b/apps/server/src/routes/admin/tracks/isrcs.ts
@@ -8,6 +8,7 @@ import {
 	updateTrackIsrcSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -26,7 +27,7 @@ trackIsrcsRouter.get("/:trackId/isrcs", async (c) => {
 			.limit(1);
 
 		if (existingTrack.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// ISRC一覧取得
@@ -55,7 +56,7 @@ trackIsrcsRouter.post("/:trackId/isrcs", async (c) => {
 			.limit(1);
 
 		if (existingTrack.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -66,7 +67,7 @@ trackIsrcsRouter.post("/:trackId/isrcs", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -81,7 +82,7 @@ trackIsrcsRouter.post("/:trackId/isrcs", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// トラック×ISRCの一意性チェック
@@ -97,7 +98,7 @@ trackIsrcsRouter.post("/:trackId/isrcs", async (c) => {
 			.limit(1);
 
 		if (isrcDuplicateCheck.length > 0) {
-			return c.json({ error: "ISRC already exists for this track" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ISRC_ALREADY_EXISTS }, 409);
 		}
 
 		// isPrimary制約チェック（同一トラック内でisPrimaryは1件のみ）
@@ -112,7 +113,7 @@ trackIsrcsRouter.post("/:trackId/isrcs", async (c) => {
 
 			if (primaryCheck.length > 0) {
 				return c.json(
-					{ error: "Primary ISRC already exists for this track" },
+					{ error: ERROR_MESSAGES.PRIMARY_ISRC_ALREADY_EXISTS },
 					409,
 				);
 			}
@@ -142,7 +143,7 @@ trackIsrcsRouter.put("/:trackId/isrcs/:id", async (c) => {
 			.limit(1);
 
 		if (existingIsrc.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -150,7 +151,7 @@ trackIsrcsRouter.put("/:trackId/isrcs/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -169,7 +170,7 @@ trackIsrcsRouter.put("/:trackId/isrcs/:id", async (c) => {
 
 			if (primaryCheck.length > 0 && primaryCheck[0]?.id !== id) {
 				return c.json(
-					{ error: "Primary ISRC already exists for this track" },
+					{ error: ERROR_MESSAGES.PRIMARY_ISRC_ALREADY_EXISTS },
 					409,
 				);
 			}
@@ -202,7 +203,7 @@ trackIsrcsRouter.delete("/:trackId/isrcs/:id", async (c) => {
 			.limit(1);
 
 		if (existingIsrc.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/routes/admin/tracks/official-songs.ts
+++ b/apps/server/src/routes/admin/tracks/official-songs.ts
@@ -10,6 +10,7 @@ import {
 	updateTrackOfficialSongSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -28,7 +29,7 @@ trackOfficialSongsRouter.get("/:trackId/official-songs", async (c) => {
 			.limit(1);
 
 		if (existingTrack.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// 原曲紐付け一覧取得（公式楽曲情報を結合）
@@ -70,7 +71,7 @@ trackOfficialSongsRouter.post("/:trackId/official-songs", async (c) => {
 			.limit(1);
 
 		if (existingTrack.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// 公式楽曲存在チェック（officialSongIdが指定されている場合のみ）
@@ -82,7 +83,7 @@ trackOfficialSongsRouter.post("/:trackId/official-songs", async (c) => {
 				.limit(1);
 
 			if (existingOfficialSong.length === 0) {
-				return c.json({ error: "Official song not found" }, 404);
+				return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 			}
 		}
 
@@ -105,7 +106,7 @@ trackOfficialSongsRouter.post("/:trackId/official-songs", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -120,7 +121,7 @@ trackOfficialSongsRouter.post("/:trackId/official-songs", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// 一意性チェック（トラック × 公式楽曲 × 順序、公式楽曲が指定されている場合のみ）
@@ -142,8 +143,7 @@ trackOfficialSongsRouter.post("/:trackId/official-songs", async (c) => {
 			if (duplicateCheck.length > 0) {
 				return c.json(
 					{
-						error:
-							"This official song is already linked to the track with the same part position",
+						error: ERROR_MESSAGES.OFFICIAL_SONG_ALREADY_LINKED,
 					},
 					409,
 				);
@@ -186,7 +186,7 @@ trackOfficialSongsRouter.put("/:trackId/official-songs/:id", async (c) => {
 			.limit(1);
 
 		if (existingRelation.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -194,7 +194,7 @@ trackOfficialSongsRouter.put("/:trackId/official-songs/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -228,8 +228,7 @@ trackOfficialSongsRouter.put("/:trackId/official-songs/:id", async (c) => {
 			if (duplicateCheck.length > 0 && duplicateCheck[0]?.id !== id) {
 				return c.json(
 					{
-						error:
-							"This official song is already linked to the track with the same part position",
+						error: ERROR_MESSAGES.OFFICIAL_SONG_ALREADY_LINKED,
 					},
 					409,
 				);
@@ -272,7 +271,7 @@ trackOfficialSongsRouter.delete("/:trackId/official-songs/:id", async (c) => {
 			.limit(1);
 
 		if (existingRelation.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.NOT_FOUND }, 404);
 		}
 
 		// 削除
@@ -306,20 +305,20 @@ trackOfficialSongsRouter.patch(
 
 			const currentIndex = relations.findIndex((r) => r.id === id);
 			if (currentIndex === -1) {
-				return c.json({ error: "Not found" }, 404);
+				return c.json({ error: ERROR_MESSAGES.NOT_FOUND }, 404);
 			}
 
 			const swapIndex =
 				body.direction === "up" ? currentIndex - 1 : currentIndex + 1;
 			if (swapIndex < 0 || swapIndex >= relations.length) {
-				return c.json({ error: "Cannot move further" }, 400);
+				return c.json({ error: ERROR_MESSAGES.CANNOT_MOVE_FURTHER }, 400);
 			}
 
 			const currentItem = relations[currentIndex];
 			const swapItem = relations[swapIndex];
 
 			if (!currentItem || !swapItem) {
-				return c.json({ error: "Invalid state" }, 500);
+				return c.json({ error: ERROR_MESSAGES.INVALID_STATE }, 500);
 			}
 
 			// 順序を入れ替え

--- a/apps/server/src/routes/admin/tracks/publications.ts
+++ b/apps/server/src/routes/admin/tracks/publications.ts
@@ -9,6 +9,7 @@ import {
 	updateTrackPublicationSchema,
 } from "@thac/db";
 import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
@@ -27,7 +28,7 @@ trackPublicationsRouter.get("/:trackId/publications", async (c) => {
 			.limit(1);
 
 		if (existingTrack.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// 公開リンク一覧取得（プラットフォーム情報を結合）
@@ -65,7 +66,7 @@ trackPublicationsRouter.post("/:trackId/publications", async (c) => {
 			.limit(1);
 
 		if (existingTrack.length === 0) {
-			return c.json({ error: "Track not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
 		}
 
 		// プラットフォーム存在チェック
@@ -76,7 +77,7 @@ trackPublicationsRouter.post("/:trackId/publications", async (c) => {
 			.limit(1);
 
 		if (existingPlatform.length === 0) {
-			return c.json({ error: "Platform not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.PLATFORM_NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -87,7 +88,7 @@ trackPublicationsRouter.post("/:trackId/publications", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -102,7 +103,7 @@ trackPublicationsRouter.post("/:trackId/publications", async (c) => {
 			.limit(1);
 
 		if (existingId.length > 0) {
-			return c.json({ error: "ID already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.ID_ALREADY_EXISTS }, 409);
 		}
 
 		// URL重複チェック
@@ -113,7 +114,7 @@ trackPublicationsRouter.post("/:trackId/publications", async (c) => {
 			.limit(1);
 
 		if (urlDuplicateCheck.length > 0) {
-			return c.json({ error: "URL already exists" }, 409);
+			return c.json({ error: ERROR_MESSAGES.URL_ALREADY_EXISTS }, 409);
 		}
 
 		// 作成
@@ -148,7 +149,7 @@ trackPublicationsRouter.put("/:trackId/publications/:id", async (c) => {
 			.limit(1);
 
 		if (existingPublication.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.NOT_FOUND }, 404);
 		}
 
 		// バリデーション
@@ -156,7 +157,7 @@ trackPublicationsRouter.put("/:trackId/publications/:id", async (c) => {
 		if (!parsed.success) {
 			return c.json(
 				{
-					error: "Validation failed",
+					error: ERROR_MESSAGES.VALIDATION_FAILED,
 					details: parsed.error.flatten().fieldErrors,
 				},
 				400,
@@ -172,7 +173,7 @@ trackPublicationsRouter.put("/:trackId/publications/:id", async (c) => {
 				.limit(1);
 
 			if (urlDuplicateCheck.length > 0 && urlDuplicateCheck[0]?.id !== id) {
-				return c.json({ error: "URL already exists" }, 409);
+				return c.json({ error: ERROR_MESSAGES.URL_ALREADY_EXISTS }, 409);
 			}
 		}
 
@@ -212,7 +213,7 @@ trackPublicationsRouter.delete("/:trackId/publications/:id", async (c) => {
 			.limit(1);
 
 		if (existingPublication.length === 0) {
-			return c.json({ error: "Not found" }, 404);
+			return c.json({ error: ERROR_MESSAGES.NOT_FOUND }, 404);
 		}
 
 		// 削除

--- a/apps/server/src/utils/api-error.ts
+++ b/apps/server/src/utils/api-error.ts
@@ -1,4 +1,5 @@
 import type { Context } from "hono";
+import { ERROR_MESSAGES } from "../constants/error-messages";
 
 /**
  * 統一エラーレスポンス形式
@@ -42,7 +43,7 @@ export function handleDbError(c: Context, error: unknown, operation: string) {
 
 	const isDev = process.env.NODE_ENV === "development";
 	const response: ApiErrorResponse = {
-		error: "データベースエラーが発生しました",
+		error: ERROR_MESSAGES.DB_ERROR,
 		code: ErrorCodes.DB_ERROR,
 	};
 


### PR DESCRIPTION
## 概要

管理APIのエラーメッセージが日本語と英語で混在している問題を解決し、全エラーメッセージを日本語に統一

## 変更内容

* エラーメッセージ定数ファイルを新規作成（`apps/server/src/constants/error-messages.ts`）
* 55個のエラーメッセージ定数を定義
  - 汎用エラー: 3個（NOT_FOUND, VALIDATION_FAILED, DB_ERROR等）
  - リソース別 Not Found: 24個（EVENT_NOT_FOUND, ARTIST_NOT_FOUND等）
  - 重複エラー (409): 18個（ID_ALREADY_EXISTS, NAME_ALREADY_EXISTS等）
  - バリデーションエラー (400): 14個
  - ファイルアップロード関連: 6個
* 全管理APIルート（30ファイル）で定数を使用するよう変更
  - master/（5ファイル）
  - events/（3ファイル）
  - artists/（3ファイル）
  - artist-aliases/（3ファイル）
  - circles/（4ファイル）
  - official/（2ファイル）
  - releases/（8ファイル）
  - tracks/（5ファイル）
  - import/（1ファイル）

## 影響範囲

* 管理API全体のエラーレスポンス
* フロントエンドでのエラーメッセージ表示（日本語に統一されるため、ユーザー体験が向上）

## 補足事項

* 既存のAPIレスポンス形式（`{ error: "メッセージ" }`）は変更なし
* `handleDbError`ユーティリティも日本語定数を使用するよう更新済み

Closes #97