### PR TITLE
feat: 同時編集時の競合制御（楽観的ロック）を実装

### DIFF
--- a/apps/server/src/constants/error-messages.ts
+++ b/apps/server/src/constants/error-messages.ts
@@ -96,6 +96,10 @@ export const ERROR_MESSAGES = {
 	FILE_NOT_UPLOADED: "ファイルがアップロードされていません",
 	ONLY_CSV_ALLOWED: "CSVファイルのみアップロード可能です",
 
+	// ===== 競合エラー (409) =====
+	DATA_CHANGED_BY_ANOTHER_USER:
+		"このデータは他のユーザーによって更新されています",
+
 	// ===== レート制限エラー (429) =====
 	RATE_LIMIT_EXCEEDED:
 		"リクエスト数が上限を超えました。しばらくしてから再試行してください",

--- a/apps/server/src/routes/admin/circles/index.ts
+++ b/apps/server/src/routes/admin/circles/index.ts
@@ -20,6 +20,7 @@ import { Hono } from "hono";
 import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
+import { checkOptimisticLockConflict } from "../../../utils/conflict-check";
 import { circleArtistsRouter, getCircleArtists } from "./artists";
 import { circleReleasesRouter, getCircleReleases } from "./releases";
 
@@ -266,8 +267,20 @@ circlesRouter.put("/:id", async (c) => {
 			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
 		}
 
-		// バリデーション
-		const parsed = updateCircleSchema.safeParse(body);
+		const existingCircle = existing[0];
+
+		// 楽観的ロック: updatedAtの競合チェック
+		const conflict = checkOptimisticLockConflict({
+			requestUpdatedAt: body.updatedAt,
+			currentEntity: existingCircle,
+		});
+		if (conflict) {
+			return c.json(conflict, 409);
+		}
+
+		// バリデーション（updatedAtを除外）
+		const { updatedAt: _, ...updateData } = body;
+		const parsed = updateCircleSchema.safeParse(updateData);
 		if (!parsed.success) {
 			return c.json(
 				{
@@ -484,8 +497,18 @@ circlesRouter.put("/:circleId/links/:linkId", async (c) => {
 		// biome-ignore lint/style/noNonNullAssertion: existing.length > 0 is guaranteed by the check above
 		const existingLink = existing[0]!;
 
-		// バリデーション
-		const parsed = updateCircleLinkSchema.safeParse(body);
+		// 楽観的ロック: updatedAtの競合チェック
+		const conflict = checkOptimisticLockConflict({
+			requestUpdatedAt: body.updatedAt,
+			currentEntity: existingLink,
+		});
+		if (conflict) {
+			return c.json(conflict, 409);
+		}
+
+		// バリデーション（updatedAtを除外）
+		const { updatedAt: _, ...updateData } = body;
+		const parsed = updateCircleLinkSchema.safeParse(updateData);
 		if (!parsed.success) {
 			return c.json(
 				{

--- a/apps/server/src/routes/admin/events/event-series.ts
+++ b/apps/server/src/routes/admin/events/event-series.ts
@@ -16,6 +16,7 @@ import { Hono } from "hono";
 import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
+import { checkOptimisticLockConflict } from "../../../utils/conflict-check";
 
 const eventSeriesRouter = new Hono<AdminContext>();
 
@@ -204,8 +205,20 @@ eventSeriesRouter.put("/:id", async (c) => {
 			return c.json({ error: ERROR_MESSAGES.EVENT_SERIES_NOT_FOUND }, 404);
 		}
 
-		// バリデーション
-		const parsed = updateEventSeriesSchema.safeParse(body);
+		const existingSeries = existing[0];
+
+		// 楽観的ロック: updatedAtの競合チェック
+		const conflict = checkOptimisticLockConflict({
+			requestUpdatedAt: body.updatedAt,
+			currentEntity: existingSeries,
+		});
+		if (conflict) {
+			return c.json(conflict, 409);
+		}
+
+		// バリデーション（updatedAtを除外）
+		const { updatedAt: _, ...updateData } = body;
+		const parsed = updateEventSeriesSchema.safeParse(updateData);
 		if (!parsed.success) {
 			return c.json(
 				{

--- a/apps/server/src/routes/admin/official/songs.ts
+++ b/apps/server/src/routes/admin/official/songs.ts
@@ -21,6 +21,7 @@ import { Hono } from "hono";
 import { ERROR_MESSAGES } from "../../../constants/error-messages";
 import type { AdminContext } from "../../../middleware/admin-auth";
 import { handleDbError } from "../../../utils/api-error";
+import { checkOptimisticLockConflict } from "../../../utils/conflict-check";
 import { parseAndValidate } from "../../../utils/import-parser";
 
 const songsRouter = new Hono<AdminContext>();
@@ -224,8 +225,20 @@ songsRouter.put("/:id", async (c) => {
 			return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 		}
 
-		// バリデーション
-		const parsed = updateOfficialSongSchema.safeParse(body);
+		const existingSong = existing[0];
+
+		// 楽観的ロック: updatedAtの競合チェック
+		const conflict = checkOptimisticLockConflict({
+			requestUpdatedAt: body.updatedAt,
+			currentEntity: existingSong,
+		});
+		if (conflict) {
+			return c.json(conflict, 409);
+		}
+
+		// バリデーション（updatedAtを除外）
+		const { updatedAt: _, ...updateData } = body;
+		const parsed = updateOfficialSongSchema.safeParse(updateData);
 		if (!parsed.success) {
 			return c.json(
 				{
@@ -507,8 +520,20 @@ songsRouter.put("/:songId/links/:linkId", async (c) => {
 			return c.json({ error: ERROR_MESSAGES.SONG_NOT_FOUND }, 404);
 		}
 
-		// バリデーション
-		const parsed = updateOfficialSongLinkSchema.safeParse(body);
+		const existingLink = existing[0];
+
+		// 楽観的ロック: updatedAtの競合チェック
+		const conflict = checkOptimisticLockConflict({
+			requestUpdatedAt: body.updatedAt,
+			currentEntity: existingLink,
+		});
+		if (conflict) {
+			return c.json(conflict, 409);
+		}
+
+		// バリデーション（updatedAtを除外）
+		const { updatedAt: _, ...updateData } = body;
+		const parsed = updateOfficialSongLinkSchema.safeParse(updateData);
 		if (!parsed.success) {
 			return c.json(
 				{

--- a/apps/server/src/utils/api-error.ts
+++ b/apps/server/src/utils/api-error.ts
@@ -25,6 +25,8 @@ export const ErrorCodes = {
 	NOT_FOUND: "NOT_FOUND",
 	/** 重複エラー */
 	DUPLICATE: "DUPLICATE",
+	/** データ競合（楽観的ロック） */
+	CONFLICT: "CONFLICT",
 	/** その他のエラー */
 	INTERNAL_ERROR: "INTERNAL_ERROR",
 } as const;

--- a/apps/server/src/utils/conflict-check.ts
+++ b/apps/server/src/utils/conflict-check.ts
@@ -1,0 +1,97 @@
+import { ERROR_MESSAGES } from "../constants/error-messages";
+import { ErrorCodes } from "./api-error";
+
+/**
+ * 競合レスポンス型
+ */
+export interface ConflictResponse<T> {
+	error: string;
+	code: string;
+	current: T;
+}
+
+/**
+ * 楽観的ロックの競合チェックオプション
+ */
+interface ConflictCheckOptions<T> {
+	/** リクエストボディに含まれるupdatedAt */
+	requestUpdatedAt: number | string | Date | null | undefined;
+	/** データベースから取得した現在のエンティティ（undefined許容） */
+	currentEntity: T | undefined;
+}
+
+/**
+ * 楽観的ロックの競合をチェックする
+ *
+ * @param options - チェックオプション
+ * @returns 競合がある場合はConflictResponse、競合がない場合はnull
+ *
+ * @example
+ * ```typescript
+ * const conflict = checkOptimisticLockConflict({
+ *   requestUpdatedAt: body.updatedAt,
+ *   currentEntity: existingArtist,
+ * });
+ *
+ * if (conflict) {
+ *   return c.json(conflict, 409);
+ * }
+ * ```
+ */
+export function checkOptimisticLockConflict<
+	T extends { updatedAt?: Date | null },
+>(options: ConflictCheckOptions<T>): ConflictResponse<T> | null {
+	const { requestUpdatedAt, currentEntity } = options;
+
+	// リクエストにupdatedAtがない場合はスキップ（後方互換性）
+	if (requestUpdatedAt === null || requestUpdatedAt === undefined) {
+		return null;
+	}
+
+	// エンティティが存在しない場合はスキップ
+	if (!currentEntity) {
+		return null;
+	}
+
+	const currentUpdatedAt = currentEntity.updatedAt;
+	if (!currentUpdatedAt) {
+		return null;
+	}
+
+	// ミリ秒単位で比較するために正規化
+	const requestTime = normalizeToMillis(requestUpdatedAt);
+	const currentTime =
+		currentUpdatedAt instanceof Date
+			? currentUpdatedAt.getTime()
+			: normalizeToMillis(currentUpdatedAt);
+
+	// タイムスタンプが一致しない場合は競合
+	if (requestTime !== currentTime) {
+		return {
+			error: ERROR_MESSAGES.DATA_CHANGED_BY_ANOTHER_USER,
+			code: ErrorCodes.CONFLICT,
+			current: currentEntity,
+		};
+	}
+
+	return null;
+}
+
+/**
+ * 様々な形式のタイムスタンプをミリ秒に正規化
+ */
+function normalizeToMillis(
+	value: number | string | Date | null | undefined,
+): number {
+	if (value === null || value === undefined) {
+		return 0;
+	}
+	if (typeof value === "number") {
+		return value;
+	}
+	if (value instanceof Date) {
+		return value.getTime();
+	}
+	// ISO文字列の場合
+	return new Date(value).getTime();
+}

--- a/apps/web/src/components/admin/artist-edit-dialog.tsx
+++ b/apps/web/src/components/admin/artist-edit-dialog.tsx
@@ -1,7 +1,13 @@
 import { createId } from "@thac/db";
 import { detectInitial } from "@thac/utils";
 import { useEffect, useState } from "react";
-import { type Artist, artistsApi, type InitialScript } from "@/lib/api-client";
+import { useConflictHandler } from "@/hooks/use-conflict-handler";
+import {
+	type Artist,
+	artistsApi,
+	type InitialScript,
+	isConflictError,
+} from "@/lib/api-client";
 import { Button } from "../ui/button";
 import {
 	Dialog,
@@ -13,6 +19,7 @@ import {
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Textarea } from "../ui/textarea";
+import { ConflictDialog } from "./conflict-dialog";
 
 export interface ArtistFormData {
 	name: string;
@@ -50,6 +57,12 @@ export function ArtistEditDialog({
 	});
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	// 楽観的ロック用: 編集開始時のupdatedAtを記録
+	const [originalUpdatedAt, setOriginalUpdatedAt] = useState<string | null>(
+		null,
+	);
+	const { conflictState, setConflict, clearConflict } =
+		useConflictHandler<Artist>();
 
 	// ダイアログが開いた時にフォームを初期化
 	useEffect(() => {
@@ -64,6 +77,7 @@ export function ArtistEditDialog({
 					initialScript: artist.initialScript,
 					nameInitial: artist.nameInitial,
 				});
+				setOriginalUpdatedAt(artist.updatedAt);
 			} else {
 				setForm({
 					name: "",
@@ -74,10 +88,12 @@ export function ArtistEditDialog({
 					initialScript: "latin",
 					nameInitial: null,
 				});
+				setOriginalUpdatedAt(null);
 			}
 			setError(null);
+			clearConflict();
 		}
-	}, [open, mode, artist]);
+	}, [open, mode, artist, clearConflict]);
 
 	const handleNameChange = (name: string) => {
 		const initial = detectInitial(name);
@@ -100,7 +116,7 @@ export function ArtistEditDialog({
 		}
 	};
 
-	const handleSubmit = async () => {
+	const handleSubmit = async (overrideUpdatedAt?: string) => {
 		if (!form.name.trim()) {
 			setError("名前を入力してください");
 			return;
@@ -131,11 +147,18 @@ export function ArtistEditDialog({
 					initialScript: form.initialScript,
 					nameInitial: form.nameInitial,
 					notes: form.notes,
+					// 楽観的ロック: updatedAtを送信
+					updatedAt: overrideUpdatedAt || originalUpdatedAt || undefined,
 				});
 			}
 			onOpenChange(false);
 			onSuccess?.();
 		} catch (e) {
+			// 楽観的ロック競合エラーの場合
+			if (isConflictError<Artist>(e)) {
+				setConflict(e.current);
+				return;
+			}
 			setError(
 				e instanceof Error
 					? e.message
@@ -148,107 +171,144 @@ export function ArtistEditDialog({
 		}
 	};
 
+	// 競合ダイアログで「編集を続ける」を選択した場合
+	const handleContinueEditing = (data: Artist) => {
+		setForm({
+			name: data.name,
+			nameJa: data.nameJa,
+			nameEn: data.nameEn,
+			sortName: data.sortName,
+			notes: data.notes,
+			initialScript: data.initialScript,
+			nameInitial: data.nameInitial,
+		});
+		setOriginalUpdatedAt(data.updatedAt);
+		clearConflict();
+	};
+
+	// 競合ダイアログで「上書き」を選択した場合
+	const handleOverwrite = () => {
+		if (conflictState.conflictData) {
+			// 最新のupdatedAtで再送信
+			handleSubmit(conflictState.conflictData.updatedAt);
+			clearConflict();
+		}
+	};
+
 	const title = mode === "create" ? "新規アーティスト" : "アーティストの編集";
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="sm:max-w-[500px]">
-				<DialogHeader>
-					<DialogTitle>{title}</DialogTitle>
-				</DialogHeader>
-				<div className="grid gap-4 py-4">
-					{error && (
-						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-							{error}
-						</div>
-					)}
-					<div className="grid gap-2">
-						<Label htmlFor="artist-name">
-							名前 <span className="text-error">*</span>
-						</Label>
-						<Input
-							id="artist-name"
-							value={form.name}
-							onChange={(e) => handleNameChange(e.target.value)}
-							placeholder="例: ZUN"
-							disabled={isSubmitting}
-						/>
-					</div>
-					<div className="grid gap-4">
+		<>
+			<Dialog open={open} onOpenChange={onOpenChange}>
+				<DialogContent className="sm:max-w-[500px]">
+					<DialogHeader>
+						<DialogTitle>{title}</DialogTitle>
+					</DialogHeader>
+					<div className="grid gap-4 py-4">
+						{error && (
+							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
+								{error}
+							</div>
+						)}
 						<div className="grid gap-2">
-							<Label htmlFor="artist-nameJa">日本語名</Label>
+							<Label htmlFor="artist-name">
+								名前 <span className="text-error">*</span>
+							</Label>
 							<Input
-								id="artist-nameJa"
-								value={form.nameJa || ""}
+								id="artist-name"
+								value={form.name}
+								onChange={(e) => handleNameChange(e.target.value)}
+								placeholder="例: ZUN"
+								disabled={isSubmitting}
+							/>
+						</div>
+						<div className="grid gap-4">
+							<div className="grid gap-2">
+								<Label htmlFor="artist-nameJa">日本語名</Label>
+								<Input
+									id="artist-nameJa"
+									value={form.nameJa || ""}
+									onChange={(e) =>
+										setForm({ ...form, nameJa: e.target.value || null })
+									}
+									placeholder="例: ZUN"
+									disabled={isSubmitting}
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label htmlFor="artist-nameEn">英語名</Label>
+								<Input
+									id="artist-nameEn"
+									value={form.nameEn || ""}
+									onChange={(e) =>
+										setForm({ ...form, nameEn: e.target.value || null })
+									}
+									placeholder="例: ZUN"
+									disabled={isSubmitting}
+								/>
+							</div>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="artist-sortName">ソート用名</Label>
+							<Input
+								id="artist-sortName"
+								value={form.sortName || ""}
 								onChange={(e) =>
-									setForm({ ...form, nameJa: e.target.value || null })
+									setForm({ ...form, sortName: e.target.value || null })
 								}
 								placeholder="例: ZUN"
 								disabled={isSubmitting}
 							/>
 						</div>
 						<div className="grid gap-2">
-							<Label htmlFor="artist-nameEn">英語名</Label>
-							<Input
-								id="artist-nameEn"
-								value={form.nameEn || ""}
+							<Label htmlFor="artist-notes">備考</Label>
+							<Textarea
+								id="artist-notes"
+								value={form.notes || ""}
 								onChange={(e) =>
-									setForm({ ...form, nameEn: e.target.value || null })
+									setForm({ ...form, notes: e.target.value || null })
 								}
-								placeholder="例: ZUN"
+								placeholder="例: 来歴、特記事項など"
+								rows={3}
 								disabled={isSubmitting}
 							/>
 						</div>
 					</div>
-					<div className="grid gap-2">
-						<Label htmlFor="artist-sortName">ソート用名</Label>
-						<Input
-							id="artist-sortName"
-							value={form.sortName || ""}
-							onChange={(e) =>
-								setForm({ ...form, sortName: e.target.value || null })
-							}
-							placeholder="例: ZUN"
+					<DialogFooter>
+						<Button
+							variant="ghost"
+							onClick={() => onOpenChange(false)}
 							disabled={isSubmitting}
-						/>
-					</div>
-					<div className="grid gap-2">
-						<Label htmlFor="artist-notes">備考</Label>
-						<Textarea
-							id="artist-notes"
-							value={form.notes || ""}
-							onChange={(e) =>
-								setForm({ ...form, notes: e.target.value || null })
-							}
-							placeholder="例: 来歴、特記事項など"
-							rows={3}
-							disabled={isSubmitting}
-						/>
-					</div>
-				</div>
-				<DialogFooter>
-					<Button
-						variant="ghost"
-						onClick={() => onOpenChange(false)}
-						disabled={isSubmitting}
-					>
-						キャンセル
-					</Button>
-					<Button
-						variant="primary"
-						onClick={handleSubmit}
-						disabled={isSubmitting || !form.name.trim()}
-					>
-						{isSubmitting
-							? mode === "create"
-								? "作成中..."
-								: "保存中..."
-							: mode === "create"
-								? "作成"
-								: "保存"}
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+						>
+							キャンセル
+						</Button>
+						<Button
+							variant="primary"
+							onClick={() => handleSubmit()}
+							disabled={isSubmitting || !form.name.trim()}
+						>
+							{isSubmitting
+								? mode === "create"
+									? "作成中..."
+									: "保存中..."
+								: mode === "create"
+									? "作成"
+									: "保存"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* 楽観的ロック競合ダイアログ */}
+			<ConflictDialog
+				open={conflictState.isConflict}
+				onOpenChange={(open) => !open && clearConflict()}
+				currentData={conflictState.conflictData}
+				getDisplayName={(data) => data.name}
+				onOverwrite={handleOverwrite}
+				onContinueEditing={handleContinueEditing}
+				isLoading={isSubmitting}
+			/>
+		</>
 	);
 }

--- a/apps/web/src/components/admin/circle-edit-dialog.tsx
+++ b/apps/web/src/components/admin/circle-edit-dialog.tsx
@@ -1,7 +1,13 @@
 import { createId } from "@thac/db";
 import { detectInitial } from "@thac/utils";
 import { useEffect, useState } from "react";
-import { type Circle, circlesApi, type InitialScript } from "@/lib/api-client";
+import { useConflictHandler } from "@/hooks/use-conflict-handler";
+import {
+	type Circle,
+	circlesApi,
+	type InitialScript,
+	isConflictError,
+} from "@/lib/api-client";
 import { Button } from "../ui/button";
 import {
 	Dialog,
@@ -13,6 +19,7 @@ import {
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Textarea } from "../ui/textarea";
+import { ConflictDialog } from "./conflict-dialog";
 
 export interface CircleFormData {
 	name: string;
@@ -50,6 +57,12 @@ export function CircleEditDialog({
 	});
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	// 楽観的ロック用: 編集開始時のupdatedAtを記録
+	const [originalUpdatedAt, setOriginalUpdatedAt] = useState<string | null>(
+		null,
+	);
+	const { conflictState, setConflict, clearConflict } =
+		useConflictHandler<Circle>();
 
 	// ダイアログが開いた時にフォームを初期化
 	useEffect(() => {
@@ -64,6 +77,7 @@ export function CircleEditDialog({
 					initialScript: circle.initialScript,
 					nameInitial: circle.nameInitial,
 				});
+				setOriginalUpdatedAt(circle.updatedAt);
 			} else {
 				setForm({
 					name: "",
@@ -74,10 +88,12 @@ export function CircleEditDialog({
 					initialScript: "latin",
 					nameInitial: null,
 				});
+				setOriginalUpdatedAt(null);
 			}
 			setError(null);
+			clearConflict();
 		}
-	}, [open, mode, circle]);
+	}, [open, mode, circle, clearConflict]);
 
 	const handleNameChange = (name: string) => {
 		const initial = detectInitial(name);
@@ -100,7 +116,7 @@ export function CircleEditDialog({
 		}
 	};
 
-	const handleSubmit = async () => {
+	const handleSubmit = async (overrideUpdatedAt?: string) => {
 		if (!form.name.trim()) {
 			setError("名前を入力してください");
 			return;
@@ -131,11 +147,18 @@ export function CircleEditDialog({
 					initialScript: form.initialScript,
 					nameInitial: form.nameInitial,
 					notes: form.notes,
+					// 楽観的ロック: updatedAtを送信
+					updatedAt: overrideUpdatedAt || originalUpdatedAt || undefined,
 				});
 			}
 			onOpenChange(false);
 			onSuccess?.();
 		} catch (e) {
+			// 楽観的ロック競合エラーの場合
+			if (isConflictError<Circle>(e)) {
+				setConflict(e.current);
+				return;
+			}
 			setError(
 				e instanceof Error
 					? e.message
@@ -148,107 +171,144 @@ export function CircleEditDialog({
 		}
 	};
 
+	// 競合ダイアログで「編集を続ける」を選択した場合
+	const handleContinueEditing = (data: Circle) => {
+		setForm({
+			name: data.name,
+			nameJa: data.nameJa,
+			nameEn: data.nameEn,
+			sortName: data.sortName,
+			notes: data.notes,
+			initialScript: data.initialScript,
+			nameInitial: data.nameInitial,
+		});
+		setOriginalUpdatedAt(data.updatedAt);
+		clearConflict();
+	};
+
+	// 競合ダイアログで「上書き」を選択した場合
+	const handleOverwrite = () => {
+		if (conflictState.conflictData) {
+			// 最新のupdatedAtで再送信
+			handleSubmit(conflictState.conflictData.updatedAt);
+			clearConflict();
+		}
+	};
+
 	const title = mode === "create" ? "新規サークル" : "サークルの編集";
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="sm:max-w-[500px]">
-				<DialogHeader>
-					<DialogTitle>{title}</DialogTitle>
-				</DialogHeader>
-				<div className="grid gap-4 py-4">
-					{error && (
-						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-							{error}
-						</div>
-					)}
-					<div className="grid gap-2">
-						<Label htmlFor="circle-name">
-							名前 <span className="text-error">*</span>
-						</Label>
-						<Input
-							id="circle-name"
-							value={form.name}
-							onChange={(e) => handleNameChange(e.target.value)}
-							placeholder="例: 上海アリス幻樂団"
-							disabled={isSubmitting}
-						/>
-					</div>
-					<div className="grid gap-4">
+		<>
+			<Dialog open={open} onOpenChange={onOpenChange}>
+				<DialogContent className="sm:max-w-[500px]">
+					<DialogHeader>
+						<DialogTitle>{title}</DialogTitle>
+					</DialogHeader>
+					<div className="grid gap-4 py-4">
+						{error && (
+							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
+								{error}
+							</div>
+						)}
 						<div className="grid gap-2">
-							<Label htmlFor="circle-nameJa">日本語名</Label>
+							<Label htmlFor="circle-name">
+								名前 <span className="text-error">*</span>
+							</Label>
 							<Input
-								id="circle-nameJa"
-								value={form.nameJa || ""}
+								id="circle-name"
+								value={form.name}
+								onChange={(e) => handleNameChange(e.target.value)}
+								placeholder="例: 上海アリス幻樂団"
+								disabled={isSubmitting}
+							/>
+						</div>
+						<div className="grid gap-4">
+							<div className="grid gap-2">
+								<Label htmlFor="circle-nameJa">日本語名</Label>
+								<Input
+									id="circle-nameJa"
+									value={form.nameJa || ""}
+									onChange={(e) =>
+										setForm({ ...form, nameJa: e.target.value || null })
+									}
+									placeholder="例: 上海アリス幻樂団"
+									disabled={isSubmitting}
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label htmlFor="circle-nameEn">英語名</Label>
+								<Input
+									id="circle-nameEn"
+									value={form.nameEn || ""}
+									onChange={(e) =>
+										setForm({ ...form, nameEn: e.target.value || null })
+									}
+									placeholder="例: Team Shanghai Alice"
+									disabled={isSubmitting}
+								/>
+							</div>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="circle-sortName">ソート用名</Label>
+							<Input
+								id="circle-sortName"
+								value={form.sortName || ""}
 								onChange={(e) =>
-									setForm({ ...form, nameJa: e.target.value || null })
+									setForm({ ...form, sortName: e.target.value || null })
 								}
 								placeholder="例: 上海アリス幻樂団"
 								disabled={isSubmitting}
 							/>
 						</div>
 						<div className="grid gap-2">
-							<Label htmlFor="circle-nameEn">英語名</Label>
-							<Input
-								id="circle-nameEn"
-								value={form.nameEn || ""}
+							<Label htmlFor="circle-notes">備考</Label>
+							<Textarea
+								id="circle-notes"
+								value={form.notes || ""}
 								onChange={(e) =>
-									setForm({ ...form, nameEn: e.target.value || null })
+									setForm({ ...form, notes: e.target.value || null })
 								}
-								placeholder="例: Team Shanghai Alice"
+								placeholder="例: 来歴、特記事項など"
+								rows={3}
 								disabled={isSubmitting}
 							/>
 						</div>
 					</div>
-					<div className="grid gap-2">
-						<Label htmlFor="circle-sortName">ソート用名</Label>
-						<Input
-							id="circle-sortName"
-							value={form.sortName || ""}
-							onChange={(e) =>
-								setForm({ ...form, sortName: e.target.value || null })
-							}
-							placeholder="例: 上海アリス幻樂団"
+					<DialogFooter>
+						<Button
+							variant="ghost"
+							onClick={() => onOpenChange(false)}
 							disabled={isSubmitting}
-						/>
-					</div>
-					<div className="grid gap-2">
-						<Label htmlFor="circle-notes">備考</Label>
-						<Textarea
-							id="circle-notes"
-							value={form.notes || ""}
-							onChange={(e) =>
-								setForm({ ...form, notes: e.target.value || null })
-							}
-							placeholder="例: 来歴、特記事項など"
-							rows={3}
-							disabled={isSubmitting}
-						/>
-					</div>
-				</div>
-				<DialogFooter>
-					<Button
-						variant="ghost"
-						onClick={() => onOpenChange(false)}
-						disabled={isSubmitting}
-					>
-						キャンセル
-					</Button>
-					<Button
-						variant="primary"
-						onClick={handleSubmit}
-						disabled={isSubmitting || !form.name.trim()}
-					>
-						{isSubmitting
-							? mode === "create"
-								? "作成中..."
-								: "保存中..."
-							: mode === "create"
-								? "作成"
-								: "保存"}
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+						>
+							キャンセル
+						</Button>
+						<Button
+							variant="primary"
+							onClick={() => handleSubmit()}
+							disabled={isSubmitting || !form.name.trim()}
+						>
+							{isSubmitting
+								? mode === "create"
+									? "作成中..."
+									: "保存中..."
+								: mode === "create"
+									? "作成"
+									: "保存"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* 楽観的ロック競合ダイアログ */}
+			<ConflictDialog
+				open={conflictState.isConflict}
+				onOpenChange={(open) => !open && clearConflict()}
+				currentData={conflictState.conflictData}
+				getDisplayName={(data) => data.name}
+				onOverwrite={handleOverwrite}
+				onContinueEditing={handleContinueEditing}
+				isLoading={isSubmitting}
+			/>
+		</>
 	);
 }

--- a/apps/web/src/components/admin/conflict-dialog.tsx
+++ b/apps/web/src/components/admin/conflict-dialog.tsx
@@ -1,0 +1,108 @@
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ConflictDialogProps<T> {
+	/** ダイアログの開閉状態 */
+	open: boolean;
+	/** ダイアログの開閉状態を変更するコールバック */
+	onOpenChange: (open: boolean) => void;
+	/** 競合したサーバー側の最新データ */
+	currentData: T | null;
+	/** エンティティの表示名を取得する関数 */
+	getDisplayName?: (data: T) => string;
+	/** 「現在のデータで上書き」を選択した場合のコールバック */
+	onOverwrite: () => void;
+	/** 「編集を続ける」を選択した場合のコールバック（最新データをフォームに反映） */
+	onContinueEditing: (data: T) => void;
+	/** ローディング状態 */
+	isLoading?: boolean;
+}
+
+/**
+ * 楽観的ロック競合時に表示するダイアログコンポーネント
+ *
+ * ユーザーに以下の選択肢を提供:
+ * 1. キャンセル - ダイアログを閉じ、変更を破棄
+ * 2. 編集を続ける - 最新データをフォームに反映して編集を続行
+ * 3. 上書き - 現在の編集内容でサーバーデータを上書き
+ */
+function ConflictDialog<T>({
+	open,
+	onOpenChange,
+	currentData,
+	getDisplayName,
+	onOverwrite,
+	onContinueEditing,
+	isLoading = false,
+}: ConflictDialogProps<T>) {
+	const handleCancel = () => {
+		onOpenChange(false);
+	};
+
+	const handleContinueEditing = () => {
+		if (currentData) {
+			onContinueEditing(currentData);
+		}
+		onOpenChange(false);
+	};
+
+	const handleOverwrite = () => {
+		onOverwrite();
+	};
+
+	const displayName =
+		currentData && getDisplayName ? getDisplayName(currentData) : "このデータ";
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-[500px]" showCloseButton={false}>
+				<DialogHeader>
+					<div className="flex items-center gap-3">
+						<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-warning/10">
+							<AlertTriangle className="h-5 w-5 text-warning" />
+						</div>
+						<DialogTitle>編集の競合が発生しました</DialogTitle>
+					</div>
+				</DialogHeader>
+				<DialogDescription className="space-y-2 py-2">
+					<p>
+						<strong>{displayName}</strong>{" "}
+						は、あなたが編集を開始した後に他のユーザーによって更新されています。
+					</p>
+					<p>どのように対応しますか？</p>
+				</DialogDescription>
+				<DialogFooter className="flex-col gap-2 sm:flex-row">
+					<Button variant="ghost" onClick={handleCancel} disabled={isLoading}>
+						キャンセル
+					</Button>
+					<Button
+						variant="outline"
+						onClick={handleContinueEditing}
+						disabled={isLoading || !currentData}
+					>
+						最新データで編集を続ける
+					</Button>
+					<Button
+						variant="warning"
+						onClick={handleOverwrite}
+						disabled={isLoading}
+					>
+						{isLoading ? "処理中..." : "現在の内容で上書き"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+export { ConflictDialog };
+export type { ConflictDialogProps };

--- a/apps/web/src/components/admin/release-edit-dialog.tsx
+++ b/apps/web/src/components/admin/release-edit-dialog.tsx
@@ -13,14 +13,17 @@ import { Label } from "@/components/ui/label";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { useConflictHandler } from "@/hooks/use-conflict-handler";
 import {
 	eventDaysApi,
 	eventsApi,
+	isConflictError,
 	RELEASE_TYPE_LABELS,
 	type Release,
 	type ReleaseType,
 	releasesApi,
 } from "@/lib/api-client";
+import { ConflictDialog } from "./conflict-dialog";
 
 // 作品タイプのオプション
 const RELEASE_TYPE_OPTIONS = Object.entries(RELEASE_TYPE_LABELS).map(
@@ -44,6 +47,12 @@ export function ReleaseEditDialog({
 	const [mutationError, setMutationError] = useState<string | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+	// 楽観的ロック用: 編集開始時のupdatedAtを記録
+	const [originalUpdatedAt, setOriginalUpdatedAt] = useState<string | null>(
+		null,
+	);
+	const { conflictState, setConflict, clearConflict } =
+		useConflictHandler<Release>();
 
 	// ダイアログが開いたらフォームを初期化
 	useEffect(() => {
@@ -59,9 +68,11 @@ export function ReleaseEditDialog({
 				notes: release.notes,
 			});
 			setSelectedEventId(release.eventId);
+			setOriginalUpdatedAt(release.updatedAt);
 			setMutationError(null);
+			clearConflict();
 		}
-	}, [open, release]);
+	}, [open, release, clearConflict]);
 
 	// イベント一覧取得
 	const { data: eventsData } = useQuery({
@@ -124,7 +135,7 @@ export function ReleaseEditDialog({
 	}, [eventDaysData]);
 
 	// 保存
-	const handleSave = async () => {
+	const handleSave = async (overrideUpdatedAt?: string) => {
 		setIsSubmitting(true);
 		setMutationError(null);
 		try {
@@ -137,10 +148,17 @@ export function ReleaseEditDialog({
 				eventId: editForm.eventId || null,
 				eventDayId: editForm.eventDayId || null,
 				notes: editForm.notes || null,
+				// 楽観的ロック: updatedAtを送信
+				updatedAt: overrideUpdatedAt || originalUpdatedAt || undefined,
 			});
 			onSuccess?.();
 			onOpenChange(false);
 		} catch (err) {
+			// 楽観的ロック競合エラーの場合
+			if (isConflictError<Release>(err)) {
+				setConflict(err.current);
+				return;
+			}
 			setMutationError(
 				err instanceof Error ? err.message : "保存に失敗しました",
 			);
@@ -149,155 +167,196 @@ export function ReleaseEditDialog({
 		}
 	};
 
+	// 競合ダイアログで「編集を続ける」を選択した場合
+	const handleContinueEditing = (data: Release) => {
+		setEditForm({
+			name: data.name,
+			nameJa: data.nameJa,
+			nameEn: data.nameEn,
+			releaseDate: data.releaseDate,
+			releaseType: data.releaseType,
+			eventId: data.eventId,
+			eventDayId: data.eventDayId,
+			notes: data.notes,
+		});
+		setSelectedEventId(data.eventId);
+		setOriginalUpdatedAt(data.updatedAt);
+		clearConflict();
+	};
+
+	// 競合ダイアログで「上書き」を選択した場合
+	const handleOverwrite = () => {
+		if (conflictState.conflictData) {
+			// 最新のupdatedAtで再送信
+			handleSave(conflictState.conflictData.updatedAt);
+			clearConflict();
+		}
+	};
+
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="sm:max-w-[600px]">
-				<DialogHeader>
-					<DialogTitle>リリースの編集</DialogTitle>
-				</DialogHeader>
-				<div className="grid gap-4 py-4">
-					{mutationError && (
-						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-							{mutationError}
-						</div>
-					)}
-					<div className="grid gap-4">
-						<div className="grid gap-2">
-							<Label>
-								作品名 <span className="text-error">*</span>
-							</Label>
-							<Input
-								value={editForm.name || ""}
-								onChange={(e) =>
-									setEditForm({ ...editForm, name: e.target.value })
-								}
-								placeholder="例: 東方紅魔郷オリジナルサウンドトラック"
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label>日本語名</Label>
-							<Input
-								value={editForm.nameJa || ""}
-								onChange={(e) =>
-									setEditForm({ ...editForm, nameJa: e.target.value })
-								}
-								placeholder="例: 東方紅魔郷"
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label>英語名</Label>
-							<Input
-								value={editForm.nameEn || ""}
-								onChange={(e) =>
-									setEditForm({ ...editForm, nameEn: e.target.value })
-								}
-								placeholder="例: Touhou Koumakyou"
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label>タイプ</Label>
-							<Select
-								value={editForm.releaseType || ""}
-								onChange={(e) =>
-									setEditForm({
-										...editForm,
-										releaseType: e.target.value as ReleaseType,
-									})
-								}
-							>
-								<option value="">選択してください</option>
-								{RELEASE_TYPE_OPTIONS.map((option) => (
-									<option key={option.value} value={option.value}>
-										{option.label}
-									</option>
-								))}
-							</Select>
-						</div>
-						<div className="grid gap-2">
-							<Label>イベント</Label>
-							<SearchableSelect
-								value={editForm.eventId || ""}
-								onChange={(value) => {
-									setEditForm({
-										...editForm,
-										eventId: value || null,
-										eventDayId: null,
-									});
-									setSelectedEventId(value || null);
-								}}
-								options={eventOptions}
-								placeholder="イベントを選択"
-								searchPlaceholder="イベントを検索..."
-								emptyMessage="イベントが見つかりません"
-								clearable
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label>イベント日</Label>
-							<SearchableSelect
-								value={editForm.eventDayId || ""}
-								onChange={(value) => {
-									const selectedDay = eventDaysData?.find(
-										(d) => d.id === value,
-									);
-									setEditForm({
-										...editForm,
-										eventDayId: value || null,
-										releaseDate: selectedDay?.date || editForm.releaseDate,
-									});
-								}}
-								options={eventDayOptions}
-								placeholder="イベント日を選択"
-								searchPlaceholder="イベント日を検索..."
-								emptyMessage={
-									selectedEventId
-										? "イベント日が見つかりません"
-										: "先にイベントを選択してください"
-								}
-								disabled={!selectedEventId || (eventDaysData?.length ?? 0) <= 1}
-								clearable
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label>発売日</Label>
-							<Input
-								type="date"
-								value={editForm.releaseDate || ""}
-								onChange={(e) =>
-									setEditForm({ ...editForm, releaseDate: e.target.value })
-								}
-								disabled={!!editForm.eventDayId}
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Label>メモ</Label>
-							<Textarea
-								value={editForm.notes || ""}
-								onChange={(e) =>
-									setEditForm({ ...editForm, notes: e.target.value })
-								}
-								placeholder="例: 来歴、特記事項など"
-							/>
+		<>
+			<Dialog open={open} onOpenChange={onOpenChange}>
+				<DialogContent className="sm:max-w-[600px]">
+					<DialogHeader>
+						<DialogTitle>リリースの編集</DialogTitle>
+					</DialogHeader>
+					<div className="grid gap-4 py-4">
+						{mutationError && (
+							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
+								{mutationError}
+							</div>
+						)}
+						<div className="grid gap-4">
+							<div className="grid gap-2">
+								<Label>
+									作品名 <span className="text-error">*</span>
+								</Label>
+								<Input
+									value={editForm.name || ""}
+									onChange={(e) =>
+										setEditForm({ ...editForm, name: e.target.value })
+									}
+									placeholder="例: 東方紅魔郷オリジナルサウンドトラック"
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label>日本語名</Label>
+								<Input
+									value={editForm.nameJa || ""}
+									onChange={(e) =>
+										setEditForm({ ...editForm, nameJa: e.target.value })
+									}
+									placeholder="例: 東方紅魔郷"
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label>英語名</Label>
+								<Input
+									value={editForm.nameEn || ""}
+									onChange={(e) =>
+										setEditForm({ ...editForm, nameEn: e.target.value })
+									}
+									placeholder="例: Touhou Koumakyou"
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label>タイプ</Label>
+								<Select
+									value={editForm.releaseType || ""}
+									onChange={(e) =>
+										setEditForm({
+											...editForm,
+											releaseType: e.target.value as ReleaseType,
+										})
+									}
+								>
+									<option value="">選択してください</option>
+									{RELEASE_TYPE_OPTIONS.map((option) => (
+										<option key={option.value} value={option.value}>
+											{option.label}
+										</option>
+									))}
+								</Select>
+							</div>
+							<div className="grid gap-2">
+								<Label>イベント</Label>
+								<SearchableSelect
+									value={editForm.eventId || ""}
+									onChange={(value) => {
+										setEditForm({
+											...editForm,
+											eventId: value || null,
+											eventDayId: null,
+										});
+										setSelectedEventId(value || null);
+									}}
+									options={eventOptions}
+									placeholder="イベントを選択"
+									searchPlaceholder="イベントを検索..."
+									emptyMessage="イベントが見つかりません"
+									clearable
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label>イベント日</Label>
+								<SearchableSelect
+									value={editForm.eventDayId || ""}
+									onChange={(value) => {
+										const selectedDay = eventDaysData?.find(
+											(d) => d.id === value,
+										);
+										setEditForm({
+											...editForm,
+											eventDayId: value || null,
+											releaseDate: selectedDay?.date || editForm.releaseDate,
+										});
+									}}
+									options={eventDayOptions}
+									placeholder="イベント日を選択"
+									searchPlaceholder="イベント日を検索..."
+									emptyMessage={
+										selectedEventId
+											? "イベント日が見つかりません"
+											: "先にイベントを選択してください"
+									}
+									disabled={
+										!selectedEventId || (eventDaysData?.length ?? 0) <= 1
+									}
+									clearable
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label>発売日</Label>
+								<Input
+									type="date"
+									value={editForm.releaseDate || ""}
+									onChange={(e) =>
+										setEditForm({ ...editForm, releaseDate: e.target.value })
+									}
+									disabled={!!editForm.eventDayId}
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label>メモ</Label>
+								<Textarea
+									value={editForm.notes || ""}
+									onChange={(e) =>
+										setEditForm({ ...editForm, notes: e.target.value })
+									}
+									placeholder="例: 来歴、特記事項など"
+								/>
+							</div>
 						</div>
 					</div>
-				</div>
-				<DialogFooter>
-					<Button
-						variant="ghost"
-						onClick={() => onOpenChange(false)}
-						disabled={isSubmitting}
-					>
-						キャンセル
-					</Button>
-					<Button
-						variant="primary"
-						onClick={handleSave}
-						disabled={isSubmitting || !editForm.name}
-					>
-						{isSubmitting ? "保存中..." : "保存"}
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+					<DialogFooter>
+						<Button
+							variant="ghost"
+							onClick={() => onOpenChange(false)}
+							disabled={isSubmitting}
+						>
+							キャンセル
+						</Button>
+						<Button
+							variant="primary"
+							onClick={() => handleSave()}
+							disabled={isSubmitting || !editForm.name}
+						>
+							{isSubmitting ? "保存中..." : "保存"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* 楽観的ロック競合ダイアログ */}
+			<ConflictDialog
+				open={conflictState.isConflict}
+				onOpenChange={(open) => !open && clearConflict()}
+				currentData={conflictState.conflictData}
+				getDisplayName={(data) => data.name}
+				onOverwrite={handleOverwrite}
+				onContinueEditing={handleContinueEditing}
+				isLoading={isSubmitting}
+			/>
+		</>
 	);
 }

--- a/apps/web/src/components/admin/track-edit-dialog.tsx
+++ b/apps/web/src/components/admin/track-edit-dialog.tsx
@@ -11,14 +11,17 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SearchableSelect } from "@/components/ui/searchable-select";
+import { useConflictHandler } from "@/hooks/use-conflict-handler";
 import {
 	discsApi,
 	eventDaysApi,
 	eventsApi,
+	isConflictError,
 	releasesApi,
 	type Track,
 	tracksApi,
 } from "@/lib/api-client";
+import { ConflictDialog } from "./conflict-dialog";
 
 interface TrackEditDialogProps {
 	open: boolean;
@@ -40,6 +43,12 @@ export function TrackEditDialog({
 		null,
 	);
 	const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+	// 楽観的ロック用: 編集開始時のupdatedAtを記録
+	const [originalUpdatedAt, setOriginalUpdatedAt] = useState<string | null>(
+		null,
+	);
+	const { conflictState, setConflict, clearConflict } =
+		useConflictHandler<Track>();
 
 	// ダイアログが開いたらフォームを初期化
 	useEffect(() => {
@@ -57,9 +66,11 @@ export function TrackEditDialog({
 			});
 			setSelectedReleaseId(track.releaseId);
 			setSelectedEventId(track.eventId);
+			setOriginalUpdatedAt(track.updatedAt);
 			setMutationError(null);
+			clearConflict();
 		}
-	}, [open, track]);
+	}, [open, track, clearConflict]);
 
 	// 作品一覧取得
 	const { data: releasesData } = useQuery({
@@ -160,7 +171,7 @@ export function TrackEditDialog({
 	}, [eventDaysData]);
 
 	// 保存
-	const handleSave = async () => {
+	const handleSave = async (overrideUpdatedAt?: string) => {
 		if (!track.releaseId) {
 			setMutationError("作品IDが不正です");
 			return;
@@ -178,10 +189,17 @@ export function TrackEditDialog({
 				releaseDate: editForm.releaseDate || null,
 				eventId: editForm.eventId || null,
 				eventDayId: editForm.eventDayId || null,
+				// 楽観的ロック: updatedAtを送信
+				updatedAt: overrideUpdatedAt || originalUpdatedAt || undefined,
 			});
 			onSuccess?.();
 			onOpenChange(false);
 		} catch (err) {
+			// 楽観的ロック競合エラーの場合
+			if (isConflictError<Track>(err)) {
+				setConflict(err.current);
+				return;
+			}
 			setMutationError(
 				err instanceof Error ? err.message : "保存に失敗しました",
 			);
@@ -190,228 +208,272 @@ export function TrackEditDialog({
 		}
 	};
 
+	// 競合ダイアログで「編集を続ける」を選択した場合
+	const handleContinueEditing = (data: Track) => {
+		setEditForm({
+			name: data.name,
+			nameJa: data.nameJa,
+			nameEn: data.nameEn,
+			trackNumber: data.trackNumber,
+			releaseId: data.releaseId,
+			discId: data.discId,
+			releaseDate: data.releaseDate,
+			eventId: data.eventId,
+			eventDayId: data.eventDayId,
+		});
+		setSelectedReleaseId(data.releaseId);
+		setSelectedEventId(data.eventId);
+		setOriginalUpdatedAt(data.updatedAt);
+		clearConflict();
+	};
+
+	// 競合ダイアログで「上書き」を選択した場合
+	const handleOverwrite = () => {
+		if (conflictState.conflictData) {
+			// 最新のupdatedAtで再送信
+			handleSave(conflictState.conflictData.updatedAt);
+			clearConflict();
+		}
+	};
+
 	const isReleaseDateEditable = !selectedReleaseId || !editForm.eventDayId;
 	const isDiscFieldVisible = !!selectedReleaseId;
 	const isDiscSelectDisabled = !discsData || discsData.length <= 1;
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="sm:max-w-[600px]">
-				<DialogHeader>
-					<DialogTitle>トラックの編集</DialogTitle>
-				</DialogHeader>
-				<div className="grid gap-4 py-4">
-					{mutationError && (
-						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-							{mutationError}
-						</div>
-					)}
+		<>
+			<Dialog open={open} onOpenChange={onOpenChange}>
+				<DialogContent className="sm:max-w-[600px]">
+					<DialogHeader>
+						<DialogTitle>トラックの編集</DialogTitle>
+					</DialogHeader>
+					<div className="grid gap-4 py-4">
+						{mutationError && (
+							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
+								{mutationError}
+							</div>
+						)}
 
-					{/* 作品（読み取り専用） */}
-					<div className="grid gap-2">
-						<Label>作品</Label>
-						<p className="text-base-content/70">
-							{releasesData?.data.find((r) => r.id === track.releaseId)?.name ||
-								"未選択"}
-						</p>
-						<p className="text-base-content/50 text-xs">
-							※作品の変更はサポートされていません。変更する場合は削除後に再作成してください。
-						</p>
-					</div>
-
-					{/* ディスク選択 */}
-					{isDiscFieldVisible && (
+						{/* 作品（読み取り専用） */}
 						<div className="grid gap-2">
-							<Label htmlFor="disc">ディスク</Label>
-							<SearchableSelect
-								value={editForm.discId || ""}
-								onChange={(value) =>
-									setEditForm({ ...editForm, discId: value || null })
+							<Label>作品</Label>
+							<p className="text-base-content/70">
+								{releasesData?.data.find((r) => r.id === track.releaseId)
+									?.name || "未選択"}
+							</p>
+							<p className="text-base-content/50 text-xs">
+								※作品の変更はサポートされていません。変更する場合は削除後に再作成してください。
+							</p>
+						</div>
+
+						{/* ディスク選択 */}
+						{isDiscFieldVisible && (
+							<div className="grid gap-2">
+								<Label htmlFor="disc">ディスク</Label>
+								<SearchableSelect
+									value={editForm.discId || ""}
+									onChange={(value) =>
+										setEditForm({ ...editForm, discId: value || null })
+									}
+									options={discOptions}
+									placeholder={
+										isDiscSelectDisabled
+											? discsData && discsData.length === 1
+												? discOptions[0]?.label
+												: "ディスクなし"
+											: "ディスクを選択"
+									}
+									searchPlaceholder="ディスクを検索..."
+									emptyMessage="ディスクが見つかりません"
+									disabled={isDiscSelectDisabled}
+									clearable={!isDiscSelectDisabled}
+								/>
+							</div>
+						)}
+
+						{/* トラック名 */}
+						<div className="grid gap-2">
+							<Label htmlFor="name">
+								トラック名 <span className="text-error">*</span>
+							</Label>
+							<Input
+								id="name"
+								value={editForm.name || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, name: e.target.value })
 								}
-								options={discOptions}
-								placeholder={
-									isDiscSelectDisabled
-										? discsData && discsData.length === 1
-											? discOptions[0]?.label
-											: "ディスクなし"
-										: "ディスクを選択"
-								}
-								searchPlaceholder="ディスクを検索..."
-								emptyMessage="ディスクが見つかりません"
-								disabled={isDiscSelectDisabled}
-								clearable={!isDiscSelectDisabled}
+								placeholder="例: ネイティブフェイス"
 							/>
 						</div>
-					)}
 
-					{/* トラック名 */}
-					<div className="grid gap-2">
-						<Label htmlFor="name">
-							トラック名 <span className="text-error">*</span>
-						</Label>
-						<Input
-							id="name"
-							value={editForm.name || ""}
-							onChange={(e) =>
-								setEditForm({ ...editForm, name: e.target.value })
-							}
-							placeholder="例: ネイティブフェイス"
-						/>
-					</div>
+						{/* トラック番号 */}
+						<div className="grid gap-2">
+							<Label htmlFor="trackNumber">
+								トラック番号 <span className="text-error">*</span>
+							</Label>
+							<Input
+								id="trackNumber"
+								type="number"
+								min="1"
+								value={editForm.trackNumber || ""}
+								onChange={(e) =>
+									setEditForm({
+										...editForm,
+										trackNumber: Number.parseInt(e.target.value, 10) || 1,
+									})
+								}
+							/>
+						</div>
 
-					{/* トラック番号 */}
-					<div className="grid gap-2">
-						<Label htmlFor="trackNumber">
-							トラック番号 <span className="text-error">*</span>
-						</Label>
-						<Input
-							id="trackNumber"
-							type="number"
-							min="1"
-							value={editForm.trackNumber || ""}
-							onChange={(e) =>
-								setEditForm({
-									...editForm,
-									trackNumber: Number.parseInt(e.target.value, 10) || 1,
-								})
-							}
-						/>
-					</div>
+						{/* 日本語名 */}
+						<div className="grid gap-2">
+							<Label htmlFor="nameJa">日本語名</Label>
+							<Input
+								id="nameJa"
+								value={editForm.nameJa || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, nameJa: e.target.value })
+								}
+								placeholder="例: ネイティブフェイス"
+							/>
+						</div>
 
-					{/* 日本語名 */}
-					<div className="grid gap-2">
-						<Label htmlFor="nameJa">日本語名</Label>
-						<Input
-							id="nameJa"
-							value={editForm.nameJa || ""}
-							onChange={(e) =>
-								setEditForm({ ...editForm, nameJa: e.target.value })
-							}
-							placeholder="例: ネイティブフェイス"
-						/>
-					</div>
+						{/* 英語名 */}
+						<div className="grid gap-2">
+							<Label htmlFor="nameEn">英語名</Label>
+							<Input
+								id="nameEn"
+								value={editForm.nameEn || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, nameEn: e.target.value })
+								}
+								placeholder="例: Native Face"
+							/>
+						</div>
 
-					{/* 英語名 */}
-					<div className="grid gap-2">
-						<Label htmlFor="nameEn">英語名</Label>
-						<Input
-							id="nameEn"
-							value={editForm.nameEn || ""}
-							onChange={(e) =>
-								setEditForm({ ...editForm, nameEn: e.target.value })
-							}
-							placeholder="例: Native Face"
-						/>
-					</div>
+						{/* イベント */}
+						<div className="grid gap-2">
+							<Label>イベント</Label>
+							{selectedReleaseId ? (
+								<>
+									<p className="text-base-content/70">
+										{editForm.eventId
+											? eventsData?.data.find((e) => e.id === editForm.eventId)
+													?.name || "未設定"
+											: "未設定"}
+									</p>
+									<p className="text-base-content/50 text-xs">
+										※作品に紐づくトラックのイベントは変更できません
+									</p>
+								</>
+							) : (
+								<SearchableSelect
+									value={editForm.eventId || ""}
+									onChange={(value) => {
+										setEditForm({
+											...editForm,
+											eventId: value || null,
+											eventDayId: null,
+										});
+										setSelectedEventId(value || null);
+									}}
+									options={eventOptions}
+									placeholder="イベントを選択"
+									searchPlaceholder="イベントを検索..."
+									emptyMessage="イベントが見つかりません"
+									clearable
+								/>
+							)}
+						</div>
 
-					{/* イベント */}
-					<div className="grid gap-2">
-						<Label>イベント</Label>
-						{selectedReleaseId ? (
-							<>
+						{/* イベント日 */}
+						<div className="grid gap-2">
+							<Label>イベント日</Label>
+							{selectedReleaseId ? (
 								<p className="text-base-content/70">
-									{editForm.eventId
-										? eventsData?.data.find((e) => e.id === editForm.eventId)
-												?.name || "未設定"
+									{editForm.eventDayId
+										? eventDayOptions.find(
+												(d) => d.value === editForm.eventDayId,
+											)?.label || "未設定"
 										: "未設定"}
 								</p>
-								<p className="text-base-content/50 text-xs">
-									※作品に紐づくトラックのイベントは変更できません
-								</p>
-							</>
-						) : (
-							<SearchableSelect
-								value={editForm.eventId || ""}
-								onChange={(value) => {
-									setEditForm({
-										...editForm,
-										eventId: value || null,
-										eventDayId: null,
-									});
-									setSelectedEventId(value || null);
-								}}
-								options={eventOptions}
-								placeholder="イベントを選択"
-								searchPlaceholder="イベントを検索..."
-								emptyMessage="イベントが見つかりません"
-								clearable
-							/>
-						)}
-					</div>
+							) : (
+								<SearchableSelect
+									value={editForm.eventDayId || ""}
+									onChange={(value) => {
+										const selectedDay = eventDaysData?.find(
+											(d) => d.id === value,
+										);
+										setEditForm({
+											...editForm,
+											eventDayId: value || null,
+											releaseDate: selectedDay?.date || editForm.releaseDate,
+										});
+									}}
+									options={eventDayOptions}
+									placeholder="イベント日を選択"
+									searchPlaceholder="イベント日を検索..."
+									emptyMessage={
+										selectedEventId
+											? "イベント日が見つかりません"
+											: "先にイベントを選択してください"
+									}
+									disabled={
+										!selectedEventId || (eventDaysData?.length ?? 0) <= 1
+									}
+									clearable
+								/>
+							)}
+						</div>
 
-					{/* イベント日 */}
-					<div className="grid gap-2">
-						<Label>イベント日</Label>
-						{selectedReleaseId ? (
-							<p className="text-base-content/70">
-								{editForm.eventDayId
-									? eventDayOptions.find((d) => d.value === editForm.eventDayId)
-											?.label || "未設定"
-									: "未設定"}
-							</p>
-						) : (
-							<SearchableSelect
-								value={editForm.eventDayId || ""}
-								onChange={(value) => {
-									const selectedDay = eventDaysData?.find(
-										(d) => d.id === value,
-									);
-									setEditForm({
-										...editForm,
-										eventDayId: value || null,
-										releaseDate: selectedDay?.date || editForm.releaseDate,
-									});
-								}}
-								options={eventDayOptions}
-								placeholder="イベント日を選択"
-								searchPlaceholder="イベント日を検索..."
-								emptyMessage={
-									selectedEventId
-										? "イベント日が見つかりません"
-										: "先にイベントを選択してください"
+						{/* リリース日 */}
+						<div className="grid gap-2">
+							<Label htmlFor="releaseDate">リリース日</Label>
+							<Input
+								id="releaseDate"
+								type="date"
+								value={editForm.releaseDate || ""}
+								onChange={(e) =>
+									setEditForm({ ...editForm, releaseDate: e.target.value })
 								}
-								disabled={!selectedEventId || (eventDaysData?.length ?? 0) <= 1}
-								clearable
+								disabled={!isReleaseDateEditable}
 							/>
-						)}
+							{!isReleaseDateEditable && (
+								<p className="text-base-content/50 text-xs">
+									※イベント日が設定されている場合、リリース日は自動設定されます
+								</p>
+							)}
+						</div>
 					</div>
+					<DialogFooter>
+						<Button
+							variant="ghost"
+							onClick={() => onOpenChange(false)}
+							disabled={isSubmitting}
+						>
+							キャンセル
+						</Button>
+						<Button
+							variant="primary"
+							onClick={() => handleSave()}
+							disabled={isSubmitting || !editForm.name}
+						>
+							{isSubmitting ? "保存中..." : "保存"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 
-					{/* リリース日 */}
-					<div className="grid gap-2">
-						<Label htmlFor="releaseDate">リリース日</Label>
-						<Input
-							id="releaseDate"
-							type="date"
-							value={editForm.releaseDate || ""}
-							onChange={(e) =>
-								setEditForm({ ...editForm, releaseDate: e.target.value })
-							}
-							disabled={!isReleaseDateEditable}
-						/>
-						{!isReleaseDateEditable && (
-							<p className="text-base-content/50 text-xs">
-								※イベント日が設定されている場合、リリース日は自動設定されます
-							</p>
-						)}
-					</div>
-				</div>
-				<DialogFooter>
-					<Button
-						variant="ghost"
-						onClick={() => onOpenChange(false)}
-						disabled={isSubmitting}
-					>
-						キャンセル
-					</Button>
-					<Button
-						variant="primary"
-						onClick={handleSave}
-						disabled={isSubmitting || !editForm.name}
-					>
-						{isSubmitting ? "保存中..." : "保存"}
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+			{/* 楽観的ロック競合ダイアログ */}
+			<ConflictDialog
+				open={conflictState.isConflict}
+				onOpenChange={(open) => !open && clearConflict()}
+				currentData={conflictState.conflictData}
+				getDisplayName={(data) => data.name}
+				onOverwrite={handleOverwrite}
+				onContinueEditing={handleContinueEditing}
+				isLoading={isSubmitting}
+			/>
+		</>
 	);
 }

--- a/apps/web/src/hooks/use-conflict-handler.ts
+++ b/apps/web/src/hooks/use-conflict-handler.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState } from "react";
+
+/**
+ * 楽観的ロック競合を処理するためのカスタムフック
+ *
+ * @template T 競合したエンティティの型
+ * @returns 競合状態と処理関数
+ */
+export interface ConflictState<T> {
+	/** 競合が発生しているかどうか */
+	isConflict: boolean;
+	/** 競合時のサーバー側の最新データ */
+	conflictData: T | null;
+}
+
+export interface UseConflictHandlerReturn<T> {
+	/** 現在の競合状態 */
+	conflictState: ConflictState<T>;
+	/** 競合を設定する */
+	setConflict: (data: T) => void;
+	/** 競合をクリアする */
+	clearConflict: () => void;
+}
+
+export function useConflictHandler<T>(): UseConflictHandlerReturn<T> {
+	const [conflictState, setConflictState] = useState<ConflictState<T>>({
+		isConflict: false,
+		conflictData: null,
+	});
+
+	const setConflict = useCallback((data: T) => {
+		setConflictState({
+			isConflict: true,
+			conflictData: data,
+		});
+	}, []);
+
+	const clearConflict = useCallback(() => {
+		setConflictState({
+			isConflict: false,
+			conflictData: null,
+		});
+	}, []);
+
+	return {
+		conflictState,
+		setConflict,
+		clearConflict,
+	};
+}


### PR DESCRIPTION
## 概要

updatedAtタイムスタンプを使用した楽観的ロック（Optimistic Locking）により、同時編集時のデータ競合を検出・防止する機能を追加。

## 変更内容

### サーバー側
* `conflict-check.ts`: 楽観的ロックの競合検出ユーティリティを新規作成
* 16件のPUTエンドポイントに競合チェックロジックを追加
* 競合検出時に409 Conflictレスポンスで現在のエンティティデータを返却

### フロントエンド側
* `api-client.ts`: ConflictErrorクラスとisConflictError型ガードを追加
* `use-conflict-handler.ts`: 競合状態管理のカスタムフックを新規作成
* `conflict-dialog.tsx`: 競合解決用ダイアログコンポーネントを新規作成
* 10件の編集ダイアログに競合処理を実装
  - artist-edit-dialog
  - artist-alias-edit-dialog
  - circle-edit-dialog
  - release-edit-dialog
  - track-edit-dialog
  - event-edit-dialog
  - event-series-edit-dialog
  - platform-edit-dialog
  - official-song-edit-dialog
  - official-work-edit-dialog

## 影響範囲

* 管理画面の全編集ダイアログで、同時編集時に競合が検出されるようになります
* 競合発生時、ユーザーは「上書き」または「編集を続ける」を選択可能

## 補足事項

### 動作フロー
1. ユーザーAが編集ダイアログを開く（updatedAtを記録）
2. ユーザーBが同じレコードを編集・保存（updatedAtが更新）
3. ユーザーAが保存しようとする（記録したupdatedAtを送信）
4. サーバーがタイムスタンプ不一致を検出 → 409 Conflictを返却
5. ConflictDialogが表示され、ユーザーが解決方法を選択:
   - 「現在のデータで上書き」→ 最新のupdatedAtで再送信
   - 「編集を続ける」→ 最新データでフォームを更新して編集継続

Closes #104