### PR TITLE
feat: 管理画面の削除確認をConfirmDialogコンポーネントに統一

### DIFF
--- a/apps/web/src/routes/admin/_admin/event-series_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/event-series_.$id.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, Home, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { DetailPageSkeleton } from "@/components/admin/detail-page-skeleton";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
 	Dialog,
 	DialogContent,
@@ -44,6 +45,7 @@ function EventSeriesDetailPage() {
 	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 	const [editForm, setEditForm] = useState<Partial<EventSeries>>({});
 	const [isDeleting, setIsDeleting] = useState(false);
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
@@ -79,17 +81,11 @@ function EventSeriesDetailPage() {
 
 	const handleDelete = async () => {
 		if (!series) return;
-		if (
-			!confirm(
-				`「${series.name}」を削除しますか？\n\n※ イベントが紐付いている場合は削除できません。`,
-			)
-		)
-			return;
-
 		setIsDeleting(true);
 		setError(null);
 		try {
 			await eventSeriesApi.delete(id);
+			setIsDeleteDialogOpen(false);
 			queryClient.invalidateQueries({ queryKey: ["eventSeries"] });
 			navigate({ to: "/admin/event-series" });
 		} catch (e) {
@@ -98,6 +94,7 @@ function EventSeriesDetailPage() {
 					? e.message
 					: "削除に失敗しました。イベントが紐付いている可能性があります。",
 			);
+		} finally {
 			setIsDeleting(false);
 		}
 	};
@@ -164,11 +161,10 @@ function EventSeriesDetailPage() {
 						variant="outline"
 						size="sm"
 						className="text-error hover:text-error"
-						onClick={handleDelete}
-						disabled={isDeleting}
+						onClick={() => setIsDeleteDialogOpen(true)}
 					>
 						<Trash2 className="mr-2 h-4 w-4" />
-						{isDeleting ? "削除中..." : "削除"}
+						削除
 					</Button>
 				</div>
 			</div>
@@ -286,6 +282,25 @@ function EventSeriesDetailPage() {
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>
+
+			{/* 削除確認ダイアログ */}
+			<ConfirmDialog
+				open={isDeleteDialogOpen}
+				onOpenChange={setIsDeleteDialogOpen}
+				title="イベントシリーズの削除"
+				description={
+					<div>
+						<p>「{series?.name}」を削除しますか？</p>
+						<p className="mt-2 text-error text-sm">
+							※イベントが紐付いている場合は削除できません。
+						</p>
+					</div>
+				}
+				confirmLabel="削除する"
+				variant="danger"
+				onConfirm={handleDelete}
+				isLoading={isDeleting}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/routes/admin/_admin/master/alias-types_.$code.tsx
+++ b/apps/web/src/routes/admin/_admin/master/alias-types_.$code.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Home, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { AliasTypeEditDialog } from "@/components/admin/alias-type-edit-dialog";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Label } from "@/components/ui/label";
 import { getAliasType } from "@/functions/get-alias-type";
 import { aliasTypesApi } from "@/lib/api-client";
@@ -24,6 +25,7 @@ function AliasTypeDetailPage() {
 	const queryClient = useQueryClient();
 
 	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
@@ -34,17 +36,11 @@ function AliasTypeDetailPage() {
 
 	const handleDelete = async () => {
 		if (!aliasType) return;
-		if (
-			!confirm(
-				`「${aliasType.label}」を削除しますか？\n\n※ 使用中の場合は削除できません。`,
-			)
-		)
-			return;
-
 		setIsDeleting(true);
 		setError(null);
 		try {
 			await aliasTypesApi.delete(aliasType.code);
+			setIsDeleteDialogOpen(false);
 			queryClient.invalidateQueries({ queryKey: ["aliasTypes"] });
 			navigate({ to: "/admin/master/alias-types" });
 		} catch (e) {
@@ -53,6 +49,7 @@ function AliasTypeDetailPage() {
 					? e.message
 					: "削除に失敗しました。使用中の可能性があります。",
 			);
+		} finally {
 			setIsDeleting(false);
 		}
 	};
@@ -110,11 +107,10 @@ function AliasTypeDetailPage() {
 						variant="outline"
 						size="sm"
 						className="text-error hover:text-error"
-						onClick={handleDelete}
-						disabled={isDeleting}
+						onClick={() => setIsDeleteDialogOpen(true)}
 					>
 						<Trash2 className="mr-2 h-4 w-4" />
-						{isDeleting ? "削除中..." : "削除"}
+						削除
 					</Button>
 				</div>
 			</div>
@@ -158,6 +154,25 @@ function AliasTypeDetailPage() {
 				mode="edit"
 				aliasType={aliasType}
 				onSuccess={handleEditSuccess}
+			/>
+
+			{/* 削除確認ダイアログ */}
+			<ConfirmDialog
+				open={isDeleteDialogOpen}
+				onOpenChange={setIsDeleteDialogOpen}
+				title="名義種別の削除"
+				description={
+					<div>
+						<p>「{aliasType?.label}」を削除しますか？</p>
+						<p className="mt-2 text-error text-sm">
+							※使用中の場合は削除できません。
+						</p>
+					</div>
+				}
+				confirmLabel="削除する"
+				variant="danger"
+				onConfirm={handleDelete}
+				isLoading={isDeleting}
 			/>
 		</div>
 	);

--- a/apps/web/src/routes/admin/_admin/master/platforms_.$code.tsx
+++ b/apps/web/src/routes/admin/_admin/master/platforms_.$code.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { DetailPageSkeleton } from "@/components/admin/detail-page-skeleton";
 import { PlatformEditDialog } from "@/components/admin/platform-edit-dialog";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Label } from "@/components/ui/label";
 import { platformsApi } from "@/lib/api-client";
 import { createMasterDetailHead } from "@/lib/head";
@@ -30,6 +31,7 @@ function PlatformDetailPage() {
 	);
 
 	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
@@ -41,17 +43,11 @@ function PlatformDetailPage() {
 
 	const handleDelete = async () => {
 		if (!platform) return;
-		if (
-			!confirm(
-				`「${platform.name}」を削除しますか？\n\n※ 使用中の場合は削除できません。`,
-			)
-		)
-			return;
-
 		setIsDeleting(true);
 		setError(null);
 		try {
 			await platformsApi.delete(platform.code);
+			setIsDeleteDialogOpen(false);
 			queryClient.invalidateQueries({ queryKey: ["platforms"] });
 			navigate({ to: "/admin/master/platforms" });
 		} catch (e) {
@@ -60,6 +56,7 @@ function PlatformDetailPage() {
 					? e.message
 					: "削除に失敗しました。使用中の可能性があります。",
 			);
+		} finally {
 			setIsDeleting(false);
 		}
 	};
@@ -118,11 +115,10 @@ function PlatformDetailPage() {
 						variant="outline"
 						size="sm"
 						className="text-error hover:text-error"
-						onClick={handleDelete}
-						disabled={isDeleting}
+						onClick={() => setIsDeleteDialogOpen(true)}
 					>
 						<Trash2 className="mr-2 h-4 w-4" />
-						{isDeleting ? "削除中..." : "削除"}
+						削除
 					</Button>
 				</div>
 			</div>
@@ -172,6 +168,25 @@ function PlatformDetailPage() {
 				onSuccess={() => {
 					queryClient.invalidateQueries({ queryKey: ["platform", code] });
 				}}
+			/>
+
+			{/* 削除確認ダイアログ */}
+			<ConfirmDialog
+				open={isDeleteDialogOpen}
+				onOpenChange={setIsDeleteDialogOpen}
+				title="プラットフォームの削除"
+				description={
+					<div>
+						<p>「{platform?.name}」を削除しますか？</p>
+						<p className="mt-2 text-error text-sm">
+							※使用中の場合は削除できません。
+						</p>
+					</div>
+				}
+				confirmLabel="削除する"
+				variant="danger"
+				onConfirm={handleDelete}
+				isLoading={isDeleting}
 			/>
 		</div>
 	);


### PR DESCRIPTION
## 概要

管理画面全体でブラウザのネイティブ`confirm()`をカスタム`ConfirmDialog`コンポーネントに統一し、一貫したUXを提供する。

## 変更内容

### 一覧ページ（8ファイル）
- `artists.tsx` - アーティスト削除確認
- `circles.tsx` - サークル削除・リンク削除確認
- `releases.tsx` - リリース削除確認
- `tracks.tsx` - トラック削除確認
- `artist-aliases.tsx` - 名義削除確認
- `events.tsx` - イベント削除・開催日削除確認
- `event-series.tsx` - イベントシリーズ削除確認
- `official/works.tsx` - 公式作品削除確認

### 詳細ページ（7ファイル）
- `artists_.$id.tsx` - アーティスト削除・名義削除確認
- `circles_.$id.tsx` - サークル削除・リンク削除確認
- `artist-aliases_.$id.tsx` - 名義削除確認
- `events_.$id.tsx` - イベント削除・開催日削除確認
- `event-series_.$id.tsx` - イベントシリーズ削除確認
- `releases_.$id.tsx` - ディスク・サークル紐付け・トラック・クレジット・公開リンク・JANコード削除確認
- `tracks_.$id.tsx` - クレジット・原曲リンク・派生関係・公開リンク・ISRC削除確認

### マスターデータページ（8ファイル）
- `master/platforms.tsx`, `master/platforms_.$code.tsx` - プラットフォーム削除確認
- `master/alias-types.tsx`, `master/alias-types_.$code.tsx` - 名義種別削除確認
- `master/credit-roles.tsx`, `master/credit-roles_.$code.tsx` - クレジットロール削除確認
- `master/official-work-categories.tsx`, `master/official-work-categories_.$code.tsx` - 公式作品カテゴリ削除確認

### その他（1ファイル）
- `official/songs.tsx` - 公式楽曲削除確認

## 影響範囲

- 管理画面の削除操作全般
- ユーザー体験の向上（ローディング状態の表示、一貫したデザイン）

Closes #99