### PR TITLE
feat: 削除APIのレスポンス形式を統一

### DIFF
--- a/apps/server/src/routes/admin/artist-aliases/index.ts
+++ b/apps/server/src/routes/admin/artist-aliases/index.ts
@@ -268,7 +268,7 @@ artistAliasesRouter.delete("/:id", async (c) => {
 		// 削除
 		await db.delete(artistAliases).where(eq(artistAliases.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/artist-aliases/:id");
 	}
@@ -322,7 +322,7 @@ artistAliasesRouter.delete("/batch", async (c) => {
 
 		return c.json({
 			success: failed.length === 0,
-			deleted: deleted.length,
+			deleted,
 			failed,
 		});
 	} catch (error) {

--- a/apps/server/src/routes/admin/artists/index.ts
+++ b/apps/server/src/routes/admin/artists/index.ts
@@ -236,7 +236,7 @@ artistsRouter.delete("/:id", async (c) => {
 		// 削除（関連別名義はCASCADE削除）
 		await db.delete(artists).where(eq(artists.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/artists/:id");
 	}
@@ -290,7 +290,7 @@ artistsRouter.delete("/batch", async (c) => {
 
 		return c.json({
 			success: failed.length === 0,
-			deleted: deleted.length,
+			deleted,
 			failed,
 		});
 	} catch (error) {

--- a/apps/server/src/routes/admin/circles/index.ts
+++ b/apps/server/src/routes/admin/circles/index.ts
@@ -249,7 +249,7 @@ circlesRouter.delete("/:id", async (c) => {
 		// 削除（関連リンクはCASCADE削除）
 		await db.delete(circles).where(eq(circles.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/circles/:id");
 	}
@@ -506,7 +506,7 @@ circlesRouter.delete("/:circleId/links/:linkId", async (c) => {
 		// 削除
 		await db.delete(circleLinks).where(eq(circleLinks.id, linkId));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id: linkId });
 	} catch (error) {
 		return handleDbError(
 			c,
@@ -564,7 +564,7 @@ circlesRouter.delete("/batch", async (c) => {
 
 		return c.json({
 			success: failed.length === 0,
-			deleted: deleted.length,
+			deleted,
 			failed,
 		});
 	} catch (error) {

--- a/apps/server/src/routes/admin/events/event-days.ts
+++ b/apps/server/src/routes/admin/events/event-days.ts
@@ -225,7 +225,7 @@ eventDaysRouter.delete("/:eventId/days/:dayId", async (c) => {
 		// 削除
 		await db.delete(eventDays).where(eq(eventDays.id, dayId));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id: dayId });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/events/:eventId/days/:dayId");
 	}

--- a/apps/server/src/routes/admin/events/event-series.ts
+++ b/apps/server/src/routes/admin/events/event-series.ts
@@ -274,7 +274,7 @@ eventSeriesRouter.delete("/:id", async (c) => {
 		// 削除
 		await db.delete(eventSeries).where(eq(eventSeries.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/event-series/:id");
 	}

--- a/apps/server/src/routes/admin/events/events.ts
+++ b/apps/server/src/routes/admin/events/events.ts
@@ -299,7 +299,7 @@ eventsRouter.delete("/:id", async (c) => {
 		// 削除（開催日はCASCADE削除）
 		await db.delete(events).where(eq(events.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/events/:id");
 	}

--- a/apps/server/src/routes/admin/master/alias-types.ts
+++ b/apps/server/src/routes/admin/master/alias-types.ts
@@ -231,7 +231,7 @@ aliasTypesRouter.delete("/:code", async (c) => {
 		// 削除
 		await db.delete(aliasTypes).where(eq(aliasTypes.code, code));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id: code });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/master/alias-types/:code");
 	}

--- a/apps/server/src/routes/admin/master/credit-roles.ts
+++ b/apps/server/src/routes/admin/master/credit-roles.ts
@@ -230,7 +230,7 @@ creditRolesRouter.delete("/:code", async (c) => {
 	// 削除
 	await db.delete(creditRoles).where(eq(creditRoles.code, code));
 
-	return c.json({ success: true });
+	return c.json({ success: true, id: code });
 });
 
 export { creditRolesRouter };

--- a/apps/server/src/routes/admin/master/official-work-categories.ts
+++ b/apps/server/src/routes/admin/master/official-work-categories.ts
@@ -249,7 +249,7 @@ officialWorkCategoriesRouter.delete("/:code", async (c) => {
 			.delete(officialWorkCategories)
 			.where(eq(officialWorkCategories.code, code));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id: code });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/server/src/routes/admin/master/platforms.ts
+++ b/apps/server/src/routes/admin/master/platforms.ts
@@ -247,7 +247,7 @@ platformsRouter.delete("/:code", async (c) => {
 		// 削除
 		await db.delete(platforms).where(eq(platforms.code, code));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id: code });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/platforms/:code");
 	}

--- a/apps/server/src/routes/admin/official/songs.ts
+++ b/apps/server/src/routes/admin/official/songs.ts
@@ -262,7 +262,7 @@ songsRouter.delete("/:id", async (c) => {
 		// 削除
 		await db.delete(officialSongs).where(eq(officialSongs.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/official/songs/:id");
 	}
@@ -567,7 +567,7 @@ songsRouter.delete("/:songId/links/:linkId", async (c) => {
 		// 削除
 		await db.delete(officialSongLinks).where(eq(officialSongLinks.id, linkId));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id: linkId });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/server/src/routes/admin/official/works.ts
+++ b/apps/server/src/routes/admin/official/works.ts
@@ -199,7 +199,7 @@ worksRouter.delete("/:id", async (c) => {
 		// 削除（関連楽曲はCASCADE削除）
 		await db.delete(officialWorks).where(eq(officialWorks.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/official/works/:id");
 	}
@@ -483,7 +483,7 @@ worksRouter.delete("/:workId/links/:linkId", async (c) => {
 		// 削除
 		await db.delete(officialWorkLinks).where(eq(officialWorkLinks.id, linkId));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id: linkId });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/server/src/routes/admin/releases/discs.ts
+++ b/apps/server/src/routes/admin/releases/discs.ts
@@ -204,7 +204,7 @@ discsRouter.delete("/:releaseId/discs/:discId", async (c) => {
 		// 削除
 		await db.delete(discs).where(eq(discs.id, discId));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id: discId });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/server/src/routes/admin/releases/jan-codes.ts
+++ b/apps/server/src/routes/admin/releases/jan-codes.ts
@@ -227,7 +227,7 @@ releaseJanCodesRouter.delete("/:releaseId/jan-codes/:id", async (c) => {
 		// 削除
 		await db.delete(releaseJanCodes).where(eq(releaseJanCodes.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/server/src/routes/admin/releases/publications.ts
+++ b/apps/server/src/routes/admin/releases/publications.ts
@@ -227,7 +227,7 @@ releasePublicationsRouter.delete("/:releaseId/publications/:id", async (c) => {
 		// 削除
 		await db.delete(releasePublications).where(eq(releasePublications.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/server/src/routes/admin/releases/release-circles.ts
+++ b/apps/server/src/routes/admin/releases/release-circles.ts
@@ -250,7 +250,7 @@ releaseCirclesRouter.delete("/:releaseId/circles/:circleId", async (c) => {
 				),
 			);
 
-		return c.json({ success: true });
+		return c.json({ success: true, id: circleId });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/server/src/routes/admin/releases/releases.ts
+++ b/apps/server/src/routes/admin/releases/releases.ts
@@ -382,7 +382,7 @@ releasesRouter.delete("/:id", async (c) => {
 		// 削除（ディスクはCASCADE削除）
 		await db.delete(releases).where(eq(releases.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/releases/:id");
 	}
@@ -436,7 +436,7 @@ releasesRouter.delete("/batch", async (c) => {
 
 		return c.json({
 			success: failed.length === 0,
-			deleted: deleted.length,
+			deleted,
 			failed,
 		});
 	} catch (error) {

--- a/apps/server/src/routes/admin/releases/track-credit-roles.ts
+++ b/apps/server/src/routes/admin/releases/track-credit-roles.ts
@@ -185,7 +185,7 @@ trackCreditRolesRouter.delete(
 					),
 				);
 
-			return c.json({ success: true });
+			return c.json({ success: true, id: roleCode });
 		} catch (error) {
 			return handleDbError(
 				c,

--- a/apps/server/src/routes/admin/releases/track-credits.ts
+++ b/apps/server/src/routes/admin/releases/track-credits.ts
@@ -446,7 +446,7 @@ trackCreditsRouter.delete(
 			// 削除（役割はCASCADEで自動削除）
 			await db.delete(trackCredits).where(eq(trackCredits.id, creditId));
 
-			return c.json({ success: true });
+			return c.json({ success: true, id: creditId });
 		} catch (error) {
 			return handleDbError(
 				c,

--- a/apps/server/src/routes/admin/releases/tracks.ts
+++ b/apps/server/src/routes/admin/releases/tracks.ts
@@ -425,7 +425,7 @@ tracksRouter.delete("/:releaseId/tracks/:trackId", async (c) => {
 		// 削除
 		await db.delete(tracks).where(eq(tracks.id, trackId));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id: trackId });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/server/src/routes/admin/tracks/derivations.ts
+++ b/apps/server/src/routes/admin/tracks/derivations.ts
@@ -165,7 +165,7 @@ trackDerivationsRouter.delete("/:trackId/derivations/:id", async (c) => {
 		// 削除
 		await db.delete(trackDerivations).where(eq(trackDerivations.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/server/src/routes/admin/tracks/index.ts
+++ b/apps/server/src/routes/admin/tracks/index.ts
@@ -446,7 +446,7 @@ tracksAdminRouter.delete("/batch", async (c) => {
 
 		return c.json({
 			success: failed.length === 0,
-			deleted: deleted.length,
+			deleted,
 			failed,
 		});
 	} catch (error) {

--- a/apps/server/src/routes/admin/tracks/isrcs.ts
+++ b/apps/server/src/routes/admin/tracks/isrcs.ts
@@ -209,7 +209,7 @@ trackIsrcsRouter.delete("/:trackId/isrcs/:id", async (c) => {
 		// 削除
 		await db.delete(trackIsrcs).where(eq(trackIsrcs.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(c, error, "DELETE /admin/tracks/:trackId/isrcs/:id");
 	}

--- a/apps/server/src/routes/admin/tracks/official-songs.ts
+++ b/apps/server/src/routes/admin/tracks/official-songs.ts
@@ -277,7 +277,7 @@ trackOfficialSongsRouter.delete("/:trackId/official-songs/:id", async (c) => {
 		// 削除
 		await db.delete(trackOfficialSongs).where(eq(trackOfficialSongs.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/server/src/routes/admin/tracks/publications.ts
+++ b/apps/server/src/routes/admin/tracks/publications.ts
@@ -219,7 +219,7 @@ trackPublicationsRouter.delete("/:trackId/publications/:id", async (c) => {
 		// 削除
 		await db.delete(trackPublications).where(eq(trackPublications.id, id));
 
-		return c.json({ success: true });
+		return c.json({ success: true, id });
 	} catch (error) {
 		return handleDbError(
 			c,

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -176,9 +176,12 @@ export const platformsApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (code: string) =>
-		fetchWithAuth<{ success: boolean }>(`/api/admin/master/platforms/${code}`, {
-			method: "DELETE",
-		}),
+		fetchWithAuth<{ success: boolean; id: string }>(
+			`/api/admin/master/platforms/${code}`,
+			{
+				method: "DELETE",
+			},
+		),
 	reorder: (items: { code: string; sortOrder: number }[]) =>
 		fetchWithAuth<{ success: boolean }>("/api/admin/master/platforms/reorder", {
 			method: "PUT",
@@ -219,7 +222,7 @@ export const aliasTypesApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (code: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/master/alias-types/${code}`,
 			{
 				method: "DELETE",
@@ -268,7 +271,7 @@ export const creditRolesApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (code: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/master/credit-roles/${code}`,
 			{
 				method: "DELETE",
@@ -629,7 +632,7 @@ export const officialWorkCategoriesApi = {
 			},
 		),
 	delete: (code: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/master/official-work-categories/${code}`,
 			{
 				method: "DELETE",
@@ -679,9 +682,12 @@ export const officialWorksApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (id: string) =>
-		fetchWithAuth<{ success: boolean }>(`/api/admin/official/works/${id}`, {
-			method: "DELETE",
-		}),
+		fetchWithAuth<{ success: boolean; id: string }>(
+			`/api/admin/official/works/${id}`,
+			{
+				method: "DELETE",
+			},
+		),
 };
 
 // Official Songs
@@ -723,9 +729,12 @@ export const officialSongsApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (id: string) =>
-		fetchWithAuth<{ success: boolean }>(`/api/admin/official/songs/${id}`, {
-			method: "DELETE",
-		}),
+		fetchWithAuth<{ success: boolean; id: string }>(
+			`/api/admin/official/songs/${id}`,
+			{
+				method: "DELETE",
+			},
+		),
 };
 
 // Official Work Links
@@ -777,7 +786,7 @@ export const officialWorkLinksApi = {
 			},
 		),
 	delete: (workId: string, linkId: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/official/works/${workId}/links/${linkId}`,
 			{
 				method: "DELETE",
@@ -842,7 +851,7 @@ export const officialSongLinksApi = {
 			},
 		),
 	delete: (songId: string, linkId: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/official/songs/${songId}/links/${linkId}`,
 			{
 				method: "DELETE",
@@ -1034,13 +1043,16 @@ export const artistsApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (id: string) =>
-		fetchWithAuth<{ success: boolean }>(`/api/admin/artists/${id}`, {
-			method: "DELETE",
-		}),
+		fetchWithAuth<{ success: boolean; id: string }>(
+			`/api/admin/artists/${id}`,
+			{
+				method: "DELETE",
+			},
+		),
 	batchDelete: (ids: string[]) =>
 		fetchWithAuth<{
 			success: boolean;
-			deleted: number;
+			deleted: string[];
 			failed: Array<{ id: string; error: string }>;
 		}>("/api/admin/artists/batch", {
 			method: "DELETE",
@@ -1088,13 +1100,16 @@ export const artistAliasesApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (id: string) =>
-		fetchWithAuth<{ success: boolean }>(`/api/admin/artist-aliases/${id}`, {
-			method: "DELETE",
-		}),
+		fetchWithAuth<{ success: boolean; id: string }>(
+			`/api/admin/artist-aliases/${id}`,
+			{
+				method: "DELETE",
+			},
+		),
 	batchDelete: (ids: string[]) =>
 		fetchWithAuth<{
 			success: boolean;
-			deleted: number;
+			deleted: string[];
 			failed: Array<{ id: string; error: string }>;
 		}>("/api/admin/artist-aliases/batch", {
 			method: "DELETE",
@@ -1137,13 +1152,16 @@ export const circlesApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (id: string) =>
-		fetchWithAuth<{ success: boolean }>(`/api/admin/circles/${id}`, {
-			method: "DELETE",
-		}),
+		fetchWithAuth<{ success: boolean; id: string }>(
+			`/api/admin/circles/${id}`,
+			{
+				method: "DELETE",
+			},
+		),
 	batchDelete: (ids: string[]) =>
 		fetchWithAuth<{
 			success: boolean;
-			deleted: number;
+			deleted: string[];
 			failed: Array<{ id: string; error: string }>;
 		}>("/api/admin/circles/batch", {
 			method: "DELETE",
@@ -1184,7 +1202,7 @@ export const circleLinksApi = {
 			},
 		),
 	delete: (circleId: string, linkId: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/circles/${circleId}/links/${linkId}`,
 			{
 				method: "DELETE",
@@ -1265,9 +1283,12 @@ export const eventSeriesApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (id: string) =>
-		fetchWithAuth<{ success: boolean }>(`/api/admin/event-series/${id}`, {
-			method: "DELETE",
-		}),
+		fetchWithAuth<{ success: boolean; id: string }>(
+			`/api/admin/event-series/${id}`,
+			{
+				method: "DELETE",
+			},
+		),
 	reorder: (items: { id: string; sortOrder: number }[]) =>
 		fetchWithAuth<{ success: boolean }>("/api/admin/event-series/reorder", {
 			method: "PUT",
@@ -1308,7 +1329,7 @@ export const eventsApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (id: string) =>
-		fetchWithAuth<{ success: boolean }>(`/api/admin/events/${id}`, {
+		fetchWithAuth<{ success: boolean; id: string }>(`/api/admin/events/${id}`, {
 			method: "DELETE",
 		}),
 };
@@ -1335,7 +1356,7 @@ export const eventDaysApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (eventId: string, dayId: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/events/${eventId}/days/${dayId}`,
 			{
 				method: "DELETE",
@@ -1439,13 +1460,16 @@ export const releasesApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (id: string) =>
-		fetchWithAuth<{ success: boolean }>(`/api/admin/releases/${id}`, {
-			method: "DELETE",
-		}),
+		fetchWithAuth<{ success: boolean; id: string }>(
+			`/api/admin/releases/${id}`,
+			{
+				method: "DELETE",
+			},
+		),
 	batchDelete: (ids: string[]) =>
 		fetchWithAuth<{
 			success: boolean;
-			deleted: number;
+			deleted: string[];
 			failed: Array<{ id: string; error: string }>;
 		}>("/api/admin/releases/batch", {
 			method: "DELETE",
@@ -1475,7 +1499,7 @@ export const discsApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (releaseId: string, discId: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/releases/${releaseId}/discs/${discId}`,
 			{
 				method: "DELETE",
@@ -1563,7 +1587,7 @@ export const releaseCirclesApi = {
 		circleId: string,
 		participationType: ParticipationType,
 	) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/releases/${releaseId}/circles/${circleId}?participationType=${encodeURIComponent(participationType)}`,
 			{
 				method: "DELETE",
@@ -1739,7 +1763,7 @@ export const tracksApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (releaseId: string, trackId: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/releases/${releaseId}/tracks/${trackId}`,
 			{
 				method: "DELETE",
@@ -1756,7 +1780,7 @@ export const tracksApi = {
 	batchDelete: (items: Array<{ trackId: string; releaseId: string }>) =>
 		fetchWithAuth<{
 			success: boolean;
-			deleted: number;
+			deleted: string[];
 			failed: Array<{ trackId: string; error: string }>;
 		}>("/api/admin/tracks/batch", {
 			method: "DELETE",
@@ -1811,7 +1835,7 @@ export const trackCreditsApi = {
 			},
 		),
 	delete: (releaseId: string, trackId: string, creditId: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/releases/${releaseId}/tracks/${trackId}/credits/${creditId}`,
 			{
 				method: "DELETE",
@@ -1841,7 +1865,7 @@ export const trackCreditRolesApi = {
 		roleCode: string,
 		rolePosition: number,
 	) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/releases/${releaseId}/tracks/${trackId}/credits/${creditId}/roles/${roleCode}/${rolePosition}`,
 			{
 				method: "DELETE",
@@ -1906,7 +1930,7 @@ export const trackOfficialSongsApi = {
 			},
 		),
 	delete: (trackId: string, id: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/tracks/${trackId}/official-songs/${id}`,
 			{
 				method: "DELETE",
@@ -1951,7 +1975,7 @@ export const trackDerivationsApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (trackId: string, id: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/tracks/${trackId}/derivations/${id}`,
 			{
 				method: "DELETE",
@@ -2005,7 +2029,7 @@ export const trackPublicationsApi = {
 			},
 		),
 	delete: (trackId: string, id: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/tracks/${trackId}/publications/${id}`,
 			{
 				method: "DELETE",
@@ -2052,7 +2076,7 @@ export const trackIsrcsApi = {
 			body: JSON.stringify(data),
 		}),
 	delete: (trackId: string, id: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/tracks/${trackId}/isrcs/${id}`,
 			{
 				method: "DELETE",
@@ -2106,7 +2130,7 @@ export const releasePublicationsApi = {
 			},
 		),
 	delete: (releaseId: string, id: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/releases/${releaseId}/publications/${id}`,
 			{
 				method: "DELETE",
@@ -2165,7 +2189,7 @@ export const releaseJanCodesApi = {
 			},
 		),
 	delete: (releaseId: string, id: string) =>
-		fetchWithAuth<{ success: boolean }>(
+		fetchWithAuth<{ success: boolean; id: string }>(
 			`/api/admin/releases/${releaseId}/jan-codes/${id}`,
 			{
 				method: "DELETE",

--- a/apps/web/src/routes/admin/_admin/artist-aliases.tsx
+++ b/apps/web/src/routes/admin/_admin/artist-aliases.tsx
@@ -203,7 +203,7 @@ function ArtistAliasesPage() {
 
 			if (result.failed.length > 0) {
 				setBatchDeleteError(
-					`${result.deleted}件削除、${result.failed.length}件失敗`,
+					`${result.deleted.length}件削除、${result.failed.length}件失敗`,
 				);
 			} else {
 				setIsBatchDeleteDialogOpen(false);

--- a/apps/web/src/routes/admin/_admin/artists.tsx
+++ b/apps/web/src/routes/admin/_admin/artists.tsx
@@ -153,7 +153,7 @@ function ArtistsPage() {
 
 			if (result.failed.length > 0) {
 				setBatchDeleteError(
-					`${result.deleted}件削除、${result.failed.length}件失敗`,
+					`${result.deleted.length}件削除、${result.failed.length}件失敗`,
 				);
 			} else {
 				setIsBatchDeleteDialogOpen(false);

--- a/apps/web/src/routes/admin/_admin/circles.tsx
+++ b/apps/web/src/routes/admin/_admin/circles.tsx
@@ -295,7 +295,7 @@ function CirclesPage() {
 
 			if (result.failed.length > 0) {
 				setBatchDeleteError(
-					`${result.deleted}件削除、${result.failed.length}件失敗`,
+					`${result.deleted.length}件削除、${result.failed.length}件失敗`,
 				);
 			} else {
 				setIsBatchDeleteDialogOpen(false);

--- a/apps/web/src/routes/admin/_admin/releases.tsx
+++ b/apps/web/src/routes/admin/_admin/releases.tsx
@@ -291,7 +291,7 @@ function ReleasesPage() {
 
 			if (result.failed.length > 0) {
 				setBatchDeleteError(
-					`${result.deleted}件削除、${result.failed.length}件失敗`,
+					`${result.deleted.length}件削除、${result.failed.length}件失敗`,
 				);
 			} else {
 				setIsBatchDeleteDialogOpen(false);

--- a/apps/web/src/routes/admin/_admin/tracks.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks.tsx
@@ -211,7 +211,7 @@ function TracksPage() {
 
 			if (result.failed.length > 0) {
 				setBatchDeleteError(
-					`${result.deleted}件削除、${result.failed.length}件失敗`,
+					`${result.deleted.length}件削除、${result.failed.length}件失敗`,
 				);
 			} else {
 				setIsBatchDeleteDialogOpen(false);


### PR DESCRIPTION
## 概要

削除APIのレスポンス形式を統一し、フロントエンド側で削除されたリソースのIDを取得可能にしました。

## 変更内容

### レスポンス形式の変更

| 種類 | 変更前 | 変更後 |
|------|--------|--------|
| 単一削除 | `{ success: true }` | `{ success: true, id: "削除されたID" }` |
| バッチ削除 | `{ deleted: number, ... }` | `{ deleted: string[], ... }` |

### サーバー側（25ファイル）

**バッチ削除エンドポイント（5件）**
- artists, artist-aliases, circles, releases, tracks

**単一削除エンドポイント（27件）**
- 主要エンティティ: artists, circles, releases, artist-aliases
- リリース関連: discs, tracks, publications, jan-codes, release-circles, track-credits, track-credit-roles
- トラック関連: isrcs, official-songs, publications, derivations
- 公式データ: works, songs（各リンク含む）
- マスターデータ: platforms, alias-types, credit-roles, official-work-categories
- イベント: events, event-series, event-days

### フロントエンド側（6ファイル）

- `api-client.ts`: 型定義を新形式に対応
- バッチ削除ハンドラー: `result.deleted` → `result.deleted.length` に変更
  - artists.tsx, circles.tsx, releases.tsx, tracks.tsx, artist-aliases.tsx

## 影響範囲

- 全管理画面の削除操作（単一削除・バッチ削除）
- API利用者は新しいレスポンス形式に対応が必要

Closes #100