### PR TITLE
feat: 検索・フィルタ変更時のローディング表示を追加

### DIFF
--- a/apps/web/src/components/admin/data-table-action-bar.tsx
+++ b/apps/web/src/components/admin/data-table-action-bar.tsx
@@ -35,6 +35,7 @@ interface DataTableActionBarProps extends React.ComponentProps<"div"> {
 	searchPlaceholder?: string;
 	searchValue?: string;
 	onSearchChange?: (value: string) => void;
+	isLoading?: boolean;
 	filterOptions?: FilterOption[];
 	filterValue?: string;
 	filterPlaceholder?: string;
@@ -55,6 +56,7 @@ function DataTableActionBar({
 	searchPlaceholder = "検索...",
 	searchValue,
 	onSearchChange,
+	isLoading = false,
 	filterOptions,
 	filterValue,
 	filterPlaceholder = "すべて",
@@ -87,6 +89,7 @@ function DataTableActionBar({
 						onChange={(e) => onSearchChange(e.target.value)}
 						size="md"
 						containerClassName="w-64"
+						isLoading={isLoading}
 					/>
 				)}
 				{filterOptions && filterOptions.length > 0 && onFilterChange && (

--- a/apps/web/src/components/ui/search-input.tsx
+++ b/apps/web/src/components/ui/search-input.tsx
@@ -1,4 +1,4 @@
-import { Search } from "lucide-react";
+import { Loader2, Search } from "lucide-react";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -22,23 +22,28 @@ const iconSizeClasses: Record<SearchInputSize, string> = {
 interface SearchInputProps extends Omit<React.ComponentProps<"input">, "size"> {
 	size?: SearchInputSize;
 	containerClassName?: string;
+	isLoading?: boolean;
 }
 
 function SearchInput({
 	className,
 	size = "md",
 	containerClassName,
+	isLoading = false,
 	...props
 }: SearchInputProps) {
+	const IconComponent = isLoading ? Loader2 : Search;
+
 	return (
 		<div
 			data-slot="search-input-container"
 			className={cn("relative", containerClassName)}
 		>
-			<Search
+			<IconComponent
 				className={cn(
 					"pointer-events-none absolute top-1/2 left-3 z-10 -translate-y-1/2 text-base-content/50",
 					iconSizeClasses[size],
+					isLoading && "animate-spin",
 				)}
 			/>
 			<input

--- a/apps/web/src/routes/admin/_admin/artist-aliases.tsx
+++ b/apps/web/src/routes/admin/_admin/artist-aliases.tsx
@@ -166,7 +166,7 @@ function ArtistAliasesPage() {
 	});
 	const aliasTypes = aliasTypesData?.data ?? [];
 
-	const { data, isPending, error } = useQuery(
+	const { data, isPending, isFetching, error } = useQuery(
 		artistAliasesListQueryOptions({
 			page,
 			limit: pageSize,
@@ -291,6 +291,7 @@ function ArtistAliasesPage() {
 					searchPlaceholder="名義名で検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					columnVisibility={{
 						columns: columnConfigs,
 						visibleColumns,

--- a/apps/web/src/routes/admin/_admin/artists.tsx
+++ b/apps/web/src/routes/admin/_admin/artists.tsx
@@ -116,7 +116,7 @@ function ArtistsPage() {
 
 	// ensureQueryData + queryOptionsパターン
 	// ローダーでプリフェッチしたデータを自動的に使用
-	const { data, isPending, error } = useQuery(
+	const { data, isPending, isFetching, error } = useQuery(
 		artistsListQueryOptions({
 			page,
 			limit: pageSize,
@@ -226,6 +226,7 @@ function ArtistsPage() {
 					searchPlaceholder="名前で検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					filterOptions={initialScriptOptions}
 					filterValue={initialScript}
 					filterPlaceholder="頭文字の文字種"

--- a/apps/web/src/routes/admin/_admin/circles.tsx
+++ b/apps/web/src/routes/admin/_admin/circles.tsx
@@ -233,7 +233,7 @@ function CirclesPage() {
 		return "web_site"; // マッチしなければweb_site
 	};
 
-	const { data, isPending, error } = useQuery(
+	const { data, isPending, isFetching, error } = useQuery(
 		circlesListQueryOptions({
 			page,
 			limit: pageSize,
@@ -478,6 +478,7 @@ function CirclesPage() {
 					searchPlaceholder="名前で検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					filterOptions={initialScriptOptions}
 					filterValue={initialScript}
 					filterPlaceholder="頭文字の文字種"

--- a/apps/web/src/routes/admin/_admin/event-series.tsx
+++ b/apps/web/src/routes/admin/_admin/event-series.tsx
@@ -68,7 +68,7 @@ function EventSeriesPage() {
 	const [deleteTarget, setDeleteTarget] = useState<EventSeries | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);
 
-	const { data, isPending, error } = useQuery(
+	const { data, isPending, isFetching, error } = useQuery(
 		eventSeriesListQueryOptions({
 			search: debouncedSearch || undefined,
 			sortBy,
@@ -198,6 +198,7 @@ function EventSeriesPage() {
 					searchPlaceholder="シリーズ名で検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					columnVisibility={{
 						columns: columnConfigs,
 						visibleColumns,

--- a/apps/web/src/routes/admin/_admin/events.tsx
+++ b/apps/web/src/routes/admin/_admin/events.tsx
@@ -130,7 +130,7 @@ function EventsPage() {
 		label: s.name,
 	}));
 
-	const { data, isPending, error } = useQuery(
+	const { data, isPending, isFetching, error } = useQuery(
 		eventsListQueryOptions({
 			page,
 			limit: pageSize,
@@ -363,6 +363,7 @@ function EventsPage() {
 					searchPlaceholder="イベント名で検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					filterOptions={seriesOptions}
 					filterValue={seriesFilter}
 					filterPlaceholder="シリーズで絞り込み"

--- a/apps/web/src/routes/admin/_admin/master/alias-types.tsx
+++ b/apps/web/src/routes/admin/_admin/master/alias-types.tsx
@@ -69,7 +69,7 @@ function AliasTypesPage() {
 	const [deleteTarget, setDeleteTarget] = useState<AliasType | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);
 
-	const { data, isPending, error } = useQuery({
+	const { data, isPending, isFetching, error } = useQuery({
 		queryKey: [
 			"alias-types",
 			page,
@@ -211,6 +211,7 @@ function AliasTypesPage() {
 					searchPlaceholder="ラベルまたはコードで検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					columnVisibility={{
 						columns: columnConfigs,
 						visibleColumns,

--- a/apps/web/src/routes/admin/_admin/master/credit-roles.tsx
+++ b/apps/web/src/routes/admin/_admin/master/credit-roles.tsx
@@ -71,7 +71,7 @@ function CreditRolesPage() {
 	const [deleteTarget, setDeleteTarget] = useState<CreditRole | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);
 
-	const { data, isPending, error } = useQuery({
+	const { data, isPending, isFetching, error } = useQuery({
 		queryKey: [
 			"credit-roles",
 			page,
@@ -206,6 +206,7 @@ function CreditRolesPage() {
 					searchPlaceholder="ラベルまたはコードで検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					columnVisibility={{
 						columns: columnConfigs,
 						visibleColumns,

--- a/apps/web/src/routes/admin/_admin/master/official-work-categories.tsx
+++ b/apps/web/src/routes/admin/_admin/master/official-work-categories.tsx
@@ -79,7 +79,7 @@ function OfficialWorkCategoriesPage() {
 	);
 	const [isDeleting, setIsDeleting] = useState(false);
 
-	const { data, isPending, error } = useQuery({
+	const { data, isPending, isFetching, error } = useQuery({
 		queryKey: [
 			"official-work-categories",
 			page,
@@ -229,6 +229,7 @@ function OfficialWorkCategoriesPage() {
 					searchPlaceholder="名前またはコードで検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					columnVisibility={{
 						columns: columnConfigs,
 						visibleColumns,

--- a/apps/web/src/routes/admin/_admin/master/platforms.tsx
+++ b/apps/web/src/routes/admin/_admin/master/platforms.tsx
@@ -110,7 +110,7 @@ function PlatformsPage() {
 	const [deleteTarget, setDeleteTarget] = useState<Platform | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);
 
-	const { data, isPending, error } = useQuery({
+	const { data, isPending, isFetching, error } = useQuery({
 		queryKey: [
 			"platforms",
 			page,
@@ -260,6 +260,7 @@ function PlatformsPage() {
 					searchPlaceholder="名前またはコードで検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					filterOptions={categoryOptions}
 					filterValue={category}
 					filterPlaceholder="カテゴリを選択"

--- a/apps/web/src/routes/admin/_admin/official/songs.tsx
+++ b/apps/web/src/routes/admin/_admin/official/songs.tsx
@@ -112,7 +112,7 @@ function OfficialSongsPage() {
 		staleTime: 300_000,
 	});
 
-	const { data, isPending, error } = useQuery(
+	const { data, isPending, isFetching, error } = useQuery(
 		officialSongsListQueryOptions({
 			page,
 			limit: pageSize,
@@ -230,6 +230,7 @@ function OfficialSongsPage() {
 					searchPlaceholder="楽曲名で検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					columnVisibility={{
 						columns: columnConfigs,
 						visibleColumns,

--- a/apps/web/src/routes/admin/_admin/official/works.tsx
+++ b/apps/web/src/routes/admin/_admin/official/works.tsx
@@ -122,7 +122,7 @@ function OfficialWorksPage() {
 			label: c.name,
 		})) ?? [];
 
-	const { data, isPending, error } = useQuery(
+	const { data, isPending, isFetching, error } = useQuery(
 		officialWorksListQueryOptions({
 			page,
 			limit: pageSize,
@@ -208,6 +208,7 @@ function OfficialWorksPage() {
 					searchPlaceholder="作品名で検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					filterOptions={categoryOptions}
 					filterValue={category}
 					filterPlaceholder="カテゴリを選択"

--- a/apps/web/src/routes/admin/_admin/releases.tsx
+++ b/apps/web/src/routes/admin/_admin/releases.tsx
@@ -150,7 +150,7 @@ function ReleasesPage() {
 	);
 	const [isDeleting, setIsDeleting] = useState(false);
 
-	const { data, isPending, error } = useQuery(
+	const { data, isPending, isFetching, error } = useQuery(
 		releasesListQueryOptions({
 			page,
 			limit: pageSize,
@@ -377,6 +377,7 @@ function ReleasesPage() {
 					searchPlaceholder="作品名で検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					filterOptions={RELEASE_TYPE_OPTIONS}
 					filterValue={releaseTypeFilter}
 					filterPlaceholder="タイプで絞り込み"

--- a/apps/web/src/routes/admin/_admin/tracks.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks.tsx
@@ -128,7 +128,7 @@ function TracksPage() {
 	});
 
 	// トラック一覧取得（ページネーション対応API）
-	const { data, isPending, error } = useQuery({
+	const { data, isPending, isFetching, error } = useQuery({
 		queryKey: [
 			"all-tracks",
 			page,
@@ -302,6 +302,7 @@ function TracksPage() {
 					searchPlaceholder="トラック名で検索..."
 					searchValue={search}
 					onSearchChange={handleSearchChange}
+					isLoading={isFetching}
 					columnVisibility={{
 						columns: columnConfigs,
 						visibleColumns,


### PR DESCRIPTION
## 概要

検索やフィルタ変更時にローディングスピナーを表示し、データ取得中であることを視覚的にフィードバックする機能を追加。

Closes #102

## 変更内容

* `SearchInput`コンポーネントに`isLoading`プロップを追加
  * ローディング中は検索アイコン（🔍）がスピナーアイコンに変更
  * `Loader2`アイコンと`animate-spin`クラスを使用
* `DataTableActionBar`に`isLoading`プロップを追加
  * `SearchInput`にローディング状態を伝播
* 管理画面一覧ページ13ファイルで`isFetching`を使用
  * `useQuery`から`isFetching`を取得
  * `DataTableActionBar`に`isLoading={isFetching}`を渡す

## 影響範囲

管理画面の全一覧ページ（13ページ）:
- アーティスト、サークル、作品、トラック
- イベント、イベントシリーズ
- アーティスト名義
- 公式作品、公式楽曲
- プラットフォーム、名義種別、クレジット役割、公式作品カテゴリ

## 補足事項

`isFetching`は`isPending`と異なり、キャッシュがある場合のリフェッチでもtrueになるため、検索・フィルタ・ソート・ページ変更時すべてでスピナーが表示される。