### PR TITLE
feat: アーティスト・サークル・リリース・名義一覧にバッチ削除機能を追加

### DIFF
--- a/apps/server/src/routes/admin/artists/index.ts
+++ b/apps/server/src/routes/admin/artists/index.ts
@@ -242,4 +242,60 @@ artistsRouter.delete("/:id", async (c) => {
 	}
 });
 
+// アーティスト一括削除
+artistsRouter.delete("/batch", async (c) => {
+	try {
+		const body = await c.req.json();
+		const { ids } = body as { ids: string[] };
+
+		if (!Array.isArray(ids) || ids.length === 0) {
+			return c.json({ error: ERROR_MESSAGES.ITEMS_REQUIRED_NON_EMPTY }, 400);
+		}
+
+		// 上限チェック（一度に100件まで）
+		if (ids.length > 100) {
+			return c.json({ error: ERROR_MESSAGES.MAXIMUM_BATCH_ITEMS }, 400);
+		}
+
+		const deleted: string[] = [];
+		const failed: Array<{ id: string; error: string }> = [];
+
+		for (const id of ids) {
+			try {
+				// 存在チェック
+				const existing = await db
+					.select()
+					.from(artists)
+					.where(eq(artists.id, id))
+					.limit(1);
+
+				if (existing.length === 0) {
+					failed.push({
+						id,
+						error: ERROR_MESSAGES.ARTIST_NOT_FOUND,
+					});
+					continue;
+				}
+
+				// 削除（関連別名義はCASCADE削除）
+				await db.delete(artists).where(eq(artists.id, id));
+				deleted.push(id);
+			} catch (e) {
+				failed.push({
+					id,
+					error: e instanceof Error ? e.message : "Unknown error",
+				});
+			}
+		}
+
+		return c.json({
+			success: failed.length === 0,
+			deleted: deleted.length,
+			failed,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/artists/batch");
+	}
+});
+
 export { artistsRouter };

--- a/apps/server/src/routes/admin/circles/index.ts
+++ b/apps/server/src/routes/admin/circles/index.ts
@@ -516,4 +516,60 @@ circlesRouter.delete("/:circleId/links/:linkId", async (c) => {
 	}
 });
 
+// サークル一括削除
+circlesRouter.delete("/batch", async (c) => {
+	try {
+		const body = await c.req.json();
+		const { ids } = body as { ids: string[] };
+
+		if (!Array.isArray(ids) || ids.length === 0) {
+			return c.json({ error: ERROR_MESSAGES.ITEMS_REQUIRED_NON_EMPTY }, 400);
+		}
+
+		// 上限チェック（一度に100件まで）
+		if (ids.length > 100) {
+			return c.json({ error: ERROR_MESSAGES.MAXIMUM_BATCH_ITEMS }, 400);
+		}
+
+		const deleted: string[] = [];
+		const failed: Array<{ id: string; error: string }> = [];
+
+		for (const id of ids) {
+			try {
+				// 存在チェック
+				const existing = await db
+					.select()
+					.from(circles)
+					.where(eq(circles.id, id))
+					.limit(1);
+
+				if (existing.length === 0) {
+					failed.push({
+						id,
+						error: ERROR_MESSAGES.CIRCLE_NOT_FOUND,
+					});
+					continue;
+				}
+
+				// 削除（関連リンクはCASCADE削除）
+				await db.delete(circles).where(eq(circles.id, id));
+				deleted.push(id);
+			} catch (e) {
+				failed.push({
+					id,
+					error: e instanceof Error ? e.message : "Unknown error",
+				});
+			}
+		}
+
+		return c.json({
+			success: failed.length === 0,
+			deleted: deleted.length,
+			failed,
+		});
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /admin/circles/batch");
+	}
+});
+
 export { circlesRouter };

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1037,6 +1037,15 @@ export const artistsApi = {
 		fetchWithAuth<{ success: boolean }>(`/api/admin/artists/${id}`, {
 			method: "DELETE",
 		}),
+	batchDelete: (ids: string[]) =>
+		fetchWithAuth<{
+			success: boolean;
+			deleted: number;
+			failed: Array<{ id: string; error: string }>;
+		}>("/api/admin/artists/batch", {
+			method: "DELETE",
+			body: JSON.stringify({ ids }),
+		}),
 };
 
 // Artist Aliases
@@ -1082,6 +1091,15 @@ export const artistAliasesApi = {
 		fetchWithAuth<{ success: boolean }>(`/api/admin/artist-aliases/${id}`, {
 			method: "DELETE",
 		}),
+	batchDelete: (ids: string[]) =>
+		fetchWithAuth<{
+			success: boolean;
+			deleted: number;
+			failed: Array<{ id: string; error: string }>;
+		}>("/api/admin/artist-aliases/batch", {
+			method: "DELETE",
+			body: JSON.stringify({ ids }),
+		}),
 };
 
 // Circles
@@ -1121,6 +1139,15 @@ export const circlesApi = {
 	delete: (id: string) =>
 		fetchWithAuth<{ success: boolean }>(`/api/admin/circles/${id}`, {
 			method: "DELETE",
+		}),
+	batchDelete: (ids: string[]) =>
+		fetchWithAuth<{
+			success: boolean;
+			deleted: number;
+			failed: Array<{ id: string; error: string }>;
+		}>("/api/admin/circles/batch", {
+			method: "DELETE",
+			body: JSON.stringify({ ids }),
 		}),
 };
 
@@ -1414,6 +1441,15 @@ export const releasesApi = {
 	delete: (id: string) =>
 		fetchWithAuth<{ success: boolean }>(`/api/admin/releases/${id}`, {
 			method: "DELETE",
+		}),
+	batchDelete: (ids: string[]) =>
+		fetchWithAuth<{
+			success: boolean;
+			deleted: number;
+			failed: Array<{ id: string; error: string }>;
+		}>("/api/admin/releases/batch", {
+			method: "DELETE",
+			body: JSON.stringify({ ids }),
 		}),
 };
 

--- a/apps/web/src/routes/admin/_admin/releases.tsx
+++ b/apps/web/src/routes/admin/_admin/releases.tsx
@@ -11,6 +11,8 @@ import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
 import { ReleaseEditDialog } from "@/components/admin/release-edit-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
 	Dialog,
 	DialogContent,
@@ -33,6 +35,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
+import { useRowSelection } from "@/hooks/use-row-selection";
 import {
 	discsApi,
 	eventDaysApi,
@@ -114,6 +117,23 @@ function ReleasesPage() {
 	const [selectedEventIdForCreate, setSelectedEventIdForCreate] = useState<
 		string | null
 	>(null);
+
+	// 選択状態管理
+	const {
+		selectedItems,
+		isSelected,
+		isAllSelected,
+		isIndeterminate,
+		toggleItem,
+		toggleAll,
+		clearSelection,
+		selectedCount,
+	} = useRowSelection<ReleaseWithCounts>();
+
+	// 一括削除ダイアログ状態
+	const [isBatchDeleteDialogOpen, setIsBatchDeleteDialogOpen] = useState(false);
+	const [isBatchDeleting, setIsBatchDeleting] = useState(false);
+	const [batchDeleteError, setBatchDeleteError] = useState<string | null>(null);
 
 	const { data, isPending, error } = useQuery(
 		releasesListQueryOptions({
@@ -250,6 +270,39 @@ function ReleasesPage() {
 		}
 	};
 
+	const handleBatchDelete = async () => {
+		setIsBatchDeleting(true);
+		setBatchDeleteError(null);
+
+		try {
+			const ids = Array.from(selectedItems.values()).map((item) => item.id);
+
+			if (ids.length === 0) {
+				setBatchDeleteError("削除可能な作品がありません");
+				return;
+			}
+
+			const result = await releasesApi.batchDelete(ids);
+
+			if (result.failed.length > 0) {
+				setBatchDeleteError(
+					`${result.deleted}件削除、${result.failed.length}件失敗`,
+				);
+			} else {
+				setIsBatchDeleteDialogOpen(false);
+				clearSelection();
+			}
+
+			invalidateQuery();
+		} catch (e) {
+			setBatchDeleteError(
+				e instanceof Error ? e.message : "一括削除に失敗しました",
+			);
+		} finally {
+			setIsBatchDeleting(false);
+		}
+	};
+
 	// 作品を編集モードで開く（詳細取得）
 	const handleEdit = async (release: ReleaseWithCounts) => {
 		try {
@@ -321,7 +374,29 @@ function ReleasesPage() {
 						label: "新規作成",
 						onClick: () => setIsCreateDialogOpen(true),
 					}}
-				/>
+					secondaryActions={
+						selectedCount > 0
+							? [
+									{
+										label: `選択中の${selectedCount}件を削除`,
+										icon: <Trash2 className="mr-2 h-4 w-4" />,
+										onClick: () => setIsBatchDeleteDialogOpen(true),
+									},
+								]
+							: undefined
+					}
+				>
+					{selectedCount > 0 && (
+						<div className="flex items-center gap-2">
+							<span className="text-base-content/70 text-sm">
+								{selectedCount}件選択中
+							</span>
+							<Button variant="ghost" size="sm" onClick={clearSelection}>
+								選択解除
+							</Button>
+						</div>
+					)}
+				</DataTableActionBar>
 
 				{displayError && (
 					<div className="border-base-300 border-b bg-error/10 p-3 text-error text-sm">
@@ -341,6 +416,14 @@ function ReleasesPage() {
 						<Table zebra>
 							<TableHeader>
 								<TableRow className="hover:bg-transparent">
+									<TableHead className="w-[50px]">
+										<Checkbox
+											checked={isAllSelected(releases)}
+											indeterminate={isIndeterminate(releases)}
+											onCheckedChange={() => toggleAll(releases)}
+											aria-label="すべて選択"
+										/>
+									</TableHead>
 									{isVisible("id") && (
 										<TableHead className="w-[220px]">ID</TableHead>
 									)}
@@ -378,7 +461,7 @@ function ReleasesPage() {
 								{releases.length === 0 ? (
 									<TableRow>
 										<TableCell
-											colSpan={visibleColumns.size + 1}
+											colSpan={visibleColumns.size + 2}
 											className="h-24 text-center text-base-content/50"
 										>
 											該当する作品が見つかりません
@@ -386,7 +469,19 @@ function ReleasesPage() {
 									</TableRow>
 								) : (
 									releases.map((release) => (
-										<TableRow key={release.id}>
+										<TableRow
+											key={release.id}
+											className={
+												isSelected(release.id) ? "bg-primary/5" : undefined
+											}
+										>
+											<TableCell>
+												<Checkbox
+													checked={isSelected(release.id)}
+													onCheckedChange={() => toggleItem(release)}
+													aria-label={`${release.name}を選択`}
+												/>
+											</TableCell>
 											{isVisible("id") && (
 												<TableCell className="font-mono text-base-content/50 text-xs">
 													{release.id}
@@ -702,6 +797,33 @@ function ReleasesPage() {
 					onSuccess={invalidateQuery}
 				/>
 			)}
+
+			{/* 一括削除確認ダイアログ */}
+			<ConfirmDialog
+				open={isBatchDeleteDialogOpen}
+				onOpenChange={(open) => {
+					setIsBatchDeleteDialogOpen(open);
+					if (!open) {
+						setBatchDeleteError(null);
+					}
+				}}
+				title="作品の一括削除"
+				description={
+					<div>
+						<p>選択した{selectedCount}件の作品を削除しますか？</p>
+						<p className="mt-2 text-error text-sm">
+							※関連するディスク・トラックも削除されます。この操作は取り消せません。
+						</p>
+						{batchDeleteError && (
+							<p className="mt-2 text-error text-sm">{batchDeleteError}</p>
+						)}
+					</div>
+				}
+				confirmLabel="削除する"
+				variant="danger"
+				onConfirm={handleBatchDelete}
+				isLoading={isBatchDeleting}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/routes/admin/_admin/tracks.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks.tsx
@@ -301,16 +301,6 @@ function TracksPage() {
 							: undefined
 					}
 				>
-					{selectedCount > 0 && (
-						<div className="flex items-center gap-2">
-							<span className="text-base-content/70 text-sm">
-								{selectedCount}件選択中
-							</span>
-							<Button variant="ghost" size="sm" onClick={clearSelection}>
-								選択解除
-							</Button>
-						</div>
-					)}
 					<SearchableSelect
 						value={releaseFilter}
 						onChange={(value) => handleReleaseFilterChange(value || "")}
@@ -321,6 +311,16 @@ function TracksPage() {
 						clearable={true}
 						className="w-[200px]"
 					/>
+					{selectedCount > 0 && (
+						<div className="flex items-center gap-2">
+							<span className="text-base-content/70 text-sm">
+								{selectedCount}件選択中
+							</span>
+							<Button variant="ghost" size="sm" onClick={clearSelection}>
+								選択解除
+							</Button>
+						</div>
+					)}
 				</DataTableActionBar>
 
 				{displayError && (


### PR DESCRIPTION
## 概要

アーティスト・サークル・リリース・アーティスト名義の各一覧ページにバッチ削除機能を追加し、トラック管理のUI表示位置を統一

Closes #98

## 変更内容

### バックエンド
* artists, circles, releases, artist-aliases に DELETE `/batch` エンドポイントを追加
* 上限100件チェック、存在確認、カスケード削除に対応

### APIクライアント
* `artistsApi.batchDelete()` メソッドを追加
* `circlesApi.batchDelete()` メソッドを追加
* `releasesApi.batchDelete()` メソッドを追加
* `artistAliasesApi.batchDelete()` メソッドを追加

### フロントエンド
* 各一覧ページにバッチ削除UIを追加
  * `useRowSelection` フックで選択状態を管理
  * テーブルヘッダー・各行にチェックボックス列を追加
  * `DataTableActionBar` に一括削除ボタンを追加
  * `ConfirmDialog` で削除確認

### UI改善
* 「選択中」表示位置を統一（tracks, artist-aliases で SearchableSelect の後ろに配置）

## 影響範囲

* `/admin/artists` - アーティスト一覧
* `/admin/circles` - サークル一覧
* `/admin/releases` - リリース一覧
* `/admin/artist-aliases` - アーティスト名義一覧
* `/admin/tracks` - トラック一覧（UI表示位置の修正のみ）