### PR TITLE
feat: 管理画面一覧ページに3段階カラムソート機能を追加

### DIFF
--- a/apps/server/src/routes/admin/events/events.ts
+++ b/apps/server/src/routes/admin/events/events.ts
@@ -1,7 +1,9 @@
 import {
 	and,
+	asc,
 	count,
 	db,
+	desc,
 	eq,
 	eventDays,
 	eventSeries,
@@ -25,6 +27,8 @@ eventsRouter.get("/", async (c) => {
 		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
 		const seriesId = c.req.query("seriesId");
 		const search = c.req.query("search");
+		const sortBy = c.req.query("sortBy") || "startDate";
+		const sortOrder = c.req.query("sortOrder") || "asc";
 
 		const offset = (page - 1) * limit;
 
@@ -44,6 +48,19 @@ eventsRouter.get("/", async (c) => {
 
 		const whereCondition =
 			conditions.length > 0 ? and(...conditions) : undefined;
+
+		// ソートカラムを決定
+		const sortColumnMap = {
+			id: events.id,
+			name: events.name,
+			startDate: events.startDate,
+			createdAt: events.createdAt,
+			updatedAt: events.updatedAt,
+		} as const;
+		const sortColumn =
+			sortColumnMap[sortBy as keyof typeof sortColumnMap] ?? events.startDate;
+		const orderByClause =
+			sortOrder === "desc" ? desc(sortColumn) : asc(sortColumn);
 
 		// データ取得（シリーズ名を含む）
 		const [data, totalResult] = await Promise.all([
@@ -66,7 +83,7 @@ eventsRouter.get("/", async (c) => {
 				.where(whereCondition)
 				.limit(limit)
 				.offset(offset)
-				.orderBy(events.startDate, events.name),
+				.orderBy(orderByClause),
 			db.select({ count: count() }).from(events).where(whereCondition),
 		]);
 

--- a/apps/web/src/hooks/use-sortable-table.ts
+++ b/apps/web/src/hooks/use-sortable-table.ts
@@ -4,6 +4,8 @@ interface UseSortableTableOptions {
 	defaultSortBy?: string;
 	defaultSortOrder?: "asc" | "desc";
 	onSortChange?: () => void;
+	/** 3段階ソート（昇順→降順→リセット）を有効にする（デフォルト: true） */
+	threeStateSort?: boolean;
 }
 
 interface UseSortableTableReturn {
@@ -22,6 +24,7 @@ export function useSortableTable(
 		defaultSortBy = "sortOrder",
 		defaultSortOrder = "asc",
 		onSortChange,
+		threeStateSort = true,
 	} = options;
 
 	const [sortBy, setSortBy] = useState<string>(defaultSortBy);
@@ -30,14 +33,31 @@ export function useSortableTable(
 	const handleSort = useCallback(
 		(column: string) => {
 			if (sortBy === column) {
-				setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+				if (sortOrder === "asc") {
+					// 昇順 → 降順
+					setSortOrder("desc");
+				} else if (threeStateSort) {
+					// 3段階モード: 降順 → リセット（デフォルトに戻す）
+					setSortBy(defaultSortBy);
+					setSortOrder(defaultSortOrder);
+				} else {
+					// 2段階モード: 降順 → 昇順
+					setSortOrder("asc");
+				}
 			} else {
 				setSortBy(column);
 				setSortOrder("asc");
 			}
 			onSortChange?.();
 		},
-		[sortBy, sortOrder, onSortChange],
+		[
+			sortBy,
+			sortOrder,
+			threeStateSort,
+			defaultSortBy,
+			defaultSortOrder,
+			onSortChange,
+		],
 	);
 
 	const resetSort = useCallback(() => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1809,12 +1809,16 @@ export const tracksApi = {
 		limit?: number;
 		search?: string;
 		releaseId?: string;
+		sortBy?: string;
+		sortOrder?: "asc" | "desc";
 	}) => {
 		const searchParams = new URLSearchParams();
 		if (params?.page) searchParams.set("page", String(params.page));
 		if (params?.limit) searchParams.set("limit", String(params.limit));
 		if (params?.search) searchParams.set("search", params.search);
 		if (params?.releaseId) searchParams.set("releaseId", params.releaseId);
+		if (params?.sortBy) searchParams.set("sortBy", params.sortBy);
+		if (params?.sortOrder) searchParams.set("sortOrder", params.sortOrder);
 		const query = searchParams.toString();
 		return fetchWithAuth<PaginatedResponse<TrackListItem>>(
 			`/api/admin/tracks${query ? `?${query}` : ""}`,

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -65,6 +65,8 @@ interface ArtistListParams {
 	limit: number;
 	search?: string;
 	initialScript?: string;
+	sortBy?: string;
+	sortOrder?: "asc" | "desc";
 }
 
 /**
@@ -77,6 +79,8 @@ export const artistsListQueryOptions = (params: ArtistListParams) => {
 	if (params.search) searchParams.set("search", params.search);
 	if (params.initialScript)
 		searchParams.set("initialScript", params.initialScript);
+	if (params.sortBy) searchParams.set("sortBy", params.sortBy);
+	if (params.sortOrder) searchParams.set("sortOrder", params.sortOrder);
 
 	return queryOptions({
 		queryKey: [
@@ -85,6 +89,8 @@ export const artistsListQueryOptions = (params: ArtistListParams) => {
 			params.limit,
 			params.search,
 			params.initialScript,
+			params.sortBy,
+			params.sortOrder,
 		],
 		queryFn: () =>
 			ssrFetch<PaginatedResponse<Artist>>(
@@ -144,6 +150,8 @@ interface ArtistAliasListParams {
 	limit: number;
 	search?: string;
 	artistId?: string;
+	sortBy?: string;
+	sortOrder?: "asc" | "desc";
 }
 
 /**
@@ -157,6 +165,8 @@ export const artistAliasesListQueryOptions = (
 	searchParams.set("limit", String(params.limit));
 	if (params.search) searchParams.set("search", params.search);
 	if (params.artistId) searchParams.set("artistId", params.artistId);
+	if (params.sortBy) searchParams.set("sortBy", params.sortBy);
+	if (params.sortOrder) searchParams.set("sortOrder", params.sortOrder);
 
 	return queryOptions({
 		queryKey: [
@@ -165,6 +175,8 @@ export const artistAliasesListQueryOptions = (
 			params.limit,
 			params.search,
 			params.artistId,
+			params.sortBy,
+			params.sortOrder,
 		],
 		queryFn: () =>
 			ssrFetch<PaginatedResponse<ArtistAlias>>(
@@ -213,6 +225,8 @@ interface CircleListParams {
 	limit: number;
 	search?: string;
 	initialScript?: string;
+	sortBy?: string;
+	sortOrder?: "asc" | "desc";
 }
 
 /**
@@ -225,6 +239,8 @@ export const circlesListQueryOptions = (params: CircleListParams) => {
 	if (params.search) searchParams.set("search", params.search);
 	if (params.initialScript)
 		searchParams.set("initialScript", params.initialScript);
+	if (params.sortBy) searchParams.set("sortBy", params.sortBy);
+	if (params.sortOrder) searchParams.set("sortOrder", params.sortOrder);
 
 	return queryOptions({
 		queryKey: [
@@ -233,6 +249,8 @@ export const circlesListQueryOptions = (params: CircleListParams) => {
 			params.limit,
 			params.search,
 			params.initialScript,
+			params.sortBy,
+			params.sortOrder,
 		],
 		queryFn: () =>
 			ssrFetch<PaginatedResponse<Circle>>(
@@ -293,6 +311,8 @@ interface EventListParams {
 	limit: number;
 	search?: string;
 	seriesId?: string;
+	sortBy?: string;
+	sortOrder?: "asc" | "desc";
 }
 
 /**
@@ -304,6 +324,8 @@ export const eventsListQueryOptions = (params: EventListParams) => {
 	searchParams.set("limit", String(params.limit));
 	if (params.search) searchParams.set("search", params.search);
 	if (params.seriesId) searchParams.set("seriesId", params.seriesId);
+	if (params.sortBy) searchParams.set("sortBy", params.sortBy);
+	if (params.sortOrder) searchParams.set("sortOrder", params.sortOrder);
 
 	return queryOptions({
 		queryKey: [
@@ -312,6 +334,8 @@ export const eventsListQueryOptions = (params: EventListParams) => {
 			params.limit,
 			params.search,
 			params.seriesId,
+			params.sortBy,
+			params.sortOrder,
 		],
 		queryFn: () =>
 			ssrFetch<PaginatedResponse<Event>>(
@@ -382,6 +406,8 @@ interface ReleaseListParams {
 	limit: number;
 	search?: string;
 	releaseType?: string;
+	sortBy?: string;
+	sortOrder?: "asc" | "desc";
 }
 
 /**
@@ -393,6 +419,8 @@ export const releasesListQueryOptions = (params: ReleaseListParams) => {
 	searchParams.set("limit", String(params.limit));
 	if (params.search) searchParams.set("search", params.search);
 	if (params.releaseType) searchParams.set("releaseType", params.releaseType);
+	if (params.sortBy) searchParams.set("sortBy", params.sortBy);
+	if (params.sortOrder) searchParams.set("sortOrder", params.sortOrder);
 
 	return queryOptions({
 		queryKey: [
@@ -401,6 +429,8 @@ export const releasesListQueryOptions = (params: ReleaseListParams) => {
 			params.limit,
 			params.search,
 			params.releaseType,
+			params.sortBy,
+			params.sortOrder,
 		],
 		queryFn: () =>
 			ssrFetch<PaginatedResponse<ReleaseWithCounts>>(
@@ -464,6 +494,8 @@ interface OfficialWorkListParams {
 	limit: number;
 	search?: string;
 	category?: string;
+	sortBy?: string;
+	sortOrder?: "asc" | "desc";
 }
 
 /**
@@ -477,6 +509,8 @@ export const officialWorksListQueryOptions = (
 	searchParams.set("limit", String(params.limit));
 	if (params.search) searchParams.set("search", params.search);
 	if (params.category) searchParams.set("category", params.category);
+	if (params.sortBy) searchParams.set("sortBy", params.sortBy);
+	if (params.sortOrder) searchParams.set("sortOrder", params.sortOrder);
 
 	return queryOptions({
 		queryKey: [
@@ -485,6 +519,8 @@ export const officialWorksListQueryOptions = (
 			params.limit,
 			params.search,
 			params.category,
+			params.sortBy,
+			params.sortOrder,
 		],
 		queryFn: () =>
 			ssrFetch<PaginatedResponse<OfficialWork>>(

--- a/apps/web/src/routes/admin/_admin/artist-aliases.tsx
+++ b/apps/web/src/routes/admin/_admin/artist-aliases.tsx
@@ -8,6 +8,7 @@ import { ArtistAliasEditDialog } from "@/components/admin/artist-alias-edit-dial
 import { DataTableActionBar } from "@/components/admin/data-table-action-bar";
 import { DataTablePagination } from "@/components/admin/data-table-pagination";
 import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
+import { SortIcon } from "@/components/admin/sort-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -24,6 +25,7 @@ import {
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useRowSelection } from "@/hooks/use-row-selection";
+import { useSortableTable } from "@/hooks/use-sortable-table";
 import {
 	type ArtistAlias,
 	aliasTypesApi,
@@ -109,6 +111,13 @@ function ArtistAliasesPage() {
 
 	const debouncedSearch = useDebounce(search, 300);
 
+	// ソート状態（3段階: 昇順→降順→リセット）
+	const { sortBy, sortOrder, handleSort } = useSortableTable({
+		defaultSortBy: "name",
+		defaultSortOrder: "asc",
+		onSortChange: () => setPage(1),
+	});
+
 	// カラム表示設定
 	const columnConfigs = useMemo(() => [...COLUMN_CONFIGS], []);
 	const { visibleColumns, toggleColumn, isVisible } = useColumnVisibility(
@@ -163,6 +172,8 @@ function ArtistAliasesPage() {
 			limit: pageSize,
 			search: debouncedSearch || undefined,
 			artistId: artistIdFilter || undefined,
+			sortBy,
+			sortOrder,
 		}),
 	);
 
@@ -349,9 +360,35 @@ function ArtistAliasesPage() {
 										/>
 									</TableHead>
 									{isVisible("id") && (
-										<TableHead className="w-[220px]">ID</TableHead>
+										<TableHead
+											className="w-[220px] cursor-pointer hover:bg-base-200"
+											onClick={() => handleSort("id")}
+										>
+											<span className="flex items-center gap-1">
+												ID
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="id"
+												/>
+											</span>
+										</TableHead>
 									)}
-									{isVisible("name") && <TableHead>名義名</TableHead>}
+									{isVisible("name") && (
+										<TableHead
+											className="cursor-pointer hover:bg-base-200"
+											onClick={() => handleSort("name")}
+										>
+											<span className="flex items-center gap-1">
+												名義名
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="name"
+												/>
+											</span>
+										</TableHead>
+									)}
 									{isVisible("artistName") && (
 										<TableHead className="w-[180px]">アーティスト</TableHead>
 									)}
@@ -368,10 +405,34 @@ function ArtistAliasesPage() {
 										<TableHead className="w-[140px]">使用期間</TableHead>
 									)}
 									{isVisible("createdAt") && (
-										<TableHead className="w-[160px]">作成日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer hover:bg-base-200"
+											onClick={() => handleSort("createdAt")}
+										>
+											<span className="flex items-center gap-1">
+												作成日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="createdAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("updatedAt") && (
-										<TableHead className="w-[160px]">更新日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer hover:bg-base-200"
+											onClick={() => handleSort("updatedAt")}
+										>
+											<span className="flex items-center gap-1">
+												更新日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="updatedAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									<TableHead className="w-[70px]" />
 								</TableRow>

--- a/apps/web/src/routes/admin/_admin/artists.tsx
+++ b/apps/web/src/routes/admin/_admin/artists.tsx
@@ -8,6 +8,7 @@ import { ArtistEditDialog } from "@/components/admin/artist-edit-dialog";
 import { DataTableActionBar } from "@/components/admin/data-table-action-bar";
 import { DataTablePagination } from "@/components/admin/data-table-pagination";
 import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
+import { SortIcon } from "@/components/admin/sort-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -23,6 +24,7 @@ import {
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useRowSelection } from "@/hooks/use-row-selection";
+import { useSortableTable } from "@/hooks/use-sortable-table";
 import {
 	type Artist,
 	artistsApi,
@@ -73,6 +75,13 @@ function ArtistsPage() {
 
 	const debouncedSearch = useDebounce(search, 300);
 
+	// ソート状態（3段階: 昇順→降順→リセット）
+	const { sortBy, sortOrder, handleSort } = useSortableTable({
+		defaultSortBy: "name",
+		defaultSortOrder: "asc",
+		onSortChange: () => setPage(1),
+	});
+
 	// カラム表示設定
 	const columnConfigs = useMemo(() => [...COLUMN_CONFIGS], []);
 	const { visibleColumns, toggleColumn, isVisible } = useColumnVisibility(
@@ -113,6 +122,8 @@ function ArtistsPage() {
 			limit: pageSize,
 			search: debouncedSearch || undefined,
 			initialScript: initialScript || undefined,
+			sortBy,
+			sortOrder,
 		}),
 	);
 
@@ -279,11 +290,43 @@ function ArtistsPage() {
 										/>
 									</TableHead>
 									{isVisible("id") && (
-										<TableHead className="w-[220px]">ID</TableHead>
+										<TableHead
+											className="w-[220px] cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("id")}
+										>
+											ID
+											<SortIcon
+												column="id"
+												sortBy={sortBy}
+												sortOrder={sortOrder}
+											/>
+										</TableHead>
 									)}
-									{isVisible("name") && <TableHead>名前</TableHead>}
+									{isVisible("name") && (
+										<TableHead
+											className="cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("name")}
+										>
+											名前
+											<SortIcon
+												column="name"
+												sortBy={sortBy}
+												sortOrder={sortOrder}
+											/>
+										</TableHead>
+									)}
 									{isVisible("nameJa") && (
-										<TableHead className="w-[150px]">日本語名</TableHead>
+										<TableHead
+											className="w-[150px] cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("nameJa")}
+										>
+											日本語名
+											<SortIcon
+												column="nameJa"
+												sortBy={sortBy}
+												sortOrder={sortOrder}
+											/>
+										</TableHead>
 									)}
 									{isVisible("nameEn") && (
 										<TableHead className="w-[150px]">英語名</TableHead>
@@ -301,10 +344,30 @@ function ArtistsPage() {
 										<TableHead className="w-[200px]">備考</TableHead>
 									)}
 									{isVisible("createdAt") && (
-										<TableHead className="w-[160px]">作成日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("createdAt")}
+										>
+											作成日時
+											<SortIcon
+												column="createdAt"
+												sortBy={sortBy}
+												sortOrder={sortOrder}
+											/>
+										</TableHead>
 									)}
 									{isVisible("updatedAt") && (
-										<TableHead className="w-[160px]">更新日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("updatedAt")}
+										>
+											更新日時
+											<SortIcon
+												column="updatedAt"
+												sortBy={sortBy}
+												sortOrder={sortOrder}
+											/>
+										</TableHead>
 									)}
 									<TableHead className="w-[70px]" />
 								</TableRow>

--- a/apps/web/src/routes/admin/_admin/circles.tsx
+++ b/apps/web/src/routes/admin/_admin/circles.tsx
@@ -18,6 +18,7 @@ import { CircleEditDialog } from "@/components/admin/circle-edit-dialog";
 import { DataTableActionBar } from "@/components/admin/data-table-action-bar";
 import { DataTablePagination } from "@/components/admin/data-table-pagination";
 import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
+import { SortIcon } from "@/components/admin/sort-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -45,6 +46,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useRowSelection } from "@/hooks/use-row-selection";
+import { useSortableTable } from "@/hooks/use-sortable-table";
 import {
 	type Circle,
 	type CircleLink,
@@ -102,6 +104,13 @@ function CirclesPage() {
 	const [initialScript, setInitialScript] = useState("");
 
 	const debouncedSearch = useDebounce(search, 300);
+
+	// ソート状態（3段階: 昇順→降順→リセット）
+	const { sortBy, sortOrder, handleSort } = useSortableTable({
+		defaultSortBy: "name",
+		defaultSortOrder: "asc",
+		onSortChange: () => setPage(1),
+	});
 
 	// カラム表示設定
 	const columnConfigs = useMemo(() => [...COLUMN_CONFIGS], []);
@@ -230,6 +239,8 @@ function CirclesPage() {
 			limit: pageSize,
 			search: debouncedSearch || undefined,
 			initialScript: initialScript || undefined,
+			sortBy,
+			sortOrder,
 		}),
 	);
 
@@ -531,11 +542,43 @@ function CirclesPage() {
 										/>
 									</TableHead>
 									{isVisible("id") && (
-										<TableHead className="w-[220px]">ID</TableHead>
+										<TableHead
+											className="w-[220px] cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("id")}
+										>
+											ID
+											<SortIcon
+												column="id"
+												sortBy={sortBy}
+												sortOrder={sortOrder}
+											/>
+										</TableHead>
 									)}
-									{isVisible("name") && <TableHead>名前</TableHead>}
+									{isVisible("name") && (
+										<TableHead
+											className="cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("name")}
+										>
+											名前
+											<SortIcon
+												column="name"
+												sortBy={sortBy}
+												sortOrder={sortOrder}
+											/>
+										</TableHead>
+									)}
 									{isVisible("nameJa") && (
-										<TableHead className="w-[150px]">日本語名</TableHead>
+										<TableHead
+											className="w-[150px] cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("nameJa")}
+										>
+											日本語名
+											<SortIcon
+												column="nameJa"
+												sortBy={sortBy}
+												sortOrder={sortOrder}
+											/>
+										</TableHead>
 									)}
 									{isVisible("nameEn") && (
 										<TableHead className="w-[150px]">英語名</TableHead>
@@ -553,10 +596,30 @@ function CirclesPage() {
 										<TableHead className="w-[200px]">備考</TableHead>
 									)}
 									{isVisible("createdAt") && (
-										<TableHead className="w-[160px]">作成日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("createdAt")}
+										>
+											作成日時
+											<SortIcon
+												column="createdAt"
+												sortBy={sortBy}
+												sortOrder={sortOrder}
+											/>
+										</TableHead>
 									)}
 									{isVisible("updatedAt") && (
-										<TableHead className="w-[160px]">更新日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("updatedAt")}
+										>
+											更新日時
+											<SortIcon
+												column="updatedAt"
+												sortBy={sortBy}
+												sortOrder={sortOrder}
+											/>
+										</TableHead>
 									)}
 									<TableHead className="w-[70px]" />
 								</TableRow>

--- a/apps/web/src/routes/admin/_admin/events.tsx
+++ b/apps/web/src/routes/admin/_admin/events.tsx
@@ -9,6 +9,7 @@ import { DataTableActionBar } from "@/components/admin/data-table-action-bar";
 import { DataTablePagination } from "@/components/admin/data-table-pagination";
 import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
 import { EventEditDialog } from "@/components/admin/event-edit-dialog";
+import { SortIcon } from "@/components/admin/sort-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -32,6 +33,7 @@ import {
 } from "@/components/ui/table";
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
+import { useSortableTable } from "@/hooks/use-sortable-table";
 import {
 	type Event,
 	type EventDay,
@@ -77,6 +79,13 @@ function EventsPage() {
 	const [seriesFilter, setSeriesFilter] = useState("");
 
 	const debouncedSearch = useDebounce(search, 300);
+
+	// ソート状態（3段階: 昇順→降順→リセット）
+	const { sortBy, sortOrder, handleSort } = useSortableTable({
+		defaultSortBy: "startDate",
+		defaultSortOrder: "asc",
+		onSortChange: () => setPage(1),
+	});
 
 	// カラム表示設定
 	const columnConfigs = useMemo(() => [...COLUMN_CONFIGS], []);
@@ -127,6 +136,8 @@ function EventsPage() {
 			limit: pageSize,
 			search: debouncedSearch || undefined,
 			seriesId: seriesFilter || undefined,
+			sortBy,
+			sortOrder,
 		}),
 	);
 
@@ -386,10 +397,34 @@ function EventsPage() {
 							<TableHeader>
 								<TableRow className="hover:bg-transparent">
 									{isVisible("id") && (
-										<TableHead className="w-[220px]">ID</TableHead>
+										<TableHead
+											className="w-[220px] cursor-pointer select-none"
+											onClick={() => handleSort("id")}
+										>
+											<span className="inline-flex items-center gap-1">
+												ID
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="id"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("name") && (
-										<TableHead className="min-w-[200px]">イベント名</TableHead>
+										<TableHead
+											className="min-w-[200px] cursor-pointer select-none"
+											onClick={() => handleSort("name")}
+										>
+											<span className="inline-flex items-center gap-1">
+												イベント名
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="name"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("seriesName") && (
 										<TableHead className="w-[160px]">シリーズ</TableHead>
@@ -398,7 +433,19 @@ function EventsPage() {
 										<TableHead className="w-[70px]">回次</TableHead>
 									)}
 									{isVisible("dateRange") && (
-										<TableHead className="w-[180px]">開催期間</TableHead>
+										<TableHead
+											className="w-[180px] cursor-pointer select-none"
+											onClick={() => handleSort("startDate")}
+										>
+											<span className="inline-flex items-center gap-1">
+												開催期間
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="startDate"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("venue") && (
 										<TableHead className="w-[120px]">会場</TableHead>
@@ -407,10 +454,34 @@ function EventsPage() {
 										<TableHead className="w-[80px]">開催日数</TableHead>
 									)}
 									{isVisible("createdAt") && (
-										<TableHead className="w-[160px]">作成日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none"
+											onClick={() => handleSort("createdAt")}
+										>
+											<span className="inline-flex items-center gap-1">
+												作成日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="createdAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("updatedAt") && (
-										<TableHead className="w-[160px]">更新日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none"
+											onClick={() => handleSort("updatedAt")}
+										>
+											<span className="inline-flex items-center gap-1">
+												更新日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="updatedAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									<TableHead className="w-[70px]" />
 								</TableRow>

--- a/apps/web/src/routes/admin/_admin/master/platforms.tsx
+++ b/apps/web/src/routes/admin/_admin/master/platforms.tsx
@@ -3,8 +3,6 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 import {
-	ArrowDown,
-	ArrowUp,
 	ArrowUpDown,
 	ChevronDown,
 	ChevronUp,
@@ -19,6 +17,7 @@ import { DataTableActionBar } from "@/components/admin/data-table-action-bar";
 import { DataTablePagination } from "@/components/admin/data-table-pagination";
 import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
 import { PlatformEditDialog } from "@/components/admin/platform-edit-dialog";
+import { SortIcon } from "@/components/admin/sort-icon";
 import { ImportDialog } from "@/components/import-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -33,6 +32,7 @@ import {
 } from "@/components/ui/table";
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
+import { useSortableTable } from "@/hooks/use-sortable-table";
 import { importApi, type Platform, platformsApi } from "@/lib/api-client";
 import { createPageHead } from "@/lib/head";
 
@@ -79,17 +79,22 @@ const categoryOptions = [
 function PlatformsPage() {
 	const queryClient = useQueryClient();
 
-	// ページネーション・フィルタ・ソート状態
+	// ページネーション・フィルタ状態
 	const [page, setPage] = useState(1);
 	const [pageSize, setPageSize] = useState(20);
 	const [search, setSearch] = useState("");
 	const [category, setCategory] = useState("");
-	const [sortBy, setSortBy] = useState<string>("sortOrder");
-	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 	const [isReordering, setIsReordering] = useState(false);
 
 	// API呼び出し用にデバウンス（300ms）
 	const debouncedSearch = useDebounce(search, 300);
+
+	// ソート状態（3段階: 昇順→降順→リセット）
+	const { sortBy, sortOrder, handleSort } = useSortableTable({
+		defaultSortBy: "sortOrder",
+		defaultSortOrder: "asc",
+		onSortChange: () => setPage(1),
+	});
 
 	// カラム表示設定
 	const columnConfigs = useMemo(() => [...COLUMN_CONFIGS], []);
@@ -229,29 +234,6 @@ function PlatformsPage() {
 		setPage(1);
 	};
 
-	const handleSort = (column: string) => {
-		if (sortBy === column) {
-			setSortOrder(sortOrder === "asc" ? "desc" : "asc");
-		} else {
-			setSortBy(column);
-			setSortOrder("asc");
-		}
-		setPage(1);
-	};
-
-	const SortIcon = ({ column }: { column: string }) => {
-		if (sortBy !== column) {
-			return (
-				<ArrowUpDown className="ml-1 inline h-4 w-4 text-base-content/30" />
-			);
-		}
-		return sortOrder === "asc" ? (
-			<ArrowUp className="ml-1 inline h-4 w-4" />
-		) : (
-			<ArrowDown className="ml-1 inline h-4 w-4" />
-		);
-	};
-
 	const displayError =
 		mutationError || (error instanceof Error ? error.message : null);
 
@@ -330,8 +312,14 @@ function PlatformsPage() {
 											className="w-[80px] cursor-pointer select-none hover:bg-base-200"
 											onClick={() => handleSort("sortOrder")}
 										>
-											順序
-											<SortIcon column="sortOrder" />
+											<span className="flex items-center gap-1">
+												順序
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="sortOrder"
+												/>
+											</span>
 										</TableHead>
 									)}
 									{isVisible("code") && (
@@ -339,8 +327,14 @@ function PlatformsPage() {
 											className="w-[150px] cursor-pointer select-none hover:bg-base-200"
 											onClick={() => handleSort("code")}
 										>
-											コード
-											<SortIcon column="code" />
+											<span className="flex items-center gap-1">
+												コード
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="code"
+												/>
+											</span>
 										</TableHead>
 									)}
 									{isVisible("name") && (
@@ -348,8 +342,14 @@ function PlatformsPage() {
 											className="cursor-pointer select-none hover:bg-base-200"
 											onClick={() => handleSort("name")}
 										>
-											名前
-											<SortIcon column="name" />
+											<span className="flex items-center gap-1">
+												名前
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="name"
+												/>
+											</span>
 										</TableHead>
 									)}
 									{isVisible("category") && (
@@ -357,18 +357,48 @@ function PlatformsPage() {
 											className="w-[120px] cursor-pointer select-none hover:bg-base-200"
 											onClick={() => handleSort("category")}
 										>
-											カテゴリ
-											<SortIcon column="category" />
+											<span className="flex items-center gap-1">
+												カテゴリ
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="category"
+												/>
+											</span>
 										</TableHead>
 									)}
 									{isVisible("urlPattern") && (
 										<TableHead>URLパターン</TableHead>
 									)}
 									{isVisible("createdAt") && (
-										<TableHead className="w-[160px]">作成日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("createdAt")}
+										>
+											<span className="flex items-center gap-1">
+												作成日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="createdAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("updatedAt") && (
-										<TableHead className="w-[160px]">更新日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none hover:bg-base-200"
+											onClick={() => handleSort("updatedAt")}
+										>
+											<span className="flex items-center gap-1">
+												更新日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="updatedAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									<TableHead className="w-[100px]" />
 								</TableRow>

--- a/apps/web/src/routes/admin/_admin/official/songs.tsx
+++ b/apps/web/src/routes/admin/_admin/official/songs.tsx
@@ -77,26 +77,12 @@ function OfficialSongsPage() {
 	// API呼び出し用にデバウンス（300ms）
 	const debouncedSearch = useDebounce(search, 300);
 
-	// ソート状態
-	const { sortBy, sortOrder, handleSort, resetSort } = useSortableTable({
+	// ソート状態（3段階: 昇順→降順→リセット）
+	const { sortBy, sortOrder, handleSort } = useSortableTable({
 		defaultSortBy: "id",
 		defaultSortOrder: "asc",
 		onSortChange: () => setPage(1),
 	});
-
-	// 楽曲名用の3段階ソートハンドラー（昇順→降順→リセット）
-	const handleNameJaSort = () => {
-		if (sortBy !== "nameJa") {
-			// 他のカラム → nameJa昇順
-			handleSort("nameJa");
-		} else if (sortOrder === "asc") {
-			// nameJa昇順 → nameJa降順
-			handleSort("nameJa");
-		} else {
-			// nameJa降順 → リセット（ID昇順）
-			resetSort();
-		}
-	};
 
 	// カラム表示設定
 	const columnConfigs = useMemo(() => [...COLUMN_CONFIGS], []);
@@ -305,7 +291,7 @@ function OfficialSongsPage() {
 									{isVisible("nameJa") && (
 										<TableHead
 											className="cursor-pointer select-none hover:bg-base-200"
-											onClick={handleNameJaSort}
+											onClick={() => handleSort("nameJa")}
 										>
 											楽曲名
 											<SortIcon

--- a/apps/web/src/routes/admin/_admin/official/works.tsx
+++ b/apps/web/src/routes/admin/_admin/official/works.tsx
@@ -8,6 +8,7 @@ import { DataTableActionBar } from "@/components/admin/data-table-action-bar";
 import { DataTablePagination } from "@/components/admin/data-table-pagination";
 import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
 import { OfficialWorkEditDialog } from "@/components/admin/official-work-edit-dialog";
+import { SortIcon } from "@/components/admin/sort-icon";
 import { ImportDialog } from "@/components/import-dialog";
 import { Badge, type BadgeVariant } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -22,6 +23,7 @@ import {
 } from "@/components/ui/table";
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
+import { useSortableTable } from "@/hooks/use-sortable-table";
 import {
 	importApi,
 	type OfficialWork,
@@ -84,6 +86,13 @@ function OfficialWorksPage() {
 	// API呼び出し用にデバウンス（300ms）
 	const debouncedSearch = useDebounce(search, 300);
 
+	// ソート状態（3段階: 昇順→降順→リセット）
+	const { sortBy, sortOrder, handleSort } = useSortableTable({
+		defaultSortBy: "position",
+		defaultSortOrder: "asc",
+		onSortChange: () => setPage(1),
+	});
+
 	// カラム表示設定
 	const columnConfigs = useMemo(() => [...COLUMN_CONFIGS], []);
 	const { visibleColumns, toggleColumn, isVisible } = useColumnVisibility(
@@ -119,6 +128,8 @@ function OfficialWorksPage() {
 			limit: pageSize,
 			search: debouncedSearch || undefined,
 			category: category || undefined,
+			sortBy,
+			sortOrder,
 		}),
 	);
 
@@ -238,9 +249,35 @@ function OfficialWorksPage() {
 							<TableHeader>
 								<TableRow className="hover:bg-transparent">
 									{isVisible("id") && (
-										<TableHead className="w-[150px]">ID</TableHead>
+										<TableHead
+											className="w-[150px] cursor-pointer hover:bg-base-200"
+											onClick={() => handleSort("id")}
+										>
+											<span className="flex items-center gap-1">
+												ID
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="id"
+												/>
+											</span>
+										</TableHead>
 									)}
-									{isVisible("nameJa") && <TableHead>作品名</TableHead>}
+									{isVisible("nameJa") && (
+										<TableHead
+											className="cursor-pointer hover:bg-base-200"
+											onClick={() => handleSort("nameJa")}
+										>
+											<span className="flex items-center gap-1">
+												作品名
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="nameJa"
+												/>
+											</span>
+										</TableHead>
+									)}
 									{isVisible("shortNameJa") && (
 										<TableHead className="w-[100px]">短縮名</TableHead>
 									)}
@@ -251,19 +288,67 @@ function OfficialWorksPage() {
 										<TableHead className="w-[60px]">番号</TableHead>
 									)}
 									{isVisible("releaseDate") && (
-										<TableHead className="w-[100px]">発売日</TableHead>
+										<TableHead
+											className="w-[100px] cursor-pointer hover:bg-base-200"
+											onClick={() => handleSort("releaseDate")}
+										>
+											<span className="flex items-center gap-1">
+												発売日
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="releaseDate"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("position") && (
-										<TableHead className="w-[70px]">表示順</TableHead>
+										<TableHead
+											className="w-[70px] cursor-pointer hover:bg-base-200"
+											onClick={() => handleSort("position")}
+										>
+											<span className="flex items-center gap-1">
+												表示順
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="position"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("officialOrganization") && (
 										<TableHead className="w-[150px]">発行元</TableHead>
 									)}
 									{isVisible("createdAt") && (
-										<TableHead className="w-[160px]">作成日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer hover:bg-base-200"
+											onClick={() => handleSort("createdAt")}
+										>
+											<span className="flex items-center gap-1">
+												作成日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="createdAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("updatedAt") && (
-										<TableHead className="w-[160px]">更新日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer hover:bg-base-200"
+											onClick={() => handleSort("updatedAt")}
+										>
+											<span className="flex items-center gap-1">
+												更新日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="updatedAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									<TableHead className="w-[100px]" />
 								</TableRow>

--- a/apps/web/src/routes/admin/_admin/releases.tsx
+++ b/apps/web/src/routes/admin/_admin/releases.tsx
@@ -9,6 +9,7 @@ import { DataTableActionBar } from "@/components/admin/data-table-action-bar";
 import { DataTablePagination } from "@/components/admin/data-table-pagination";
 import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
 import { ReleaseEditDialog } from "@/components/admin/release-edit-dialog";
+import { SortIcon } from "@/components/admin/sort-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -36,6 +37,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useRowSelection } from "@/hooks/use-row-selection";
+import { useSortableTable } from "@/hooks/use-sortable-table";
 import {
 	discsApi,
 	eventDaysApi,
@@ -98,6 +100,13 @@ function ReleasesPage() {
 
 	const debouncedSearch = useDebounce(search, 300);
 
+	// ソート状態（3段階: 昇順→降順→リセット）
+	const { sortBy, sortOrder, handleSort } = useSortableTable({
+		defaultSortBy: "releaseDate",
+		defaultSortOrder: "asc",
+		onSortChange: () => setPage(1),
+	});
+
 	// カラム表示設定
 	const columnConfigs = useMemo(() => [...COLUMN_CONFIGS], []);
 	const { visibleColumns, toggleColumn, isVisible } = useColumnVisibility(
@@ -147,6 +156,8 @@ function ReleasesPage() {
 			limit: pageSize,
 			search: debouncedSearch || undefined,
 			releaseType: releaseTypeFilter || undefined,
+			sortBy,
+			sortOrder,
 		}),
 	);
 
@@ -430,16 +441,52 @@ function ReleasesPage() {
 										/>
 									</TableHead>
 									{isVisible("id") && (
-										<TableHead className="w-[220px]">ID</TableHead>
+										<TableHead
+											className="w-[220px] cursor-pointer select-none"
+											onClick={() => handleSort("id")}
+										>
+											<span className="inline-flex items-center gap-1">
+												ID
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="id"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("name") && (
-										<TableHead className="min-w-[200px]">作品名</TableHead>
+										<TableHead
+											className="min-w-[200px] cursor-pointer select-none"
+											onClick={() => handleSort("name")}
+										>
+											<span className="inline-flex items-center gap-1">
+												作品名
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="name"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("releaseType") && (
 										<TableHead className="w-[120px]">タイプ</TableHead>
 									)}
 									{isVisible("releaseDate") && (
-										<TableHead className="w-[120px]">発売日</TableHead>
+										<TableHead
+											className="w-[120px] cursor-pointer select-none"
+											onClick={() => handleSort("releaseDate")}
+										>
+											<span className="inline-flex items-center gap-1">
+												発売日
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="releaseDate"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("event") && (
 										<TableHead className="min-w-[180px]">イベント</TableHead>
@@ -454,10 +501,34 @@ function ReleasesPage() {
 										<TableHead className="w-[100px]">トラック数</TableHead>
 									)}
 									{isVisible("createdAt") && (
-										<TableHead className="w-[160px]">作成日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none"
+											onClick={() => handleSort("createdAt")}
+										>
+											<span className="inline-flex items-center gap-1">
+												作成日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="createdAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("updatedAt") && (
-										<TableHead className="w-[160px]">更新日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none"
+											onClick={() => handleSort("updatedAt")}
+										>
+											<span className="inline-flex items-center gap-1">
+												更新日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="updatedAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									<TableHead className="w-[70px]" />
 								</TableRow>

--- a/apps/web/src/routes/admin/_admin/tracks.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks.tsx
@@ -8,6 +8,7 @@ import { useMemo, useState } from "react";
 import { DataTableActionBar } from "@/components/admin/data-table-action-bar";
 import { DataTablePagination } from "@/components/admin/data-table-pagination";
 import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
+import { SortIcon } from "@/components/admin/sort-icon";
 import { TrackEditDialog } from "@/components/admin/track-edit-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -34,6 +35,7 @@ import {
 import { useColumnVisibility } from "@/hooks/use-column-visibility";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useRowSelection } from "@/hooks/use-row-selection";
+import { useSortableTable } from "@/hooks/use-sortable-table";
 import {
 	releasesApi,
 	type Track,
@@ -74,6 +76,13 @@ function TracksPage() {
 	const [releaseFilter, setReleaseFilter] = useState("");
 
 	const debouncedSearch = useDebounce(search, 300);
+
+	// ソート状態（3段階: 昇順→降順→リセット）
+	const { sortBy, sortOrder, handleSort } = useSortableTable({
+		defaultSortBy: "name",
+		defaultSortOrder: "asc",
+		onSortChange: () => setPage(1),
+	});
 
 	// カラム表示設定
 	const columnConfigs = useMemo(() => [...COLUMN_CONFIGS], []);
@@ -120,13 +129,23 @@ function TracksPage() {
 
 	// トラック一覧取得（ページネーション対応API）
 	const { data, isPending, error } = useQuery({
-		queryKey: ["all-tracks", page, pageSize, debouncedSearch, releaseFilter],
+		queryKey: [
+			"all-tracks",
+			page,
+			pageSize,
+			debouncedSearch,
+			releaseFilter,
+			sortBy,
+			sortOrder,
+		],
 		queryFn: () =>
 			tracksApi.listPaginated({
 				page,
 				limit: pageSize,
 				search: debouncedSearch || undefined,
 				releaseId: releaseFilter || undefined,
+				sortBy,
+				sortOrder,
 			}),
 		staleTime: 30_000,
 	});
@@ -353,10 +372,34 @@ function TracksPage() {
 										/>
 									</TableHead>
 									{isVisible("id") && (
-										<TableHead className="w-[220px]">ID</TableHead>
+										<TableHead
+											className="w-[220px] cursor-pointer select-none"
+											onClick={() => handleSort("id")}
+										>
+											<span className="inline-flex items-center gap-1">
+												ID
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="id"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("name") && (
-										<TableHead className="min-w-[200px]">トラック名</TableHead>
+										<TableHead
+											className="min-w-[200px] cursor-pointer select-none"
+											onClick={() => handleSort("name")}
+										>
+											<span className="inline-flex items-center gap-1">
+												トラック名
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="name"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("releaseName") && (
 										<TableHead className="min-w-[200px]">作品</TableHead>
@@ -365,7 +408,19 @@ function TracksPage() {
 										<TableHead className="w-[100px]">ディスク</TableHead>
 									)}
 									{isVisible("trackNumber") && (
-										<TableHead className="w-[60px]">No.</TableHead>
+										<TableHead
+											className="w-[60px] cursor-pointer select-none"
+											onClick={() => handleSort("trackNumber")}
+										>
+											<span className="inline-flex items-center gap-1">
+												No.
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="trackNumber"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("event") && (
 										<TableHead className="min-w-[150px]">イベント</TableHead>
@@ -389,10 +444,34 @@ function TracksPage() {
 										<TableHead className="w-[100px]">クレジット数</TableHead>
 									)}
 									{isVisible("createdAt") && (
-										<TableHead className="w-[160px]">作成日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none"
+											onClick={() => handleSort("createdAt")}
+										>
+											<span className="inline-flex items-center gap-1">
+												作成日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="createdAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									{isVisible("updatedAt") && (
-										<TableHead className="w-[160px]">更新日時</TableHead>
+										<TableHead
+											className="w-[160px] cursor-pointer select-none"
+											onClick={() => handleSort("updatedAt")}
+										>
+											<span className="inline-flex items-center gap-1">
+												更新日時
+												<SortIcon
+													sortBy={sortBy}
+													sortOrder={sortOrder}
+													column="updatedAt"
+												/>
+											</span>
+										</TableHead>
 									)}
 									<TableHead className="w-[70px]" />
 								</TableRow>


### PR DESCRIPTION
## 概要

管理画面の一覧ページで「昇順→降順→リセット」の3段階カラムソートを実装。

## 変更内容

### useSortableTableフック拡張
* `threeStateSort`オプション追加（デフォルト: true）
* 3段階サイクル: 昇順 → 降順 → リセット（デフォルトソートに戻る）

### バックエンドAPI対応（7ファイル）
* circles, artists, releases, tracks, events, artist-aliases, official/works 各エンドポイント
* sortBy/sortOrderクエリパラメータ追加
* 動的ソートカラムマッピング実装

### フロントエンド対応（10ファイル）
* 各一覧ページにSortIcon + useSortableTableを導入
* query-optionsに各リストパラメータのソート対応追加
* api-client: tracksApi.listPaginatedにソートパラメータ追加
* master/platforms: 独自実装を共通フックに統一
* official/songs: 個別実装を削除、フック利用に統一

### ソート対象カラム

| ページ | ソート可能カラム |
|--------|-----------------|
| circles | id, name, nameJa, createdAt, updatedAt |
| artists | id, name, nameJa, createdAt, updatedAt |
| releases | id, name, releaseDate, createdAt, updatedAt |
| tracks | id, name, trackNumber, createdAt, updatedAt |
| events | id, name, startDate, createdAt, updatedAt |
| artist-aliases | id, name, createdAt, updatedAt |
| official/works | id, nameJa, position, releaseDate, createdAt, updatedAt |
| master/platforms | sortOrder, code, name, category, createdAt, updatedAt |

## 影響範囲

* 管理画面の全一覧ページでカラムソートの動作が変更
* 2回クリック後のリセット動作が追加される