### PR TITLE
feat: 詳細ページの複数APIコールを統合エンドポイントに統一

### DIFF
--- a/apps/server/src/routes/admin/artists/tracks.ts
+++ b/apps/server/src/routes/admin/artists/tracks.ts
@@ -13,206 +13,228 @@ import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
+/**
+ * アーティストの関連楽曲を取得する関数
+ * 統合エンドポイント用にロジックを分離
+ */
+export async function getArtistTracks(artistId: string) {
+	// アーティストのクレジット一覧を取得
+	const credits = await db
+		.select({
+			creditId: trackCredits.id,
+			trackId: trackCredits.trackId,
+			creditName: trackCredits.creditName,
+		})
+		.from(trackCredits)
+		.where(eq(trackCredits.artistId, artistId));
+
+	if (credits.length === 0) {
+		return {
+			totalUniqueTrackCount: 0,
+			byRole: {} as Record<string, number>,
+			tracks: [] as Array<{
+				id: string;
+				name: string;
+				nameJa: string | null;
+				trackNumber: number;
+				release: {
+					id: string;
+					name: string;
+					releaseDate: string | null;
+					circleNames: string | null;
+				} | null;
+			}>,
+			statistics: {
+				releaseCount: 0,
+				earliestReleaseDate: null as string | null,
+				latestReleaseDate: null as string | null,
+			},
+		};
+	}
+
+	const creditIds = credits.map((c) => c.creditId);
+	const trackIds = [...new Set(credits.map((c) => c.trackId))];
+
+	// クレジットの役割を取得
+	const creditRoles = await db
+		.select({
+			trackCreditId: trackCreditRoles.trackCreditId,
+			roleCode: trackCreditRoles.roleCode,
+		})
+		.from(trackCreditRoles)
+		.where(inArray(trackCreditRoles.trackCreditId, creditIds));
+
+	// トラック情報を取得
+	const trackList = await db
+		.select({
+			id: tracks.id,
+			name: tracks.name,
+			nameJa: tracks.nameJa,
+			releaseId: tracks.releaseId,
+			trackNumber: tracks.trackNumber,
+		})
+		.from(tracks)
+		.where(inArray(tracks.id, trackIds))
+		.orderBy(tracks.name);
+
+	// リリース情報を取得（nullを除外）
+	const releaseIds = [
+		...new Set(
+			trackList
+				.map((t) => t.releaseId)
+				.filter((id): id is string => id !== null),
+		),
+	];
+	const releaseList = await db
+		.select({
+			id: releases.id,
+			name: releases.name,
+			releaseDate: releases.releaseDate,
+		})
+		.from(releases)
+		.where(inArray(releases.id, releaseIds));
+
+	const releaseMap = new Map(releaseList.map((r) => [r.id, r]));
+
+	// リリースサークル情報を取得
+	const releaseCirclesList =
+		releaseIds.length > 0
+			? await db
+					.select({
+						releaseId: releaseCircles.releaseId,
+						circleId: releaseCircles.circleId,
+					})
+					.from(releaseCircles)
+					.where(inArray(releaseCircles.releaseId, releaseIds))
+			: [];
+
+	// サークル情報を取得
+	const circleIds = [...new Set(releaseCirclesList.map((rc) => rc.circleId))];
+	const circleList =
+		circleIds.length > 0
+			? await db
+					.select({
+						id: circles.id,
+						name: circles.name,
+					})
+					.from(circles)
+					.where(inArray(circles.id, circleIds))
+			: [];
+
+	const circleMap = new Map(circleList.map((c) => [c.id, c.name]));
+
+	// リリースIDからサークル名一覧へのマップを作成
+	const releaseCircleNamesMap = new Map<string, string[]>();
+	for (const rc of releaseCirclesList) {
+		const circleName = circleMap.get(rc.circleId);
+		if (circleName) {
+			const names = releaseCircleNamesMap.get(rc.releaseId) || [];
+			if (!names.includes(circleName)) {
+				names.push(circleName);
+			}
+			releaseCircleNamesMap.set(rc.releaseId, names);
+		}
+	}
+
+	// クレジットIDからトラックIDへのマップ
+	const creditToTrack = new Map(credits.map((c) => [c.creditId, c.trackId]));
+
+	// 役割別に楽曲をグループ化
+	const byRole: Record<string, Set<string>> = {};
+	for (const cr of creditRoles) {
+		const trackId = creditToTrack.get(cr.trackCreditId);
+		if (trackId) {
+			if (!byRole[cr.roleCode]) {
+				byRole[cr.roleCode] = new Set();
+			}
+			const roleSet = byRole[cr.roleCode];
+			if (roleSet) {
+				roleSet.add(trackId);
+			}
+		}
+	}
+
+	// 役割別カウント
+	const roleCount: Record<string, number> = {};
+	for (const [roleCode, trackSet] of Object.entries(byRole)) {
+		roleCount[roleCode] = trackSet.size;
+	}
+
+	// トラック情報を整形
+	const tracksWithRelease = trackList
+		.map((t) => {
+			const release = t.releaseId ? releaseMap.get(t.releaseId) : undefined;
+			const circleNames = t.releaseId
+				? releaseCircleNamesMap.get(t.releaseId)
+				: undefined;
+			return {
+				id: t.id,
+				name: t.name,
+				nameJa: t.nameJa,
+				trackNumber: t.trackNumber,
+				release: release
+					? {
+							id: release.id,
+							name: release.name,
+							releaseDate: release.releaseDate,
+							circleNames: circleNames ? circleNames.join(" / ") : null,
+						}
+					: null,
+			};
+		})
+		// 作品名 → トラック番号でソート
+		.sort((a, b) => {
+			// 作品なしは後ろへ
+			if (!a.release && b.release) return 1;
+			if (a.release && !b.release) return -1;
+			if (!a.release && !b.release) return a.name.localeCompare(b.name);
+
+			// ここに到達した時点で両方ともreleaseが存在する（上記の条件で除外済み）
+			// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
+			const releaseA = a.release!;
+			// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
+			const releaseB = b.release!;
+
+			// 作品名でソート
+			const releaseCompare = releaseA.name.localeCompare(releaseB.name);
+			if (releaseCompare !== 0) return releaseCompare;
+
+			// 同じ作品内ではトラック番号でソート
+			return a.trackNumber - b.trackNumber;
+		});
+
+	// 統計情報を計算
+	const releaseDates = releaseList
+		.map((r) => r.releaseDate)
+		.filter((d): d is string => d !== null)
+		.sort();
+
+	const statistics = {
+		releaseCount: releaseList.length,
+		earliestReleaseDate:
+			releaseDates.length > 0 ? (releaseDates[0] ?? null) : null,
+		latestReleaseDate:
+			releaseDates.length > 0
+				? (releaseDates[releaseDates.length - 1] ?? null)
+				: null,
+	};
+
+	return {
+		totalUniqueTrackCount: trackIds.length,
+		byRole: roleCount,
+		tracks: tracksWithRelease,
+		statistics,
+	};
+}
+
 const artistTracksRouter = new Hono<AdminContext>();
 
 // アーティストの関連楽曲取得（role別）
 artistTracksRouter.get("/:artistId/tracks", async (c) => {
 	try {
 		const artistId = c.req.param("artistId");
-
-		// アーティストのクレジット一覧を取得
-		const credits = await db
-			.select({
-				creditId: trackCredits.id,
-				trackId: trackCredits.trackId,
-				creditName: trackCredits.creditName,
-			})
-			.from(trackCredits)
-			.where(eq(trackCredits.artistId, artistId));
-
-		if (credits.length === 0) {
-			return c.json({
-				totalUniqueTrackCount: 0,
-				byRole: {},
-				tracks: [],
-				statistics: {
-					releaseCount: 0,
-					earliestReleaseDate: null,
-					latestReleaseDate: null,
-				},
-			});
-		}
-
-		const creditIds = credits.map((c) => c.creditId);
-		const trackIds = [...new Set(credits.map((c) => c.trackId))];
-
-		// クレジットの役割を取得
-		const creditRoles = await db
-			.select({
-				trackCreditId: trackCreditRoles.trackCreditId,
-				roleCode: trackCreditRoles.roleCode,
-			})
-			.from(trackCreditRoles)
-			.where(inArray(trackCreditRoles.trackCreditId, creditIds));
-
-		// トラック情報を取得
-		const trackList = await db
-			.select({
-				id: tracks.id,
-				name: tracks.name,
-				nameJa: tracks.nameJa,
-				releaseId: tracks.releaseId,
-				trackNumber: tracks.trackNumber,
-			})
-			.from(tracks)
-			.where(inArray(tracks.id, trackIds))
-			.orderBy(tracks.name);
-
-		// リリース情報を取得（nullを除外）
-		const releaseIds = [
-			...new Set(
-				trackList
-					.map((t) => t.releaseId)
-					.filter((id): id is string => id !== null),
-			),
-		];
-		const releaseList = await db
-			.select({
-				id: releases.id,
-				name: releases.name,
-				releaseDate: releases.releaseDate,
-			})
-			.from(releases)
-			.where(inArray(releases.id, releaseIds));
-
-		const releaseMap = new Map(releaseList.map((r) => [r.id, r]));
-
-		// リリースサークル情報を取得
-		const releaseCirclesList =
-			releaseIds.length > 0
-				? await db
-						.select({
-							releaseId: releaseCircles.releaseId,
-							circleId: releaseCircles.circleId,
-						})
-						.from(releaseCircles)
-						.where(inArray(releaseCircles.releaseId, releaseIds))
-				: [];
-
-		// サークル情報を取得
-		const circleIds = [...new Set(releaseCirclesList.map((rc) => rc.circleId))];
-		const circleList =
-			circleIds.length > 0
-				? await db
-						.select({
-							id: circles.id,
-							name: circles.name,
-						})
-						.from(circles)
-						.where(inArray(circles.id, circleIds))
-				: [];
-
-		const circleMap = new Map(circleList.map((c) => [c.id, c.name]));
-
-		// リリースIDからサークル名一覧へのマップを作成
-		const releaseCircleNamesMap = new Map<string, string[]>();
-		for (const rc of releaseCirclesList) {
-			const circleName = circleMap.get(rc.circleId);
-			if (circleName) {
-				const names = releaseCircleNamesMap.get(rc.releaseId) || [];
-				if (!names.includes(circleName)) {
-					names.push(circleName);
-				}
-				releaseCircleNamesMap.set(rc.releaseId, names);
-			}
-		}
-
-		// クレジットIDからトラックIDへのマップ
-		const creditToTrack = new Map(credits.map((c) => [c.creditId, c.trackId]));
-
-		// 役割別に楽曲をグループ化
-		const byRole: Record<string, Set<string>> = {};
-		for (const cr of creditRoles) {
-			const trackId = creditToTrack.get(cr.trackCreditId);
-			if (trackId) {
-				if (!byRole[cr.roleCode]) {
-					byRole[cr.roleCode] = new Set();
-				}
-				const roleSet = byRole[cr.roleCode];
-				if (roleSet) {
-					roleSet.add(trackId);
-				}
-			}
-		}
-
-		// 役割別カウント
-		const roleCount: Record<string, number> = {};
-		for (const [roleCode, trackSet] of Object.entries(byRole)) {
-			roleCount[roleCode] = trackSet.size;
-		}
-
-		// トラック情報を整形
-		const tracksWithRelease = trackList
-			.map((t) => {
-				const release = t.releaseId ? releaseMap.get(t.releaseId) : undefined;
-				const circleNames = t.releaseId
-					? releaseCircleNamesMap.get(t.releaseId)
-					: undefined;
-				return {
-					id: t.id,
-					name: t.name,
-					nameJa: t.nameJa,
-					trackNumber: t.trackNumber,
-					release: release
-						? {
-								id: release.id,
-								name: release.name,
-								releaseDate: release.releaseDate,
-								circleNames: circleNames ? circleNames.join(" / ") : null,
-							}
-						: null,
-				};
-			})
-			// 作品名 → トラック番号でソート
-			.sort((a, b) => {
-				// 作品なしは後ろへ
-				if (!a.release && b.release) return 1;
-				if (a.release && !b.release) return -1;
-				if (!a.release && !b.release) return a.name.localeCompare(b.name);
-
-				// ここに到達した時点で両方ともreleaseが存在する（上記の条件で除外済み）
-				// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
-				const releaseA = a.release!;
-				// biome-ignore lint/style/noNonNullAssertion: 上記の条件分岐で両方ともnullでないことが保証済み
-				const releaseB = b.release!;
-
-				// 作品名でソート
-				const releaseCompare = releaseA.name.localeCompare(releaseB.name);
-				if (releaseCompare !== 0) return releaseCompare;
-
-				// 同じ作品内ではトラック番号でソート
-				return a.trackNumber - b.trackNumber;
-			});
-
-		// 統計情報を計算
-		const releaseDates = releaseList
-			.map((r) => r.releaseDate)
-			.filter((d): d is string => d !== null)
-			.sort();
-
-		const statistics = {
-			releaseCount: releaseList.length,
-			earliestReleaseDate: releaseDates.length > 0 ? releaseDates[0] : null,
-			latestReleaseDate:
-				releaseDates.length > 0 ? releaseDates[releaseDates.length - 1] : null,
-		};
-
-		return c.json({
-			totalUniqueTrackCount: trackIds.length,
-			byRole: roleCount,
-			tracks: tracksWithRelease,
-			statistics,
-		});
+		const result = await getArtistTracks(artistId);
+		return c.json(result);
 	} catch (error) {
 		return handleDbError(c, error, "GET /admin/artists/:artistId/tracks");
 	}

--- a/apps/server/src/routes/admin/circles/artists.ts
+++ b/apps/server/src/routes/admin/circles/artists.ts
@@ -13,6 +13,197 @@ import { Hono } from "hono";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
+/**
+ * サークルの参加アーティスト一覧を取得する関数
+ * 統合エンドポイント用にロジックを分離
+ * 経路: circle → releaseCircles → releases → tracks → trackCredits → artists
+ */
+export async function getCircleArtists(circleId: string) {
+	// サークルのリリース一覧からリリースIDを取得
+	const releaseCirclesResult = await db
+		.select({
+			releaseId: releaseCircles.releaseId,
+		})
+		.from(releaseCircles)
+		.where(eq(releaseCircles.circleId, circleId));
+
+	if (releaseCirclesResult.length === 0) {
+		return {
+			artists: [] as Array<{
+				artistId: string;
+				artistName: string;
+				trackCount: number;
+				releaseCount: number;
+				roles: string[];
+			}>,
+			statistics: {
+				totalArtistCount: 0,
+				totalTrackCount: 0,
+				releaseCount: 0,
+				earliestReleaseDate: null as string | null,
+				latestReleaseDate: null as string | null,
+			},
+		};
+	}
+
+	const releaseIds = [...new Set(releaseCirclesResult.map((r) => r.releaseId))];
+
+	// リリースからトラックIDを取得
+	const tracksResult = await db
+		.select({
+			id: tracks.id,
+			releaseId: tracks.releaseId,
+		})
+		.from(tracks)
+		.where(inArray(tracks.releaseId, releaseIds));
+
+	if (tracksResult.length === 0) {
+		return {
+			artists: [],
+			statistics: {
+				totalArtistCount: 0,
+				totalTrackCount: 0,
+				releaseCount: releaseIds.length,
+				earliestReleaseDate: null,
+				latestReleaseDate: null,
+			},
+		};
+	}
+
+	const trackIds = [...new Set(tracksResult.map((t) => t.id))];
+
+	// トラックからクレジット情報を取得
+	const creditsResult = await db
+		.select({
+			id: trackCredits.id,
+			artistId: trackCredits.artistId,
+			trackId: trackCredits.trackId,
+		})
+		.from(trackCredits)
+		.where(inArray(trackCredits.trackId, trackIds));
+
+	if (creditsResult.length === 0) {
+		return {
+			artists: [],
+			statistics: {
+				totalArtistCount: 0,
+				totalTrackCount: trackIds.length,
+				releaseCount: releaseIds.length,
+				earliestReleaseDate: null,
+				latestReleaseDate: null,
+			},
+		};
+	}
+
+	// クレジットの役割情報を取得
+	const creditIds = creditsResult.map((c) => c.id);
+	const rolesResult = await db
+		.select({
+			trackCreditId: trackCreditRoles.trackCreditId,
+			roleCode: trackCreditRoles.roleCode,
+		})
+		.from(trackCreditRoles)
+		.where(inArray(trackCreditRoles.trackCreditId, creditIds));
+
+	// クレジットIDと役割のマッピング
+	const creditToRolesMap = new Map<string, Set<string>>();
+	for (const role of rolesResult) {
+		const roles = creditToRolesMap.get(role.trackCreditId) || new Set<string>();
+		roles.add(role.roleCode);
+		creditToRolesMap.set(role.trackCreditId, roles);
+	}
+
+	// アーティスト情報を取得
+	const artistIds = [...new Set(creditsResult.map((c) => c.artistId))];
+	const artistList = await db
+		.select({
+			id: artists.id,
+			name: artists.name,
+		})
+		.from(artists)
+		.where(inArray(artists.id, artistIds))
+		.orderBy(artists.name);
+
+	// トラックとリリースのマッピング
+	const trackToReleaseMap = new Map<string, string>();
+	for (const track of tracksResult) {
+		if (track.releaseId) {
+			trackToReleaseMap.set(track.id, track.releaseId);
+		}
+	}
+
+	// アーティストごとにトラック数、リリース数、役割を集計
+	const artistStats = new Map<
+		string,
+		{
+			trackIds: Set<string>;
+			releaseIds: Set<string>;
+			roles: Set<string>;
+		}
+	>();
+
+	for (const credit of creditsResult) {
+		const stats = artistStats.get(credit.artistId) || {
+			trackIds: new Set<string>(),
+			releaseIds: new Set<string>(),
+			roles: new Set<string>(),
+		};
+
+		stats.trackIds.add(credit.trackId);
+
+		// クレジットに紐づく役割を追加
+		const creditRoles = creditToRolesMap.get(credit.id);
+		if (creditRoles) {
+			for (const role of creditRoles) {
+				stats.roles.add(role);
+			}
+		}
+
+		const releaseId = trackToReleaseMap.get(credit.trackId);
+		if (releaseId) {
+			stats.releaseIds.add(releaseId);
+		}
+
+		artistStats.set(credit.artistId, stats);
+	}
+
+	// レスポンスを整形
+	const result = artistList.map((artist) => {
+		const stats = artistStats.get(artist.id);
+		return {
+			artistId: artist.id,
+			artistName: artist.name,
+			trackCount: stats?.trackIds.size ?? 0,
+			releaseCount: stats?.releaseIds.size ?? 0,
+			roles: stats ? Array.from(stats.roles).sort() : [],
+		};
+	});
+
+	// リリース日情報を取得して活動期間を計算
+	const releasesData = await db
+		.select({
+			releaseDate: releases.releaseDate,
+		})
+		.from(releases)
+		.where(inArray(releases.id, releaseIds));
+
+	const releaseDates = releasesData
+		.map((r) => r.releaseDate)
+		.filter((d): d is string => d !== null)
+		.sort();
+
+	return {
+		artists: result,
+		statistics: {
+			totalArtistCount: artistList.length,
+			totalTrackCount: trackIds.length,
+			releaseCount: releaseIds.length,
+			earliestReleaseDate: releaseDates[0] ?? null,
+			latestReleaseDate: releaseDates[releaseDates.length - 1] ?? null,
+		},
+	};
+}
+
 const circleArtistsRouter = new Hono<AdminContext>();
 
 // サークルの参加アーティスト一覧取得
@@ -20,181 +211,8 @@ const circleArtistsRouter = new Hono<AdminContext>();
 circleArtistsRouter.get("/:circleId/artists", async (c) => {
 	try {
 		const circleId = c.req.param("circleId");
-
-		// サークルのリリース一覧からリリースIDを取得
-		const releaseCirclesResult = await db
-			.select({
-				releaseId: releaseCircles.releaseId,
-			})
-			.from(releaseCircles)
-			.where(eq(releaseCircles.circleId, circleId));
-
-		if (releaseCirclesResult.length === 0) {
-			return c.json({
-				artists: [],
-				statistics: {
-					totalArtistCount: 0,
-					totalTrackCount: 0,
-					releaseCount: 0,
-				},
-			});
-		}
-
-		const releaseIds = [
-			...new Set(releaseCirclesResult.map((r) => r.releaseId)),
-		];
-
-		// リリースからトラックIDを取得（リリース日も取得して活動期間計算に使用）
-		const tracksResult = await db
-			.select({
-				id: tracks.id,
-				releaseId: tracks.releaseId,
-			})
-			.from(tracks)
-			.where(inArray(tracks.releaseId, releaseIds));
-
-		if (tracksResult.length === 0) {
-			return c.json({
-				artists: [],
-				statistics: {
-					totalArtistCount: 0,
-					totalTrackCount: 0,
-					releaseCount: releaseIds.length,
-				},
-			});
-		}
-
-		const trackIds = [...new Set(tracksResult.map((t) => t.id))];
-
-		// トラックからクレジット情報を取得
-		const creditsResult = await db
-			.select({
-				id: trackCredits.id,
-				artistId: trackCredits.artistId,
-				trackId: trackCredits.trackId,
-			})
-			.from(trackCredits)
-			.where(inArray(trackCredits.trackId, trackIds));
-
-		if (creditsResult.length === 0) {
-			return c.json({
-				artists: [],
-				statistics: {
-					totalArtistCount: 0,
-					totalTrackCount: trackIds.length,
-					releaseCount: releaseIds.length,
-				},
-			});
-		}
-
-		// クレジットの役割情報を取得
-		const creditIds = creditsResult.map((c) => c.id);
-		const rolesResult = await db
-			.select({
-				trackCreditId: trackCreditRoles.trackCreditId,
-				roleCode: trackCreditRoles.roleCode,
-			})
-			.from(trackCreditRoles)
-			.where(inArray(trackCreditRoles.trackCreditId, creditIds));
-
-		// クレジットIDと役割のマッピング
-		const creditToRolesMap = new Map<string, Set<string>>();
-		for (const role of rolesResult) {
-			const roles =
-				creditToRolesMap.get(role.trackCreditId) || new Set<string>();
-			roles.add(role.roleCode);
-			creditToRolesMap.set(role.trackCreditId, roles);
-		}
-
-		// アーティスト情報を取得
-		const artistIds = [...new Set(creditsResult.map((c) => c.artistId))];
-		const artistList = await db
-			.select({
-				id: artists.id,
-				name: artists.name,
-			})
-			.from(artists)
-			.where(inArray(artists.id, artistIds))
-			.orderBy(artists.name);
-
-		// トラックとリリースのマッピング
-		const trackToReleaseMap = new Map<string, string>();
-		for (const track of tracksResult) {
-			if (track.releaseId) {
-				trackToReleaseMap.set(track.id, track.releaseId);
-			}
-		}
-
-		// アーティストごとにトラック数、リリース数、役割を集計
-		const artistStats = new Map<
-			string,
-			{
-				trackIds: Set<string>;
-				releaseIds: Set<string>;
-				roles: Set<string>;
-			}
-		>();
-
-		for (const credit of creditsResult) {
-			const stats = artistStats.get(credit.artistId) || {
-				trackIds: new Set<string>(),
-				releaseIds: new Set<string>(),
-				roles: new Set<string>(),
-			};
-
-			stats.trackIds.add(credit.trackId);
-
-			// クレジットに紐づく役割を追加
-			const creditRoles = creditToRolesMap.get(credit.id);
-			if (creditRoles) {
-				for (const role of creditRoles) {
-					stats.roles.add(role);
-				}
-			}
-
-			const releaseId = trackToReleaseMap.get(credit.trackId);
-			if (releaseId) {
-				stats.releaseIds.add(releaseId);
-			}
-
-			artistStats.set(credit.artistId, stats);
-		}
-
-		// レスポンスを整形
-		const result = artistList.map((artist) => {
-			const stats = artistStats.get(artist.id);
-			return {
-				artistId: artist.id,
-				artistName: artist.name,
-				trackCount: stats?.trackIds.size ?? 0,
-				releaseCount: stats?.releaseIds.size ?? 0,
-				roles: stats ? Array.from(stats.roles).sort() : [],
-			};
-		});
-
-		// リリース日情報を取得して活動期間を計算
-		const releasesData = await db
-			.select({
-				releaseDate: releases.releaseDate,
-			})
-			.from(releases)
-			.where(inArray(releases.id, releaseIds));
-
-		const releaseDates = releasesData
-			.map((r) => r.releaseDate)
-			.filter((d): d is string => d !== null)
-			.sort();
-
-		return c.json({
-			artists: result,
-			statistics: {
-				totalArtistCount: artistList.length,
-				totalTrackCount: trackIds.length,
-				releaseCount: releaseIds.length,
-				earliestReleaseDate: releaseDates[0] ?? null,
-				latestReleaseDate: releaseDates[releaseDates.length - 1] ?? null,
-			},
-		});
+		const result = await getCircleArtists(circleId);
+		return c.json(result);
 	} catch (error) {
 		return handleDbError(c, error, "GET /admin/circles/:circleId/artists");
 	}

--- a/apps/server/src/routes/admin/circles/releases.ts
+++ b/apps/server/src/routes/admin/circles/releases.ts
@@ -1,5 +1,4 @@
 import {
-	circles,
 	db,
 	eq,
 	type ParticipationType,
@@ -7,9 +6,54 @@ import {
 	releases,
 } from "@thac/db";
 import { Hono } from "hono";
-import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
+
+/**
+ * サークルのリリース一覧を取得する関数
+ * 統合エンドポイント用にロジックを分離
+ * 参加形態別にグループ化して返す
+ */
+export async function getCircleReleases(circleId: string) {
+	// リリースを参加形態別に取得
+	const data = await db
+		.select({
+			releaseId: releases.id,
+			releaseName: releases.name,
+			releaseDate: releases.releaseDate,
+			releaseType: releases.releaseType,
+			participationType: releaseCircles.participationType,
+		})
+		.from(releaseCircles)
+		.innerJoin(releases, eq(releaseCircles.releaseId, releases.id))
+		.where(eq(releaseCircles.circleId, circleId))
+		.orderBy(releases.releaseDate, releaseCircles.position);
+
+	// 参加形態別にグループ化
+	const participationOrder: ParticipationType[] = [
+		"host",
+		"co-host",
+		"participant",
+		"guest",
+		"split_partner",
+	];
+
+	const grouped = participationOrder
+		.map((type) => ({
+			participationType: type,
+			releases: data
+				.filter((d) => d.participationType === type)
+				.map((d) => ({
+					id: d.releaseId,
+					name: d.releaseName,
+					releaseDate: d.releaseDate,
+					releaseType: d.releaseType,
+				})),
+		}))
+		.filter((g) => g.releases.length > 0);
+
+	return grouped;
+}
 
 const circleReleasesRouter = new Hono<AdminContext>();
 
@@ -17,56 +61,8 @@ const circleReleasesRouter = new Hono<AdminContext>();
 circleReleasesRouter.get("/:circleId/releases", async (c) => {
 	try {
 		const circleId = c.req.param("circleId");
-
-		// サークル存在チェック
-		const existingCircle = await db
-			.select()
-			.from(circles)
-			.where(eq(circles.id, circleId))
-			.limit(1);
-
-		if (existingCircle.length === 0) {
-			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
-		}
-
-		// リリースを参加形態別に取得
-		const data = await db
-			.select({
-				releaseId: releases.id,
-				releaseName: releases.name,
-				releaseDate: releases.releaseDate,
-				releaseType: releases.releaseType,
-				participationType: releaseCircles.participationType,
-			})
-			.from(releaseCircles)
-			.innerJoin(releases, eq(releaseCircles.releaseId, releases.id))
-			.where(eq(releaseCircles.circleId, circleId))
-			.orderBy(releases.releaseDate, releaseCircles.position);
-
-		// 参加形態別にグループ化
-		const participationOrder: ParticipationType[] = [
-			"host",
-			"co-host",
-			"participant",
-			"guest",
-			"split_partner",
-		];
-
-		const grouped = participationOrder
-			.map((type) => ({
-				participationType: type,
-				releases: data
-					.filter((d) => d.participationType === type)
-					.map((d) => ({
-						id: d.releaseId,
-						name: d.releaseName,
-						releaseDate: d.releaseDate,
-						releaseType: d.releaseType,
-					})),
-			}))
-			.filter((g) => g.releases.length > 0);
-
-		return c.json(grouped);
+		const result = await getCircleReleases(circleId);
+		return c.json(result);
 	} catch (error) {
 		return handleDbError(c, error, "GET /admin/circles/:circleId/releases");
 	}

--- a/apps/server/src/routes/admin/releases/jan-codes.ts
+++ b/apps/server/src/routes/admin/releases/jan-codes.ts
@@ -12,6 +12,20 @@ import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
 
+/**
+ * リリースのJANコード一覧を取得する関数
+ * 統合エンドポイント用にロジックを分離
+ */
+export async function getReleaseJanCodes(releaseId: string) {
+	// JANコード一覧取得
+	const janCodes = await db
+		.select()
+		.from(releaseJanCodes)
+		.where(eq(releaseJanCodes.releaseId, releaseId));
+
+	return janCodes;
+}
+
 const releaseJanCodesRouter = new Hono<AdminContext>();
 
 // リリースのJANコード一覧取得
@@ -30,13 +44,8 @@ releaseJanCodesRouter.get("/:releaseId/jan-codes", async (c) => {
 			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
 		}
 
-		// JANコード一覧取得
-		const janCodes = await db
-			.select()
-			.from(releaseJanCodes)
-			.where(eq(releaseJanCodes.releaseId, releaseId));
-
-		return c.json(janCodes);
+		const result = await getReleaseJanCodes(releaseId);
+		return c.json(result);
 	} catch (error) {
 		return handleDbError(c, error, "GET /admin/releases/:releaseId/jan-codes");
 	}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1004,6 +1004,26 @@ export interface ArtistCircle {
 	participationTypes: string[];
 }
 
+// アーティスト統合レスポンス
+export interface ArtistFullStats {
+	trackCount: number;
+	releaseCount: number;
+	circleCount: number;
+	byRole: Record<string, number>;
+	earliestReleaseDate: string | null;
+	latestReleaseDate: string | null;
+}
+
+export interface ArtistFullResponse {
+	artist: ArtistWithAliases;
+	tracks: {
+		data: ArtistTrack[];
+		total: number;
+	};
+	circles: ArtistCircle[];
+	stats: ArtistFullStats;
+}
+
 // Artists
 export const artistsApi = {
 	list: (params?: {
@@ -1025,6 +1045,10 @@ export const artistsApi = {
 	},
 	get: (id: string) =>
 		fetchWithAuth<ArtistWithAliases>(`/api/admin/artists/${id}`),
+	getFull: (id: string, ssrHeaders?: Headers) =>
+		fetchWithAuth<ArtistFullResponse>(`/api/admin/artists/${id}/full`, {
+			ssrHeaders,
+		}),
 	getTracks: (id: string) =>
 		fetchWithAuth<ArtistTracksResponse>(`/api/admin/artists/${id}/tracks`),
 	getCircles: (id: string) =>
@@ -1477,6 +1501,38 @@ export const releasesApi = {
 		}),
 };
 
+// リリース統合レスポンス
+export interface ReleaseEventInfo {
+	id: string;
+	name: string;
+	dayId: string | null;
+	dayNumber: number | null;
+	dayDate: string | null;
+}
+
+export interface ReleaseFullStats {
+	discCount: number;
+	trackCount: number;
+	circleCount: number;
+}
+
+export interface ReleaseFullResponse {
+	release: ReleaseWithDiscs;
+	tracks: TrackWithCreditCount[];
+	circles: ReleaseCircleWithCircle[];
+	publications: ReleasePublication[];
+	janCodes: ReleaseJanCode[];
+	event: ReleaseEventInfo | null;
+	stats: ReleaseFullStats;
+}
+
+export const releasesFullApi = {
+	get: (id: string, ssrHeaders?: Headers) =>
+		fetchWithAuth<ReleaseFullResponse>(`/api/admin/releases/${id}/full`, {
+			ssrHeaders,
+		}),
+};
+
 // Discs
 export const discsApi = {
 	list: (releaseId: string) =>
@@ -1644,6 +1700,29 @@ export const circleArtistsApi = {
 		fetchWithAuth<CircleArtistsResponse>(
 			`/api/admin/circles/${circleId}/artists`,
 		),
+};
+
+// サークル統合レスポンス
+export interface CircleFullStats {
+	artistCount: number;
+	releaseCount: number;
+	trackCount: number;
+	earliestReleaseDate: string | null;
+	latestReleaseDate: string | null;
+}
+
+export interface CircleFullResponse {
+	circle: CircleWithLinks;
+	artists: CircleArtistsResponse;
+	releases: CircleReleasesByType[];
+	stats: CircleFullStats;
+}
+
+export const circlesFullApi = {
+	get: (id: string, ssrHeaders?: Headers) =>
+		fetchWithAuth<CircleFullResponse>(`/api/admin/circles/${id}/full`, {
+			ssrHeaders,
+		}),
 };
 
 // ===== トラック管理 =====

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -20,10 +20,13 @@ import type {
 	Artist,
 	ArtistAlias,
 	ArtistCircle,
+	ArtistFullResponse,
 	ArtistTracksResponse,
 	ArtistWithAliases,
 	Circle,
 	CircleArtistsResponse,
+	CircleFullResponse,
+	CircleReleasesByType,
 	CircleWithLinks,
 	CreditRole,
 	Event,
@@ -35,6 +38,7 @@ import type {
 	OfficialWorkCategory,
 	PaginatedResponse,
 	Platform,
+	ReleaseFullResponse,
 	ReleaseWithCounts,
 	ReleaseWithDiscs,
 	TrackDetail,
@@ -118,6 +122,18 @@ export const artistCirclesQueryOptions = (id: string) =>
 	queryOptions({
 		queryKey: ["artist", id, "circles"],
 		queryFn: () => ssrFetch<ArtistCircle[]>(`/api/admin/artists/${id}/circles`),
+		staleTime: STALE_TIME.SHORT,
+	});
+
+/**
+ * アーティスト詳細（統合）のqueryOptions
+ * 基本情報 + 別名義 + 関連楽曲 + 参加サークルを一括取得
+ */
+export const artistFullQueryOptions = (id: string) =>
+	queryOptions({
+		queryKey: ["artist", id, "full"],
+		queryFn: () =>
+			ssrFetch<ArtistFullResponse>(`/api/admin/artists/${id}/full`),
 		staleTime: STALE_TIME.SHORT,
 	});
 
@@ -244,6 +260,29 @@ export const circleArtistsQueryOptions = (id: string) =>
 		queryKey: ["circle", id, "artists"],
 		queryFn: () =>
 			ssrFetch<CircleArtistsResponse>(`/api/admin/circles/${id}/artists`),
+		staleTime: STALE_TIME.SHORT,
+	});
+
+/**
+ * サークルのリリース一覧のqueryOptions
+ */
+export const circleReleasesQueryOptions = (id: string) =>
+	queryOptions({
+		queryKey: ["circle", id, "releases"],
+		queryFn: () =>
+			ssrFetch<CircleReleasesByType[]>(`/api/admin/circles/${id}/releases`),
+		staleTime: STALE_TIME.SHORT,
+	});
+
+/**
+ * サークル詳細（統合）のqueryOptions
+ * 基本情報 + リンク + 参加アーティスト + リリース一覧を一括取得
+ */
+export const circleFullQueryOptions = (id: string) =>
+	queryOptions({
+		queryKey: ["circle", id, "full"],
+		queryFn: () =>
+			ssrFetch<CircleFullResponse>(`/api/admin/circles/${id}/full`),
 		staleTime: STALE_TIME.SHORT,
 	});
 
@@ -391,6 +430,18 @@ export const releaseTracksQueryOptions = (releaseId: string) =>
 			ssrFetch<TrackWithCreditCount[]>(
 				`/api/admin/releases/${releaseId}/tracks`,
 			),
+		staleTime: STALE_TIME.SHORT,
+	});
+
+/**
+ * リリース詳細（統合）のqueryOptions
+ * 基本情報 + ディスク + トラック + サークル + 公開リンク + JANコード + イベント情報を一括取得
+ */
+export const releaseFullQueryOptions = (id: string) =>
+	queryOptions({
+		queryKey: ["release", id, "full"],
+		queryFn: () =>
+			ssrFetch<ReleaseFullResponse>(`/api/admin/releases/${id}/full`),
 		staleTime: STALE_TIME.SHORT,
 	});
 


### PR DESCRIPTION
## 概要

詳細ページで複数回実行されていたAPIコールを統合エンドポイント（`/:id/full`）にまとめ、パフォーマンスを改善

Closes #101

## 変更内容

### バックエンド

**アーティスト統合エンドポイント (`GET /admin/artists/:id/full`)**
- `getArtistTracks()`, `getArtistCircles()` 関数を抽出して再利用可能に
- 統計情報（トラック数、サークル数、役割別集計、最古/最新リリース日）を追加

**サークル統合エンドポイント (`GET /admin/circles/:id/full`)**
- `getCircleArtists()`, `getCircleReleases()` 関数を抽出して再利用可能に
- 統計情報（アーティスト数、リリース数、トラック数）を追加

**リリース統合エンドポイント (`GET /admin/releases/:id/full`)**
- `getReleaseTracks()`, `getReleaseCircles()`, `getReleasePublications()`, `getReleaseJanCodes()` 関数を抽出
- イベント情報を整形して返却
- 統計情報（ディスク数、トラック数、サークル数）を追加

### フロントエンド

- `api-client.ts`: 統合レスポンス型と API メソッドを追加
- `query-options.ts`: 統合エンドポイント用のクエリオプションを追加
- 各詳細ページ: 個別クエリを統合クエリに置き換え
  - アーティスト: 3クエリ → 1クエリ
  - サークル: 3クエリ → 1クエリ
  - リリース: 複数クエリ → 1クエリ

### パフォーマンス改善

- `Promise.all` による並列データ取得で応答時間を最適化
- フロントエンドのネットワークリクエスト数を大幅に削減

## 影響範囲

- アーティスト詳細ページ (`/admin/artists/:id`)
- サークル詳細ページ (`/admin/circles/:id`)
- リリース詳細ページ (`/admin/releases/:id`)

## 補足事項

- 既存の個別エンドポイントは後方互換性のため維持
- ダイアログ用の条件付きクエリ（クレジット編集など）は引き続き個別に取得