### PR TITLE
feat: 管理APIにレート制限を追加

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,13 +11,14 @@
 		"test": "bun test"
 	},
 	"dependencies": {
-		"hono": "^4.8.2",
-		"better-auth": "catalog:",
-		"dotenv": "catalog:",
-		"zod": "catalog:",
 		"@thac/auth": "workspace:*",
 		"@thac/db": "workspace:*",
-		"@thac/utils": "workspace:*"
+		"@thac/utils": "workspace:*",
+		"better-auth": "catalog:",
+		"dotenv": "catalog:",
+		"hono": "^4.8.2",
+		"hono-rate-limiter": "^0.5.3",
+		"zod": "catalog:"
 	},
 	"devDependencies": {
 		"@types/bun": "catalog:",

--- a/apps/server/src/constants/error-messages.ts
+++ b/apps/server/src/constants/error-messages.ts
@@ -95,6 +95,10 @@ export const ERROR_MESSAGES = {
 	FILE_NOT_SPECIFIED: "ファイルが指定されていません",
 	FILE_NOT_UPLOADED: "ファイルがアップロードされていません",
 	ONLY_CSV_ALLOWED: "CSVファイルのみアップロード可能です",
+
+	// ===== レート制限エラー (429) =====
+	RATE_LIMIT_EXCEEDED:
+		"リクエスト数が上限を超えました。しばらくしてから再試行してください",
 	FILE_SIZE_EXCEEDED: (maxSizeMB: number) =>
 		`ファイルサイズが${maxSizeMB}MBを超えています`,
 	DATA_FETCH_FAILED: "データの取得に失敗しました",

--- a/apps/server/src/middleware/rate-limit.ts
+++ b/apps/server/src/middleware/rate-limit.ts
@@ -1,0 +1,71 @@
+import type { Context, Next } from "hono";
+import { rateLimiter } from "hono-rate-limiter";
+import { ERROR_MESSAGES } from "../constants/error-messages";
+
+const isDev = process.env.NODE_ENV === "development";
+const multiplier = isDev ? 10 : 1;
+
+// キー生成: ユーザーID優先、フォールバックはIP
+const keyGenerator = (c: Context) =>
+	c.get("user")?.id ?? c.req.header("x-forwarded-for") ?? "anonymous";
+
+// GET用（100リクエスト/分）
+const readRateLimiter = rateLimiter({
+	windowMs: 60 * 1000,
+	limit: 100 * multiplier,
+	standardHeaders: "draft-6",
+	keyGenerator,
+	message: { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+});
+
+// POST/PUT/PATCH用（30リクエスト/分）
+const writeRateLimiter = rateLimiter({
+	windowMs: 60 * 1000,
+	limit: 30 * multiplier,
+	standardHeaders: "draft-6",
+	keyGenerator,
+	message: { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+});
+
+// DELETE用（20リクエスト/分）
+const deleteRateLimiter = rateLimiter({
+	windowMs: 60 * 1000,
+	limit: 20 * multiplier,
+	standardHeaders: "draft-6",
+	keyGenerator,
+	message: { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+});
+
+// バッチ操作用（10リクエスト/分）
+const batchRateLimiter = rateLimiter({
+	windowMs: 60 * 1000,
+	limit: 10 * multiplier,
+	standardHeaders: "draft-6",
+	keyGenerator,
+	message: { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+});
+
+/**
+ * HTTPメソッド・パス別のレート制限ミドルウェア
+ * 認証ミドルウェアの後に適用することで、ユーザーIDでレート制限を適用可能
+ */
+export async function methodRateLimiter(c: Context, next: Next) {
+	const method = c.req.method;
+	const path = c.req.path;
+
+	if (method === "GET") {
+		return readRateLimiter(c, next);
+	}
+	if (method === "POST" || method === "PUT" || method === "PATCH") {
+		return writeRateLimiter(c, next);
+	}
+	if (method === "DELETE") {
+		// バッチ操作は厳しい制限
+		if (path.includes("/batch")) {
+			return batchRateLimiter(c, next);
+		}
+		return deleteRateLimiter(c, next);
+	}
+
+	return next();
+}

--- a/apps/server/src/routes/admin/index.ts
+++ b/apps/server/src/routes/admin/index.ts
@@ -3,6 +3,7 @@ import {
 	type AdminContext,
 	adminAuthMiddleware,
 } from "../../middleware/admin-auth";
+import { methodRateLimiter } from "../../middleware/rate-limit";
 import { artistAliasesRouter } from "./artist-aliases";
 import { artistsRouter } from "./artists";
 import { circlesRouter } from "./circles";
@@ -18,6 +19,9 @@ const adminRouter = new Hono<AdminContext>();
 
 // 管理者認証ミドルウェアを適用
 adminRouter.use("/*", adminAuthMiddleware);
+
+// レート制限ミドルウェアを適用（認証後）
+adminRouter.use("/*", methodRateLimiter);
 
 // 統計情報ルート
 adminRouter.route("/stats", statsRouter);

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "better-auth": "catalog:",
         "dotenv": "catalog:",
         "hono": "^4.8.2",
+        "hono-rate-limiter": "^0.5.3",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -743,6 +744,8 @@
     "happy-dom": ["happy-dom@20.0.11", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g=="],
 
     "hono": ["hono@4.11.1", "", {}, "sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg=="],
+
+    "hono-rate-limiter": ["hono-rate-limiter@0.5.3", "", { "peerDependencies": { "hono": "^4.10.8", "unstorage": "^1.17.3" }, "optionalPeers": ["unstorage"] }, "sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A=="],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 


### PR DESCRIPTION
## 概要

管理APIエンドポイントに`hono-rate-limiter`を使用してレート制限を実装し、DoS攻撃や過剰なリクエストを防止する。

## 変更内容

* `hono-rate-limiter`パッケージをインストール
* HTTPメソッド別のレート制限ミドルウェアを新規作成
  * GET（一覧・詳細）: 100リクエスト/分
  * POST/PUT/PATCH（作成・更新）: 30リクエスト/分
  * DELETE（通常）: 20リクエスト/分
  * DELETE（バッチ `/batch`）: 10リクエスト/分
* 開発環境では制限を10倍に緩和
* ユーザーID優先、IPアドレスフォールバックでキー生成
* エラーメッセージ定数に`RATE_LIMIT_EXCEEDED`を追加
* ステアリングドキュメント（tech.md）にRate Limitingセクションを追加

## 影響範囲

* 管理API（`/api/admin/*`）全体に影響
* 制限超過時はHTTP 429エラーと`RateLimit-*`ヘッダーを返却

## 補足事項

* ストレージはデフォルトのインメモリストアを使用（単一サーバー想定）
* レスポンスヘッダーは`draft-6`形式（`RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`）

Closes #106