### PR TITLE
feat: 詳細検索コンポーネントを追加し、フィルターチップを検索フォーム下部に表示

### DIFF
--- a/apps/web/src/components/search/AdvancedSearchModal.tsx
+++ b/apps/web/src/components/search/AdvancedSearchModal.tsx
@@ -1,0 +1,300 @@
+import { X } from "lucide-react";
+import {
+	forwardRef,
+	useCallback,
+	useImperativeHandle,
+	useRef,
+	useState,
+} from "react";
+import { ArtistRoleFilter } from "./ArtistRoleFilter";
+import { CircleFilter } from "./CircleFilter";
+import { DateRangeFilter } from "./DateRangeFilter";
+import { EventFilter } from "./EventFilter";
+import { FilterChips } from "./FilterChips";
+import { FilterSection } from "./FilterSection";
+import {
+	mockArtists,
+	mockCircles,
+	mockEventSeries,
+	mockEvents,
+	mockOriginalSongs,
+	originalSongCategoryOrder,
+} from "./mock-data";
+import { OriginalSongCountFilter } from "./OriginalSongCountFilter";
+import { OriginalSongFilter } from "./OriginalSongFilter";
+import { RoleCountFilter } from "./RoleCountFilter";
+import { SearchSyntaxHelp } from "./SearchSyntaxHelp";
+import { TextSearchFilter } from "./TextSearchFilter";
+import type { AdvancedSearchFilters, FilterSectionState } from "./types";
+import {
+	DEFAULT_ROLE_COUNTS,
+	DEFAULT_SECTION_STATE,
+	DEFAULT_TEXT_SEARCH,
+} from "./types";
+import { useFilterChips } from "./useFilterChips";
+
+export interface AdvancedSearchModalRef {
+	showModal: () => void;
+	close: () => void;
+}
+
+interface AdvancedSearchModalProps {
+	/** フィルター状態 */
+	filters: AdvancedSearchFilters;
+	/** フィルター変更ハンドラ */
+	onFiltersChange: (filters: AdvancedSearchFilters) => void;
+	/** 検索実行ハンドラ */
+	onSearch: () => void;
+}
+
+/**
+ * 詳細検索モーダル
+ *
+ * すべてのフィルターを統合したモーダルダイアログ
+ * - フィルターチップ表示
+ * - アコーディオンセクション
+ * - 検索構文ヘルプ
+ */
+export const AdvancedSearchModal = forwardRef<
+	AdvancedSearchModalRef,
+	AdvancedSearchModalProps
+>(function AdvancedSearchModal({ filters, onFiltersChange, onSearch }, ref) {
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	const [sectionState, setSectionState] = useState<FilterSectionState>(
+		DEFAULT_SECTION_STATE,
+	);
+
+	// フィルターチップのロジックをフックから取得
+	const { chips, handleRemoveChip, handleClearAll } = useFilterChips(
+		filters,
+		onFiltersChange,
+	);
+
+	useImperativeHandle(ref, () => ({
+		showModal: () => dialogRef.current?.showModal(),
+		close: () => dialogRef.current?.close(),
+	}));
+
+	// セクション開閉の切り替え
+	const toggleSection = useCallback((key: keyof FilterSectionState) => {
+		setSectionState((prev) => ({ ...prev, [key]: !prev[key] }));
+	}, []);
+
+	// 選択数の計算
+	const textSearchCount = Object.values(filters.textSearch).filter(
+		Boolean,
+	).length;
+	const originalSongCount = filters.originalSongs.length;
+	const artistCount = filters.artists.length;
+	const circleCount = filters.circles.length;
+	const roleCountCount = Object.values(filters.roleCounts).filter(
+		(v) => v !== "any",
+	).length;
+	const hasSongCount = filters.songCount !== "any";
+	const hasDateRange = !!filters.dateRange.from || !!filters.dateRange.to;
+	const hasEvent = !!filters.event;
+
+	// 検索実行
+	const handleSearch = () => {
+		onSearch();
+		dialogRef.current?.close();
+	};
+
+	// 閉じる
+	const handleClose = () => {
+		dialogRef.current?.close();
+	};
+
+	return (
+		<dialog ref={dialogRef} className="modal modal-bottom sm:modal-middle">
+			<div className="modal-box flex max-h-[90vh] max-w-4xl flex-col p-0">
+				{/* ヘッダー */}
+				<div className="flex items-center justify-between border-base-300 border-b px-4 py-3">
+					<h3 className="font-bold text-lg">詳細検索</h3>
+					<button
+						type="button"
+						onClick={handleClose}
+						className="btn btn-ghost btn-sm btn-circle"
+						aria-label="閉じる"
+					>
+						<X className="h-5 w-5" />
+					</button>
+				</div>
+
+				{/* フィルターチップエリア */}
+				{chips.length > 0 && (
+					<div className="border-base-300 border-b px-4 py-3">
+						<FilterChips
+							chips={chips}
+							onRemove={handleRemoveChip}
+							onClearAll={handleClearAll}
+						/>
+					</div>
+				)}
+
+				{/* スクロール可能なコンテンツ */}
+				<div className="flex-1 divide-y divide-base-300 overflow-y-auto">
+					{/* テキスト検索 */}
+					<FilterSection
+						title="テキスト検索"
+						selectedCount={textSearchCount}
+						isOpen={sectionState.textSearch}
+						onToggle={() => toggleSection("textSearch")}
+						onClear={() =>
+							onFiltersChange({
+								...filters,
+								textSearch: DEFAULT_TEXT_SEARCH,
+							})
+						}
+					>
+						<TextSearchFilter
+							value={filters.textSearch}
+							onChange={(textSearch) =>
+								onFiltersChange({ ...filters, textSearch })
+							}
+						/>
+					</FilterSection>
+
+					{/* 原曲フィルター */}
+					<FilterSection
+						title="原曲を選択"
+						selectedCount={originalSongCount}
+						isOpen={sectionState.originalSongs}
+						onToggle={() => toggleSection("originalSongs")}
+						onClear={() => onFiltersChange({ ...filters, originalSongs: [] })}
+					>
+						<OriginalSongFilter
+							selectedSongs={filters.originalSongs}
+							onChange={(songs) =>
+								onFiltersChange({ ...filters, originalSongs: songs })
+							}
+							options={mockOriginalSongs}
+							categoryOrder={originalSongCategoryOrder}
+						/>
+					</FilterSection>
+
+					{/* 役割別アーティストフィルター */}
+					<FilterSection
+						title="役割別アーティスト"
+						selectedCount={artistCount}
+						isOpen={sectionState.artists}
+						onToggle={() => toggleSection("artists")}
+						onClear={() => onFiltersChange({ ...filters, artists: [] })}
+					>
+						<ArtistRoleFilter
+							selectedArtists={filters.artists}
+							onChange={(artists) => onFiltersChange({ ...filters, artists })}
+							options={mockArtists}
+						/>
+					</FilterSection>
+
+					{/* サークルフィルター */}
+					<FilterSection
+						title="サークル"
+						selectedCount={circleCount}
+						isOpen={sectionState.circles}
+						onToggle={() => toggleSection("circles")}
+						onClear={() => onFiltersChange({ ...filters, circles: [] })}
+					>
+						<CircleFilter
+							selectedCircles={filters.circles}
+							onChange={(circles) => onFiltersChange({ ...filters, circles })}
+							options={mockCircles}
+						/>
+					</FilterSection>
+
+					{/* 役割者数フィルター */}
+					<FilterSection
+						title="役割者数"
+						selectedCount={roleCountCount}
+						isOpen={sectionState.roleCounts}
+						onToggle={() => toggleSection("roleCounts")}
+						onClear={() =>
+							onFiltersChange({
+								...filters,
+								roleCounts: DEFAULT_ROLE_COUNTS,
+							})
+						}
+					>
+						<RoleCountFilter
+							value={filters.roleCounts}
+							onChange={(roleCounts) =>
+								onFiltersChange({ ...filters, roleCounts })
+							}
+						/>
+					</FilterSection>
+
+					{/* 原曲数フィルター */}
+					<FilterSection
+						title="原曲数"
+						selectedCount={hasSongCount ? 1 : 0}
+						isOpen={sectionState.songCount}
+						onToggle={() => toggleSection("songCount")}
+						onClear={() => onFiltersChange({ ...filters, songCount: "any" })}
+					>
+						<OriginalSongCountFilter
+							value={filters.songCount}
+							onChange={(songCount) =>
+								onFiltersChange({ ...filters, songCount })
+							}
+						/>
+					</FilterSection>
+
+					{/* リリース日フィルター */}
+					<FilterSection
+						title="リリース日"
+						selectedCount={hasDateRange ? 1 : 0}
+						isOpen={sectionState.dateRange}
+						onToggle={() => toggleSection("dateRange")}
+						onClear={() => onFiltersChange({ ...filters, dateRange: {} })}
+					>
+						<DateRangeFilter
+							dateRange={filters.dateRange}
+							onChange={(dateRange) =>
+								onFiltersChange({ ...filters, dateRange })
+							}
+						/>
+					</FilterSection>
+
+					{/* イベントフィルター */}
+					<FilterSection
+						title="イベント"
+						selectedCount={hasEvent ? 1 : 0}
+						isOpen={sectionState.event}
+						onToggle={() => toggleSection("event")}
+						onClear={() => onFiltersChange({ ...filters, event: null })}
+					>
+						<EventFilter
+							selectedEvent={filters.event}
+							onChange={(event) => onFiltersChange({ ...filters, event })}
+							eventSeries={mockEventSeries}
+							events={mockEvents}
+						/>
+					</FilterSection>
+
+					{/* 検索構文ヘルプ */}
+					<SearchSyntaxHelp />
+				</div>
+
+				{/* フッター（アクション） */}
+				<div className="modal-action mt-0 border-base-300 border-t px-4 py-3">
+					<button type="button" onClick={handleClose} className="btn btn-ghost">
+						閉じる
+					</button>
+					<button
+						type="button"
+						onClick={handleSearch}
+						className="btn btn-primary"
+					>
+						検索
+					</button>
+				</div>
+			</div>
+
+			{/* バックドロップ */}
+			<form method="dialog" className="modal-backdrop">
+				<button type="submit">close</button>
+			</form>
+		</dialog>
+	);
+});

--- a/apps/web/src/components/search/AdvancedSearchPanel.tsx
+++ b/apps/web/src/components/search/AdvancedSearchPanel.tsx
@@ -1,0 +1,312 @@
+import { useCallback, useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import { ArtistRoleFilter } from "./ArtistRoleFilter";
+import { CircleFilter } from "./CircleFilter";
+import { DateRangeFilter } from "./DateRangeFilter";
+import { EventFilter } from "./EventFilter";
+import { createFilterChip, FilterChips } from "./FilterChips";
+import { FilterSection } from "./FilterSection";
+import {
+	mockArtists,
+	mockCircles,
+	mockEventSeries,
+	mockEvents,
+	mockOriginalSongs,
+	originalSongCategoryOrder,
+} from "./mock-data";
+import { OriginalSongCountFilter } from "./OriginalSongCountFilter";
+import { OriginalSongFilter } from "./OriginalSongFilter";
+import { SearchSyntaxHelp } from "./SearchSyntaxHelp";
+import type {
+	AdvancedSearchFilters,
+	FilterChip,
+	FilterSectionState,
+} from "./types";
+import { DEFAULT_FILTERS, DEFAULT_SECTION_STATE, ROLE_LABELS } from "./types";
+
+interface AdvancedSearchPanelProps {
+	/** フィルター状態 */
+	filters: AdvancedSearchFilters;
+	/** フィルター変更ハンドラ */
+	onFiltersChange: (filters: AdvancedSearchFilters) => void;
+	/** パネルの表示状態 */
+	isOpen: boolean;
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+/**
+ * 詳細検索パネル
+ *
+ * すべてのフィルターを統合したメインパネル
+ * - フィルターチップ表示
+ * - アコーディオンセクション
+ * - 検索構文ヘルプ
+ */
+export function AdvancedSearchPanel({
+	filters,
+	onFiltersChange,
+	isOpen,
+	className,
+}: AdvancedSearchPanelProps) {
+	const [sectionState, setSectionState] = useState<FilterSectionState>(
+		DEFAULT_SECTION_STATE,
+	);
+
+	// セクション開閉の切り替え
+	const toggleSection = useCallback((key: keyof FilterSectionState) => {
+		setSectionState((prev) => ({ ...prev, [key]: !prev[key] }));
+	}, []);
+
+	// フィルターチップの生成
+	const chips = useMemo<FilterChip[]>(() => {
+		const result: FilterChip[] = [];
+
+		// 原曲
+		for (const song of filters.originalSongs) {
+			result.push(
+				createFilterChip("originalSong", song.id, song.name, song.id),
+			);
+		}
+
+		// サークル
+		for (const circle of filters.circles) {
+			result.push(
+				createFilterChip("circle", circle.id, circle.name, circle.id),
+			);
+		}
+
+		// アーティスト
+		for (const artist of filters.artists) {
+			result.push(
+				createFilterChip(
+					"artist",
+					`${artist.role}-${artist.id}`,
+					`${ROLE_LABELS[artist.role]}: ${artist.name}`,
+					artist.id,
+				),
+			);
+		}
+
+		// 日付範囲
+		if (filters.dateRange.from || filters.dateRange.to) {
+			const from = filters.dateRange.from || "...";
+			const to = filters.dateRange.to || "...";
+			result.push(
+				createFilterChip("date", "range", `${from} 〜 ${to}`, "date"),
+			);
+		}
+
+		// イベント
+		if (filters.event) {
+			result.push(
+				createFilterChip(
+					"event",
+					filters.event.id,
+					filters.event.name,
+					filters.event.id,
+					filters.event.seriesName,
+				),
+			);
+		}
+
+		// 原曲数
+		if (filters.songCount !== "any") {
+			const label =
+				typeof filters.songCount === "number"
+					? `${filters.songCount}曲以上`
+					: filters.songCount === "3+"
+						? "3曲以上"
+						: `${filters.songCount}曲`;
+			result.push(
+				createFilterChip("songCount", "count", label, filters.songCount),
+			);
+		}
+
+		return result;
+	}, [filters]);
+
+	// チップ削除
+	const handleRemoveChip = useCallback(
+		(chip: FilterChip) => {
+			switch (chip.type) {
+				case "originalSong":
+					onFiltersChange({
+						...filters,
+						originalSongs: filters.originalSongs.filter(
+							(s) => s.id !== chip.value,
+						),
+					});
+					break;
+				case "circle":
+					onFiltersChange({
+						...filters,
+						circles: filters.circles.filter((c) => c.id !== chip.value),
+					});
+					break;
+				case "artist":
+					onFiltersChange({
+						...filters,
+						artists: filters.artists.filter(
+							(a) => `artist-${a.role}-${a.id}` !== chip.id,
+						),
+					});
+					break;
+				case "date":
+					onFiltersChange({
+						...filters,
+						dateRange: {},
+					});
+					break;
+				case "event":
+					onFiltersChange({
+						...filters,
+						event: null,
+					});
+					break;
+				case "songCount":
+					onFiltersChange({
+						...filters,
+						songCount: "any",
+					});
+					break;
+			}
+		},
+		[filters, onFiltersChange],
+	);
+
+	// すべてクリア
+	const handleClearAll = useCallback(() => {
+		onFiltersChange(DEFAULT_FILTERS);
+	}, [onFiltersChange]);
+
+	// 選択数の計算
+	const originalSongCount = filters.originalSongs.length;
+	const circleCount = filters.circles.length;
+	const artistCount = filters.artists.length;
+	const hasDateRange = !!filters.dateRange.from || !!filters.dateRange.to;
+	const hasEvent = !!filters.event;
+	const hasSongCount = filters.songCount !== "any";
+
+	if (!isOpen) {
+		return null;
+	}
+
+	return (
+		<div
+			className={cn(
+				"glass-card overflow-hidden rounded-xl border border-base-300",
+				className,
+			)}
+		>
+			{/* フィルターチップエリア */}
+			{chips.length > 0 && (
+				<div className="border-base-300 border-b p-3">
+					<FilterChips
+						chips={chips}
+						onRemove={handleRemoveChip}
+						onClearAll={handleClearAll}
+					/>
+				</div>
+			)}
+
+			{/* フィルターセクション */}
+			<div className="divide-y divide-base-300">
+				{/* 原曲フィルター */}
+				<FilterSection
+					title="原曲を選択"
+					selectedCount={originalSongCount}
+					isOpen={sectionState.originalSongs}
+					onToggle={() => toggleSection("originalSongs")}
+					onClear={() => onFiltersChange({ ...filters, originalSongs: [] })}
+				>
+					<OriginalSongFilter
+						selectedSongs={filters.originalSongs}
+						onChange={(songs) =>
+							onFiltersChange({ ...filters, originalSongs: songs })
+						}
+						options={mockOriginalSongs}
+						categoryOrder={originalSongCategoryOrder}
+					/>
+				</FilterSection>
+
+				{/* 役割別アーティストフィルター */}
+				<FilterSection
+					title="役割別アーティスト"
+					selectedCount={artistCount}
+					isOpen={sectionState.artists}
+					onToggle={() => toggleSection("artists")}
+					onClear={() => onFiltersChange({ ...filters, artists: [] })}
+				>
+					<ArtistRoleFilter
+						selectedArtists={filters.artists}
+						onChange={(artists) => onFiltersChange({ ...filters, artists })}
+						options={mockArtists}
+					/>
+				</FilterSection>
+
+				{/* サークルフィルター */}
+				<FilterSection
+					title="サークル"
+					selectedCount={circleCount}
+					isOpen={sectionState.circles}
+					onToggle={() => toggleSection("circles")}
+					onClear={() => onFiltersChange({ ...filters, circles: [] })}
+				>
+					<CircleFilter
+						selectedCircles={filters.circles}
+						onChange={(circles) => onFiltersChange({ ...filters, circles })}
+						options={mockCircles}
+					/>
+				</FilterSection>
+
+				{/* リリース日フィルター */}
+				<FilterSection
+					title="リリース日"
+					selectedCount={hasDateRange ? 1 : 0}
+					isOpen={sectionState.dateRange}
+					onToggle={() => toggleSection("dateRange")}
+					onClear={() => onFiltersChange({ ...filters, dateRange: {} })}
+				>
+					<DateRangeFilter
+						dateRange={filters.dateRange}
+						onChange={(dateRange) => onFiltersChange({ ...filters, dateRange })}
+					/>
+				</FilterSection>
+
+				{/* イベントフィルター */}
+				<FilterSection
+					title="イベント"
+					selectedCount={hasEvent ? 1 : 0}
+					isOpen={sectionState.event}
+					onToggle={() => toggleSection("event")}
+					onClear={() => onFiltersChange({ ...filters, event: null })}
+				>
+					<EventFilter
+						selectedEvent={filters.event}
+						onChange={(event) => onFiltersChange({ ...filters, event })}
+						eventSeries={mockEventSeries}
+						events={mockEvents}
+					/>
+				</FilterSection>
+
+				{/* 原曲数フィルター */}
+				<FilterSection
+					title="原曲数"
+					selectedCount={hasSongCount ? 1 : 0}
+					isOpen={sectionState.songCount}
+					onToggle={() => toggleSection("songCount")}
+					onClear={() => onFiltersChange({ ...filters, songCount: "any" })}
+				>
+					<OriginalSongCountFilter
+						value={filters.songCount}
+						onChange={(songCount) => onFiltersChange({ ...filters, songCount })}
+					/>
+				</FilterSection>
+			</div>
+
+			{/* 検索構文ヘルプ */}
+			<SearchSyntaxHelp />
+		</div>
+	);
+}

--- a/apps/web/src/components/search/ArtistRoleFilter.tsx
+++ b/apps/web/src/components/search/ArtistRoleFilter.tsx
@@ -1,0 +1,247 @@
+import { Check, Plus, Search, Users, X } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { MockArtist } from "./mock-data";
+import type { CreditRole, SelectedArtist } from "./types";
+import { ROLE_LABELS } from "./types";
+
+interface ArtistRoleFilterProps {
+	/** 選択中のアーティストリスト */
+	selectedArtists: SelectedArtist[];
+	/** 選択変更ハンドラ */
+	onChange: (artists: SelectedArtist[]) => void;
+	/** 選択可能なアーティストオプション */
+	options: MockArtist[];
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+/** 選択可能な役割（主要なもののみ） */
+const SELECTABLE_ROLES: CreditRole[] = [
+	"vocalist",
+	"lyricist",
+	"arranger",
+	"composer",
+];
+
+/**
+ * 役割別アーティスト選択フィルター（複数選択対応）
+ *
+ * - タブで役割を切り替え
+ * - 各役割でアーティストを複数選択可能
+ * - 選択中のアーティストをチップで表示（役割付き）
+ */
+export function ArtistRoleFilter({
+	selectedArtists,
+	onChange,
+	options,
+	className,
+}: ArtistRoleFilterProps) {
+	const [activeRole, setActiveRole] = useState<CreditRole>("vocalist");
+	const [search, setSearch] = useState("");
+	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+	// 役割ごとの選択数
+	const roleCountMap = useMemo(() => {
+		const map = new Map<CreditRole, number>();
+		for (const artist of selectedArtists) {
+			map.set(artist.role, (map.get(artist.role) || 0) + 1);
+		}
+		return map;
+	}, [selectedArtists]);
+
+	// 現在の役割で選択中のIDセット
+	const selectedIdsForRole = useMemo(() => {
+		return new Set(
+			selectedArtists.filter((a) => a.role === activeRole).map((a) => a.id),
+		);
+	}, [selectedArtists, activeRole]);
+
+	// 検索でフィルタリング
+	const filteredOptions = useMemo(() => {
+		if (!search) return options;
+		const lowerSearch = search.toLowerCase();
+		return options.filter(
+			(o) =>
+				o.name.toLowerCase().includes(lowerSearch) ||
+				o.nameJa?.toLowerCase().includes(lowerSearch),
+		);
+	}, [options, search]);
+
+	// アーティストを選択/解除
+	const toggleArtist = useCallback(
+		(artist: MockArtist) => {
+			const existingIndex = selectedArtists.findIndex(
+				(a) => a.id === artist.id && a.role === activeRole,
+			);
+
+			if (existingIndex >= 0) {
+				// 解除
+				const newArtists = [...selectedArtists];
+				newArtists.splice(existingIndex, 1);
+				onChange(newArtists);
+			} else {
+				// 選択
+				onChange([
+					...selectedArtists,
+					{ id: artist.id, name: artist.name, role: activeRole },
+				]);
+			}
+		},
+		[selectedArtists, activeRole, onChange],
+	);
+
+	// 選択中のアーティストを削除
+	const removeArtist = useCallback(
+		(id: string, role: CreditRole) => {
+			onChange(
+				selectedArtists.filter((a) => !(a.id === id && a.role === role)),
+			);
+		},
+		[selectedArtists, onChange],
+	);
+
+	return (
+		<div className={cn("space-y-3", className)}>
+			{/* 選択中のアーティストチップ */}
+			{selectedArtists.length > 0 && (
+				<div className="flex flex-wrap gap-2">
+					{selectedArtists.map((artist) => (
+						<div
+							key={`${artist.role}-${artist.id}`}
+							className="badge badge-accent gap-1 pr-1 transition-all hover:opacity-80"
+						>
+							<Users className="h-3 w-3" />
+							<span className="max-w-[100px] truncate">
+								{ROLE_LABELS[artist.role]}: {artist.name}
+							</span>
+							<button
+								type="button"
+								onClick={() => removeArtist(artist.id, artist.role)}
+								className="ml-1 rounded-full p-0.5 transition-colors hover:bg-base-content/20"
+								aria-label={`${artist.name}を削除`}
+							>
+								<X className="h-3 w-3" />
+							</button>
+						</div>
+					))}
+				</div>
+			)}
+
+			{/* 役割タブ */}
+			<div className="flex flex-wrap gap-1">
+				{SELECTABLE_ROLES.map((role) => {
+					const count = roleCountMap.get(role) || 0;
+					const isActive = role === activeRole;
+					return (
+						<button
+							key={role}
+							type="button"
+							onClick={() => {
+								setActiveRole(role);
+								setIsDropdownOpen(true);
+							}}
+							className={cn(
+								"btn btn-sm gap-1",
+								isActive ? "btn-accent" : "btn-ghost",
+							)}
+						>
+							{ROLE_LABELS[role]}
+							{count > 0 && <span className="badge badge-sm">{count}</span>}
+						</button>
+					);
+				})}
+			</div>
+
+			{/* アーティスト追加ボタン/ドロップダウン */}
+			<div className="relative">
+				<button
+					type="button"
+					onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+					className="btn btn-outline btn-sm gap-2"
+				>
+					<Plus className="h-4 w-4" />
+					{ROLE_LABELS[activeRole]}を追加
+				</button>
+
+				{/* ドロップダウンパネル */}
+				{isDropdownOpen && (
+					<div className="absolute top-full left-0 z-50 mt-2 w-full max-w-md rounded-lg border border-base-300 bg-base-100 shadow-lg">
+						{/* ヘッダー */}
+						<div className="flex items-center justify-between border-base-300 border-b p-2">
+							<span className="font-medium text-sm">
+								{ROLE_LABELS[activeRole]}を選択
+							</span>
+							<button
+								type="button"
+								onClick={() => {
+									setIsDropdownOpen(false);
+									setSearch("");
+								}}
+								className="btn btn-ghost btn-xs btn-circle"
+								aria-label="閉じる"
+							>
+								<X className="h-4 w-4" />
+							</button>
+						</div>
+
+						{/* 検索欄 */}
+						<div className="border-base-300 border-b p-2">
+							<div className="relative">
+								<Search className="pointer-events-none absolute top-1/2 left-3 z-10 h-4 w-4 -translate-y-1/2 text-base-content/50" />
+								<input
+									type="text"
+									value={search}
+									onChange={(e) => setSearch(e.target.value)}
+									placeholder={`${ROLE_LABELS[activeRole]}を検索...`}
+									className="input input-sm input-bordered w-full pl-9"
+								/>
+							</div>
+						</div>
+
+						{/* オプションリスト */}
+						<div className="max-h-72 overflow-y-auto">
+							{filteredOptions.length === 0 ? (
+								<div className="p-4 text-center text-base-content/50">
+									該当するアーティストがいません
+								</div>
+							) : (
+								filteredOptions.map((artist) => {
+									const isSelected = selectedIdsForRole.has(artist.id);
+									return (
+										<button
+											key={artist.id}
+											type="button"
+											onClick={() => toggleArtist(artist)}
+											className={cn(
+												"flex w-full items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-base-200",
+												isSelected && "bg-accent/10 font-medium text-accent",
+											)}
+										>
+											<div
+												className={cn(
+													"flex h-4 w-4 shrink-0 items-center justify-center rounded border",
+													isSelected
+														? "border-accent bg-accent text-accent-content"
+														: "border-base-300",
+												)}
+											>
+												{isSelected && <Check className="h-3 w-3" />}
+											</div>
+											<span>{artist.name}</span>
+											{artist.nameJa && artist.nameJa !== artist.name && (
+												<span className="text-base-content/50 text-sm">
+													({artist.nameJa})
+												</span>
+											)}
+										</button>
+									);
+								})
+							)}
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/search/CircleFilter.tsx
+++ b/apps/web/src/components/search/CircleFilter.tsx
@@ -1,0 +1,186 @@
+import { Check, Disc3, Plus, Search, X } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { MockCircle } from "./mock-data";
+import type { SelectedCircle } from "./types";
+
+interface CircleFilterProps {
+	/** 選択中のサークルリスト */
+	selectedCircles: SelectedCircle[];
+	/** 選択変更ハンドラ */
+	onChange: (circles: SelectedCircle[]) => void;
+	/** 選択可能なサークルオプション */
+	options: MockCircle[];
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+/**
+ * サークル選択フィルター（複数選択対応）
+ *
+ * - 検索可能なドロップダウン
+ * - チェックボックスで複数選択
+ * - 選択中のサークルをチップで表示
+ */
+export function CircleFilter({
+	selectedCircles,
+	onChange,
+	options,
+	className,
+}: CircleFilterProps) {
+	const [search, setSearch] = useState("");
+	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+	// 選択中のIDセット
+	const selectedIds = useMemo(
+		() => new Set(selectedCircles.map((c) => c.id)),
+		[selectedCircles],
+	);
+
+	// 検索でフィルタリング
+	const filteredOptions = useMemo(() => {
+		if (!search) return options;
+		const lowerSearch = search.toLowerCase();
+		return options.filter(
+			(o) =>
+				o.name.toLowerCase().includes(lowerSearch) ||
+				o.nameJa?.toLowerCase().includes(lowerSearch),
+		);
+	}, [options, search]);
+
+	// サークルを選択/解除
+	const toggleCircle = useCallback(
+		(circle: MockCircle) => {
+			if (selectedIds.has(circle.id)) {
+				onChange(selectedCircles.filter((c) => c.id !== circle.id));
+			} else {
+				onChange([...selectedCircles, { id: circle.id, name: circle.name }]);
+			}
+		},
+		[selectedIds, selectedCircles, onChange],
+	);
+
+	// 選択中のサークルを削除
+	const removeCircle = useCallback(
+		(id: string) => {
+			onChange(selectedCircles.filter((c) => c.id !== id));
+		},
+		[selectedCircles, onChange],
+	);
+
+	return (
+		<div className={cn("space-y-3", className)}>
+			{/* 選択中のサークルチップ */}
+			{selectedCircles.length > 0 && (
+				<div className="flex flex-wrap gap-2">
+					{selectedCircles.map((circle) => (
+						<div
+							key={circle.id}
+							className="badge badge-secondary gap-1 pr-1 transition-all hover:opacity-80"
+						>
+							<Disc3 className="h-3 w-3" />
+							<span className="max-w-[120px] truncate">{circle.name}</span>
+							<button
+								type="button"
+								onClick={() => removeCircle(circle.id)}
+								className="ml-1 rounded-full p-0.5 transition-colors hover:bg-base-content/20"
+								aria-label={`${circle.name}を削除`}
+							>
+								<X className="h-3 w-3" />
+							</button>
+						</div>
+					))}
+				</div>
+			)}
+
+			{/* サークル追加ボタン/ドロップダウン */}
+			<div className="relative">
+				<button
+					type="button"
+					onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+					className="btn btn-outline btn-sm gap-2"
+				>
+					<Plus className="h-4 w-4" />
+					サークルを追加
+				</button>
+
+				{/* ドロップダウンパネル */}
+				{isDropdownOpen && (
+					<div className="absolute top-full left-0 z-50 mt-2 w-full max-w-md rounded-lg border border-base-300 bg-base-100 shadow-lg">
+						{/* ヘッダー */}
+						<div className="flex items-center justify-between border-base-300 border-b p-2">
+							<span className="font-medium text-sm">サークルを選択</span>
+							<button
+								type="button"
+								onClick={() => {
+									setIsDropdownOpen(false);
+									setSearch("");
+								}}
+								className="btn btn-ghost btn-xs btn-circle"
+								aria-label="閉じる"
+							>
+								<X className="h-4 w-4" />
+							</button>
+						</div>
+
+						{/* 検索欄 */}
+						<div className="border-base-300 border-b p-2">
+							<div className="relative">
+								<Search className="pointer-events-none absolute top-1/2 left-3 z-10 h-4 w-4 -translate-y-1/2 text-base-content/50" />
+								<input
+									type="text"
+									value={search}
+									onChange={(e) => setSearch(e.target.value)}
+									placeholder="サークルを検索..."
+									className="input input-sm input-bordered w-full pl-9"
+								/>
+							</div>
+						</div>
+
+						{/* オプションリスト */}
+						<div className="max-h-72 overflow-y-auto">
+							{filteredOptions.length === 0 ? (
+								<div className="p-4 text-center text-base-content/50">
+									該当するサークルがありません
+								</div>
+							) : (
+								filteredOptions.map((circle) => {
+									const isSelected = selectedIds.has(circle.id);
+									return (
+										<button
+											key={circle.id}
+											type="button"
+											onClick={() => toggleCircle(circle)}
+											className={cn(
+												"flex w-full items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-base-200",
+												isSelected &&
+													"bg-secondary/10 font-medium text-secondary",
+											)}
+										>
+											<div
+												className={cn(
+													"flex h-4 w-4 shrink-0 items-center justify-center rounded border",
+													isSelected
+														? "border-secondary bg-secondary text-secondary-content"
+														: "border-base-300",
+												)}
+											>
+												{isSelected && <Check className="h-3 w-3" />}
+											</div>
+											<span>{circle.name}</span>
+											{circle.nameJa && circle.nameJa !== circle.name && (
+												<span className="text-base-content/50 text-sm">
+													({circle.nameJa})
+												</span>
+											)}
+										</button>
+									);
+								})
+							)}
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/search/DateRangeFilter.tsx
+++ b/apps/web/src/components/search/DateRangeFilter.tsx
@@ -1,0 +1,112 @@
+import { Calendar } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { DateRange } from "./types";
+
+interface DateRangeFilterProps {
+	/** 選択中の日付範囲 */
+	dateRange: DateRange;
+	/** 日付範囲変更ハンドラ */
+	onChange: (dateRange: DateRange) => void;
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+/** クイックプリセット */
+const PRESETS = [
+	{ label: "2024年", from: "2024-01", to: "2024-12" },
+	{ label: "2023年", from: "2023-01", to: "2023-12" },
+	{ label: "2020年代", from: "2020-01", to: "2029-12" },
+	{ label: "2010年代", from: "2010-01", to: "2019-12" },
+] as const;
+
+/**
+ * リリース日範囲選択フィルター
+ *
+ * - 開始日・終了日の入力
+ * - クイックプリセット（2024年、2023年、2020年代など）
+ * - YYYY-MM形式
+ */
+export function DateRangeFilter({
+	dateRange,
+	onChange,
+	className,
+}: DateRangeFilterProps) {
+	const handleFromChange = (value: string) => {
+		onChange({ ...dateRange, from: value || undefined });
+	};
+
+	const handleToChange = (value: string) => {
+		onChange({ ...dateRange, to: value || undefined });
+	};
+
+	const handlePreset = (from: string, to: string) => {
+		onChange({ from, to });
+	};
+
+	const handleClear = () => {
+		onChange({});
+	};
+
+	const hasValue = dateRange.from || dateRange.to;
+
+	return (
+		<div className={cn("space-y-3", className)}>
+			{/* 日付入力 */}
+			<div className="flex flex-wrap items-center gap-2">
+				<div className="flex items-center gap-2">
+					<Calendar className="h-4 w-4 text-base-content/50" />
+					<span className="text-sm">開始:</span>
+					<input
+						type="month"
+						value={dateRange.from || ""}
+						onChange={(e) => handleFromChange(e.target.value)}
+						className="input input-sm input-bordered w-36"
+						placeholder="YYYY-MM"
+					/>
+				</div>
+
+				<span className="text-base-content/50">〜</span>
+
+				<div className="flex items-center gap-2">
+					<span className="text-sm">終了:</span>
+					<input
+						type="month"
+						value={dateRange.to || ""}
+						onChange={(e) => handleToChange(e.target.value)}
+						className="input input-sm input-bordered w-36"
+						placeholder="YYYY-MM"
+					/>
+				</div>
+
+				{hasValue && (
+					<button
+						type="button"
+						onClick={handleClear}
+						className="btn btn-ghost btn-sm text-base-content/60"
+					>
+						クリア
+					</button>
+				)}
+			</div>
+
+			{/* クイックプリセット */}
+			<div className="flex flex-wrap gap-2">
+				<span className="text-base-content/60 text-sm">プリセット:</span>
+				{PRESETS.map((preset) => {
+					const isActive =
+						dateRange.from === preset.from && dateRange.to === preset.to;
+					return (
+						<button
+							key={preset.label}
+							type="button"
+							onClick={() => handlePreset(preset.from, preset.to)}
+							className={cn("btn btn-xs", isActive ? "btn-info" : "btn-ghost")}
+						>
+							{preset.label}
+						</button>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/search/EventFilter.tsx
+++ b/apps/web/src/components/search/EventFilter.tsx
@@ -1,0 +1,135 @@
+import { Calendar, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { MockEvent, MockEventSeries } from "./mock-data";
+import type { SelectedEvent } from "./types";
+
+interface EventFilterProps {
+	/** 選択中のイベント */
+	selectedEvent: SelectedEvent | null;
+	/** イベント変更ハンドラ */
+	onChange: (event: SelectedEvent | null) => void;
+	/** イベントシリーズのリスト */
+	eventSeries: MockEventSeries[];
+	/** イベントのリスト */
+	events: MockEvent[];
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+/**
+ * イベント選択フィルター
+ *
+ * - シリーズ選択 → イベント選択 の2段階
+ * - シリーズでフィルタリングされたイベントを表示
+ */
+export function EventFilter({
+	selectedEvent,
+	onChange,
+	eventSeries,
+	events,
+	className,
+}: EventFilterProps) {
+	const [selectedSeriesId, setSelectedSeriesId] = useState<string>("");
+
+	// 選択されたシリーズに属するイベント
+	const filteredEvents = useMemo(() => {
+		if (!selectedSeriesId) return [];
+		return events.filter((e) => e.seriesId === selectedSeriesId);
+	}, [events, selectedSeriesId]);
+
+	const handleSeriesChange = (seriesId: string) => {
+		setSelectedSeriesId(seriesId);
+		// シリーズ変更時は選択をクリア
+		if (selectedEvent?.seriesName) {
+			const series = eventSeries.find((s) => s.id === seriesId);
+			if (series?.name !== selectedEvent.seriesName) {
+				onChange(null);
+			}
+		}
+	};
+
+	const handleEventChange = (eventId: string) => {
+		if (!eventId) {
+			onChange(null);
+			return;
+		}
+		const event = events.find((e) => e.id === eventId);
+		if (event) {
+			onChange({
+				id: event.id,
+				name: event.name,
+				seriesName: event.seriesName,
+			});
+		}
+	};
+
+	const handleClear = () => {
+		setSelectedSeriesId("");
+		onChange(null);
+	};
+
+	return (
+		<div className={cn("space-y-3", className)}>
+			{/* 選択中のイベント表示 */}
+			{selectedEvent && (
+				<div className="flex items-center gap-2">
+					<div className="badge badge-info gap-1 pr-1">
+						<Calendar className="h-3 w-3" />
+						<span>
+							{selectedEvent.seriesName}: {selectedEvent.name}
+						</span>
+						<button
+							type="button"
+							onClick={handleClear}
+							className="ml-1 rounded-full p-0.5 transition-colors hover:bg-base-content/20"
+							aria-label="イベントをクリア"
+						>
+							<X className="h-3 w-3" />
+						</button>
+					</div>
+				</div>
+			)}
+
+			{/* シリーズ・イベント選択 */}
+			<div className="space-y-3">
+				{/* シリーズ選択 */}
+				<div className="flex items-center gap-2">
+					<span className="w-20 shrink-0 text-sm">シリーズ</span>
+					<select
+						value={selectedSeriesId}
+						onChange={(e) => handleSeriesChange(e.target.value)}
+						className="select select-sm select-bordered flex-1"
+					>
+						<option value="">選択してください</option>
+						{eventSeries.map((series) => (
+							<option key={series.id} value={series.id}>
+								{series.name}
+							</option>
+						))}
+					</select>
+				</div>
+
+				{/* イベント選択（シリーズ選択後に表示） */}
+				{selectedSeriesId && (
+					<div className="flex items-center gap-2">
+						<span className="w-20 shrink-0 text-sm">イベント</span>
+						<select
+							value={selectedEvent?.id || ""}
+							onChange={(e) => handleEventChange(e.target.value)}
+							className="select select-sm select-bordered flex-1"
+						>
+							<option value="">選択してください</option>
+							{filteredEvents.map((event) => (
+								<option key={event.id} value={event.id}>
+									{event.name}
+									{event.date && ` (${event.date})`}
+								</option>
+							))}
+						</select>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/search/FilterChips.tsx
+++ b/apps/web/src/components/search/FilterChips.tsx
@@ -1,0 +1,145 @@
+import {
+	Calendar,
+	Disc3,
+	Hash,
+	Music,
+	Search,
+	UserCheck,
+	Users,
+	X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FilterChip, FilterChipType } from "./types";
+import { CHIP_COLORS } from "./types";
+
+interface FilterChipsProps {
+	/** 表示するチップのリスト */
+	chips: FilterChip[];
+	/** チップの削除ハンドラ */
+	onRemove: (chip: FilterChip) => void;
+	/** すべてクリアハンドラ */
+	onClearAll: () => void;
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+/** フィルタータイプに対応するアイコン */
+const CHIP_ICONS: Record<FilterChipType, React.ElementType> = {
+	textSearch: Search,
+	originalSong: Music,
+	artist: Users,
+	circle: Disc3,
+	roleCount: UserCheck,
+	songCount: Hash,
+	date: Calendar,
+	event: Calendar,
+};
+
+/** フィルタータイプに対応するラベルプレフィックス */
+const CHIP_PREFIXES: Record<FilterChipType, string> = {
+	textSearch: "",
+	originalSong: "原曲",
+	artist: "",
+	circle: "サークル",
+	roleCount: "",
+	songCount: "原曲数",
+	date: "期間",
+	event: "イベント",
+};
+
+/**
+ * 選択中のフィルターをチップとして表示するコンポーネント
+ *
+ * - 各チップは削除可能（×ボタン）
+ * - 色分けでフィルタータイプを視覚的に区別
+ * - 「すべてクリア」ボタンで一括削除
+ * - 横スクロール対応（モバイル）
+ */
+export function FilterChips({
+	chips,
+	onRemove,
+	onClearAll,
+	className,
+}: FilterChipsProps) {
+	if (chips.length === 0) {
+		return null;
+	}
+
+	return (
+		<div
+			className={cn(
+				"flex flex-wrap items-center gap-2 rounded-lg border border-base-300 bg-base-200/30 p-3",
+				className,
+			)}
+		>
+			<span className="mr-1 text-base-content/60 text-sm">選択中:</span>
+
+			{/* チップリスト */}
+			<div className="flex flex-wrap gap-2">
+				{chips.map((chip) => {
+					const Icon = CHIP_ICONS[chip.type];
+					const prefix = CHIP_PREFIXES[chip.type];
+					const colorClass = CHIP_COLORS[chip.type];
+
+					return (
+						<div
+							key={chip.id}
+							className={cn(
+								"badge gap-1 pr-1",
+								colorClass,
+								"transition-all hover:opacity-80",
+							)}
+						>
+							<Icon className="h-3 w-3" />
+							<span>
+								{prefix && `${prefix}: `}
+								{chip.label}
+								{chip.sublabel && (
+									<span className="text-xs opacity-70"> ({chip.sublabel})</span>
+								)}
+							</span>
+							<button
+								type="button"
+								onClick={() => onRemove(chip)}
+								className="ml-1 rounded-full p-0.5 transition-colors hover:bg-base-content/20"
+								aria-label={`${chip.label}を削除`}
+							>
+								<X className="h-3 w-3" />
+							</button>
+						</div>
+					);
+				})}
+			</div>
+
+			{/* すべてクリアボタン */}
+			{chips.length > 1 && (
+				<button
+					type="button"
+					onClick={onClearAll}
+					className="ml-auto rounded px-2 py-1 text-base-content/60 text-xs transition-colors hover:bg-base-300 hover:text-base-content"
+				>
+					すべてクリア
+				</button>
+			)}
+		</div>
+	);
+}
+
+/**
+ * FilterChip オブジェクトを生成するヘルパー関数
+ */
+export function createFilterChip(
+	type: FilterChipType,
+	id: string,
+	label: string,
+	value: string | number,
+	sublabel?: string,
+): FilterChip {
+	return {
+		id: `${type}-${id}`,
+		type,
+		label,
+		sublabel,
+		value,
+	};
+}

--- a/apps/web/src/components/search/FilterSection.tsx
+++ b/apps/web/src/components/search/FilterSection.tsx
@@ -1,0 +1,94 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface FilterSectionProps {
+	/** セクションのタイトル */
+	title: string;
+	/** 選択中のアイテム数（バッジ表示用） */
+	selectedCount?: number;
+	/** 展開状態 */
+	isOpen: boolean;
+	/** 展開状態の変更ハンドラ */
+	onToggle: () => void;
+	/** クリアハンドラ（選択中のアイテムがある場合に表示） */
+	onClear?: () => void;
+	/** 子要素 */
+	children: ReactNode;
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+/**
+ * 詳細検索のフィルターセクション（アコーディオン）
+ *
+ * - ヘッダー全体がクリック可能
+ * - 選択中のアイテム数をバッジで表示
+ * - 「クリア」ボタンで選択をリセット
+ * - スムーズなアニメーションで開閉
+ */
+export function FilterSection({
+	title,
+	selectedCount = 0,
+	isOpen,
+	onToggle,
+	onClear,
+	children,
+	className,
+}: FilterSectionProps) {
+	const handleClear = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		onClear?.();
+	};
+
+	return (
+		<div className={cn("border-base-300 border-b last:border-b-0", className)}>
+			{/* ヘッダー（クリック可能） */}
+			<button
+				type="button"
+				onClick={onToggle}
+				className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left transition-colors hover:bg-base-200/50"
+			>
+				<div className="flex items-center gap-2">
+					{/* 展開アイコン */}
+					{isOpen ? (
+						<ChevronDown className="h-4 w-4 text-base-content/60" />
+					) : (
+						<ChevronRight className="h-4 w-4 text-base-content/60" />
+					)}
+
+					{/* タイトル */}
+					<span className="font-medium text-base-content">{title}</span>
+
+					{/* 選択数バッジ */}
+					{selectedCount > 0 && (
+						<span className="badge badge-primary badge-sm">
+							{selectedCount}
+						</span>
+					)}
+				</div>
+
+				{/* クリアボタン */}
+				{selectedCount > 0 && onClear && (
+					<button
+						type="button"
+						onClick={handleClear}
+						className="rounded px-2 py-1 text-base-content/60 text-xs transition-colors hover:bg-base-300 hover:text-base-content"
+					>
+						クリア
+					</button>
+				)}
+			</button>
+
+			{/* コンテンツ（展開時のみ表示） */}
+			<div
+				className={cn(
+					"transition-all duration-200 ease-in-out",
+					isOpen ? "opacity-100" : "max-h-0 overflow-hidden opacity-0",
+				)}
+			>
+				<div className="px-4 pb-4">{children}</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/search/OriginalSongCountFilter.tsx
+++ b/apps/web/src/components/search/OriginalSongCountFilter.tsx
@@ -1,0 +1,97 @@
+import { Hash } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import type { SongCountFilter } from "./types";
+
+interface OriginalSongCountFilterProps {
+	/** 選択中の原曲数フィルター */
+	value: SongCountFilter;
+	/** 値変更ハンドラ */
+	onChange: (value: SongCountFilter) => void;
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+/** プリセットボタンの値 */
+const PRESET_VALUES: { label: string; value: SongCountFilter }[] = [
+	{ label: "すべて", value: "any" },
+	{ label: "1曲", value: "1" },
+	{ label: "2曲", value: "2" },
+	{ label: "3曲以上", value: "3+" },
+];
+
+/**
+ * 原曲数フィルター
+ *
+ * - プリセットボタン（すべて、1曲、2曲、3曲以上）
+ * - カスタム入力（○曲以上）
+ */
+export function OriginalSongCountFilter({
+	value,
+	onChange,
+	className,
+}: OriginalSongCountFilterProps) {
+	const [customValue, setCustomValue] = useState<string>("");
+
+	const handlePresetClick = (presetValue: SongCountFilter) => {
+		onChange(presetValue);
+		setCustomValue("");
+	};
+
+	const handleCustomChange = (inputValue: string) => {
+		setCustomValue(inputValue);
+		const num = Number.parseInt(inputValue, 10);
+		if (!Number.isNaN(num) && num > 0) {
+			onChange(num);
+		} else if (inputValue === "") {
+			onChange("any");
+		}
+	};
+
+	const isCustom = typeof value === "number" && value > 3;
+
+	return (
+		<div className={cn("space-y-3", className)}>
+			{/* プリセットボタン */}
+			<div className="flex flex-wrap items-center gap-2">
+				<Hash className="h-4 w-4 text-base-content/50" />
+				<div className="flex gap-1">
+					{PRESET_VALUES.map((preset) => {
+						const isActive = value === preset.value;
+						return (
+							<button
+								key={preset.label}
+								type="button"
+								onClick={() => handlePresetClick(preset.value)}
+								className={cn(
+									"btn btn-sm",
+									isActive && !isCustom ? "btn-primary" : "btn-ghost",
+								)}
+							>
+								{preset.label}
+							</button>
+						);
+					})}
+				</div>
+			</div>
+
+			{/* カスタム入力 */}
+			<div className="flex items-center gap-2">
+				<span className="text-base-content/60 text-sm">または</span>
+				<input
+					type="number"
+					min="1"
+					max="99"
+					value={customValue || (isCustom ? String(value) : "")}
+					onChange={(e) => handleCustomChange(e.target.value)}
+					placeholder="4"
+					className={cn(
+						"input input-sm input-bordered w-16",
+						isCustom && "input-primary",
+					)}
+				/>
+				<span className="text-sm">曲以上</span>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/search/OriginalSongFilter.tsx
+++ b/apps/web/src/components/search/OriginalSongFilter.tsx
@@ -1,0 +1,278 @@
+import { Check, Music, Plus, Search, X } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { NestedOption } from "../ui/nested-grouped-searchable-select";
+import type { SelectedOriginalSong } from "./types";
+
+interface OriginalSongFilterProps {
+	/** 選択中の原曲リスト */
+	selectedSongs: SelectedOriginalSong[];
+	/** 選択変更ハンドラ */
+	onChange: (songs: SelectedOriginalSong[]) => void;
+	/** 選択可能な原曲オプション */
+	options: NestedOption[];
+	/** カテゴリの表示順序 */
+	categoryOrder?: readonly string[];
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+interface WorkGroup {
+	workName: string;
+	options: NestedOption[];
+}
+
+interface CategoryGroup {
+	category: string;
+	works: WorkGroup[];
+}
+
+/**
+ * 原曲選択フィルター（3階層構造・複数選択対応）
+ *
+ * - カテゴリ → 作品 → 楽曲 の3階層表示
+ * - チェックボックスで複数選択可能
+ * - 検索機能付き
+ * - 選択中の原曲をチップで表示
+ */
+export function OriginalSongFilter({
+	selectedSongs,
+	onChange,
+	options,
+	categoryOrder,
+	className,
+}: OriginalSongFilterProps) {
+	const [search, setSearch] = useState("");
+	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+	// 選択中のIDセット
+	const selectedIds = useMemo(
+		() => new Set(selectedSongs.map((s) => s.id)),
+		[selectedSongs],
+	);
+
+	// 検索でフィルタリング
+	const filteredOptions = useMemo(() => {
+		if (!search) return options;
+		const lowerSearch = search.toLowerCase();
+		return options.filter(
+			(o) =>
+				o.label.toLowerCase().includes(lowerSearch) ||
+				o.category?.toLowerCase().includes(lowerSearch) ||
+				o.subgroup?.toLowerCase().includes(lowerSearch),
+		);
+	}, [options, search]);
+
+	// ネストされたグループ化オプション
+	const groupedOptions = useMemo(() => {
+		const categoryMap = new Map<string, Map<string, NestedOption[]>>();
+		const ungroupedLabel = "その他";
+
+		for (const option of filteredOptions) {
+			const category = option.category || ungroupedLabel;
+			const work = option.subgroup || ungroupedLabel;
+
+			let workMap = categoryMap.get(category);
+			if (!workMap) {
+				workMap = new Map();
+				categoryMap.set(category, workMap);
+			}
+
+			let opts = workMap.get(work);
+			if (!opts) {
+				opts = [];
+				workMap.set(work, opts);
+			}
+			opts.push(option);
+		}
+
+		const result: CategoryGroup[] = [];
+		for (const [category, workMap] of categoryMap) {
+			const works: WorkGroup[] = [];
+			for (const [workName, opts] of workMap) {
+				works.push({ workName, options: opts });
+			}
+			result.push({ category, works });
+		}
+
+		// カテゴリでソート
+		result.sort((a, b) => {
+			if (a.category === "その他") return 1;
+			if (b.category === "その他") return -1;
+			if (categoryOrder) {
+				const aIndex = categoryOrder.indexOf(a.category);
+				const bIndex = categoryOrder.indexOf(b.category);
+				if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
+				if (aIndex !== -1) return -1;
+				if (bIndex !== -1) return 1;
+			}
+			return a.category.localeCompare(b.category, "ja");
+		});
+
+		return result;
+	}, [filteredOptions, categoryOrder]);
+
+	// 原曲を選択/解除
+	const toggleSong = useCallback(
+		(option: NestedOption) => {
+			if (selectedIds.has(option.value)) {
+				// 解除
+				onChange(selectedSongs.filter((s) => s.id !== option.value));
+			} else {
+				// 選択
+				onChange([
+					...selectedSongs,
+					{
+						id: option.value,
+						name: option.label,
+						workName: option.subgroup,
+						categoryName: option.category,
+					},
+				]);
+			}
+		},
+		[selectedIds, selectedSongs, onChange],
+	);
+
+	// 選択中の原曲を削除
+	const removeSong = useCallback(
+		(id: string) => {
+			onChange(selectedSongs.filter((s) => s.id !== id));
+		},
+		[selectedSongs, onChange],
+	);
+
+	const hasOptions = groupedOptions.some((cat) =>
+		cat.works.some((work) => work.options.length > 0),
+	);
+
+	return (
+		<div className={cn("space-y-3", className)}>
+			{/* 選択中の原曲チップ */}
+			{selectedSongs.length > 0 && (
+				<div className="flex flex-wrap gap-2">
+					{selectedSongs.map((song) => (
+						<div
+							key={song.id}
+							className="badge badge-primary gap-1 pr-1 transition-all hover:opacity-80"
+						>
+							<Music className="h-3 w-3" />
+							<span className="max-w-[120px] truncate">{song.name}</span>
+							<button
+								type="button"
+								onClick={() => removeSong(song.id)}
+								className="ml-1 rounded-full p-0.5 transition-colors hover:bg-base-content/20"
+								aria-label={`${song.name}を削除`}
+							>
+								<X className="h-3 w-3" />
+							</button>
+						</div>
+					))}
+				</div>
+			)}
+
+			{/* 原曲追加ボタン/ドロップダウン */}
+			<div className="relative">
+				<button
+					type="button"
+					onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+					className="btn btn-outline btn-sm gap-2"
+				>
+					<Plus className="h-4 w-4" />
+					原曲を追加
+				</button>
+
+				{/* ドロップダウンパネル */}
+				{isDropdownOpen && (
+					<div className="absolute top-full left-0 z-50 mt-2 w-full max-w-md rounded-lg border border-base-300 bg-base-100 shadow-lg">
+						{/* ヘッダー */}
+						<div className="flex items-center justify-between border-base-300 border-b p-2">
+							<span className="font-medium text-sm">原曲を選択</span>
+							<button
+								type="button"
+								onClick={() => {
+									setIsDropdownOpen(false);
+									setSearch("");
+								}}
+								className="btn btn-ghost btn-xs btn-circle"
+								aria-label="閉じる"
+							>
+								<X className="h-4 w-4" />
+							</button>
+						</div>
+
+						{/* 検索欄 */}
+						<div className="border-base-300 border-b p-2">
+							<div className="relative">
+								<Search className="pointer-events-none absolute top-1/2 left-3 z-10 h-4 w-4 -translate-y-1/2 text-base-content/50" />
+								<input
+									type="text"
+									value={search}
+									onChange={(e) => setSearch(e.target.value)}
+									placeholder="原曲を検索..."
+									className="input input-sm input-bordered w-full pl-9"
+								/>
+							</div>
+						</div>
+
+						{/* オプションリスト */}
+						<div className="max-h-72 overflow-y-auto">
+							{!hasOptions ? (
+								<div className="p-4 text-center text-base-content/50">
+									該当する原曲がありません
+								</div>
+							) : (
+								groupedOptions.map((categoryGroup) => (
+									<div key={categoryGroup.category}>
+										{/* カテゴリヘッダー（Level 1） */}
+										<div className="sticky top-0 z-20 bg-base-300 px-4 py-2 font-semibold text-base-content text-sm">
+											{categoryGroup.category}
+										</div>
+
+										{categoryGroup.works.map((workGroup) => (
+											<div key={workGroup.workName}>
+												{/* 作品ヘッダー（Level 2） */}
+												<div className="sticky top-[36px] z-10 bg-base-200 px-4 py-1 pl-6 font-medium text-base-content/70 text-xs">
+													{workGroup.workName}
+												</div>
+
+												{/* 楽曲（Level 3） */}
+												{workGroup.options.map((option) => {
+													const isSelected = selectedIds.has(option.value);
+													return (
+														<button
+															key={option.value}
+															type="button"
+															onClick={() => toggleSong(option)}
+															className={cn(
+																"flex w-full items-center gap-2 py-2 pr-4 pl-10 text-left transition-colors hover:bg-base-200",
+																isSelected &&
+																	"bg-primary/10 font-medium text-primary",
+															)}
+														>
+															<div
+																className={cn(
+																	"flex h-4 w-4 shrink-0 items-center justify-center rounded border",
+																	isSelected
+																		? "border-primary bg-primary text-primary-content"
+																		: "border-base-300",
+																)}
+															>
+																{isSelected && <Check className="h-3 w-3" />}
+															</div>
+															<span>{option.label}</span>
+														</button>
+													);
+												})}
+											</div>
+										))}
+									</div>
+								))
+							)}
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/search/RoleCountFilter.tsx
+++ b/apps/web/src/components/search/RoleCountFilter.tsx
@@ -1,0 +1,155 @@
+import { cn } from "@/lib/utils";
+import type {
+	RoleCountEntry,
+	RoleCountFilters,
+	RoleCountMatchType,
+	RoleCountValue,
+} from "./types";
+
+interface RoleCountFilterProps {
+	/** 役割者数フィルター */
+	value: RoleCountFilters;
+	/** 変更ハンドラ */
+	onChange: (value: RoleCountFilters) => void;
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+interface CountSelectorProps {
+	label: string;
+	value: RoleCountValue;
+	onChange: (value: RoleCountValue) => void;
+}
+
+function CountSelector({ label, value, onChange }: CountSelectorProps) {
+	const isAny = value === "any";
+	const entry: RoleCountEntry | null = value !== "any" ? value : null;
+	const numericValue = entry?.count ?? "";
+	const matchType = entry?.matchType ?? "gte";
+
+	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const inputValue = e.target.value;
+		if (inputValue === "") {
+			onChange("any");
+		} else {
+			const num = Number.parseInt(inputValue, 10);
+			if (!Number.isNaN(num) && num >= 0) {
+				onChange({ count: num, matchType });
+			}
+		}
+	};
+
+	const handleMatchTypeChange = (newMatchType: RoleCountMatchType) => {
+		if (entry) {
+			onChange({ count: entry.count, matchType: newMatchType });
+		}
+	};
+
+	return (
+		<div className="form-control">
+			<label className="label py-1">
+				<span className="label-text text-sm">{label}</span>
+			</label>
+			<div className="flex items-center gap-2">
+				<button
+					type="button"
+					onClick={() => onChange("any")}
+					className={cn("btn btn-xs", isAny ? "btn-primary" : "btn-ghost")}
+				>
+					すべて
+				</button>
+				<input
+					type="number"
+					min="0"
+					value={numericValue}
+					onChange={handleInputChange}
+					placeholder="人数"
+					className="input input-xs input-bordered w-16"
+				/>
+				<span className="text-sm">人</span>
+				{entry && (
+					<div className="flex gap-1">
+						<button
+							type="button"
+							onClick={() => handleMatchTypeChange("exact")}
+							className={cn(
+								"btn btn-xs",
+								matchType === "exact" ? "btn-secondary" : "btn-ghost",
+							)}
+						>
+							一致
+						</button>
+						<button
+							type="button"
+							onClick={() => handleMatchTypeChange("gte")}
+							className={cn(
+								"btn btn-xs",
+								matchType === "gte" ? "btn-secondary" : "btn-ghost",
+							)}
+						>
+							以上
+						</button>
+						<button
+							type="button"
+							onClick={() => handleMatchTypeChange("lte")}
+							className={cn(
+								"btn btn-xs",
+								matchType === "lte" ? "btn-secondary" : "btn-ghost",
+							)}
+						>
+							以下
+						</button>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+/**
+ * 役割者数フィルター
+ *
+ * - ボーカル数
+ * - 作詞者数
+ * - 作曲者数
+ * - 編曲者数
+ *
+ * 任意の数値を入力可能
+ */
+export function RoleCountFilter({
+	value,
+	onChange,
+	className,
+}: RoleCountFilterProps) {
+	const handleChange = (
+		field: keyof RoleCountFilters,
+		newValue: RoleCountValue,
+	) => {
+		onChange({ ...value, [field]: newValue });
+	};
+
+	return (
+		<div className={cn("space-y-3", className)}>
+			<CountSelector
+				label="ボーカル数"
+				value={value.vocalistCount}
+				onChange={(v) => handleChange("vocalistCount", v)}
+			/>
+			<CountSelector
+				label="作詞者数"
+				value={value.lyricistCount}
+				onChange={(v) => handleChange("lyricistCount", v)}
+			/>
+			<CountSelector
+				label="作曲者数"
+				value={value.composerCount}
+				onChange={(v) => handleChange("composerCount", v)}
+			/>
+			<CountSelector
+				label="編曲者数"
+				value={value.arrangerCount}
+				onChange={(v) => handleChange("arrangerCount", v)}
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/components/search/SearchSyntaxHelp.tsx
+++ b/apps/web/src/components/search/SearchSyntaxHelp.tsx
@@ -1,0 +1,98 @@
+import { Check, Copy, HelpCircle } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { searchSyntaxHelp } from "./mock-data";
+
+interface SearchSyntaxHelpProps {
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+/**
+ * 検索構文ヘルプパネル
+ *
+ * - 使用可能な検索キーワードの一覧
+ * - 例をクリックでコピー
+ * - 折りたたみ可能
+ */
+export function SearchSyntaxHelp({ className }: SearchSyntaxHelpProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const [copiedKeyword, setCopiedKeyword] = useState<string | null>(null);
+
+	const handleCopy = async (text: string, keyword: string) => {
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopiedKeyword(keyword);
+			setTimeout(() => setCopiedKeyword(null), 2000);
+		} catch {
+			// コピー失敗時は何もしない
+		}
+	};
+
+	return (
+		<div className={cn("border-base-300 border-t", className)}>
+			{/* ヘッダー（クリックで開閉） */}
+			<button
+				type="button"
+				onClick={() => setIsOpen(!isOpen)}
+				className="flex w-full items-center gap-2 px-4 py-3 text-left text-base-content/60 transition-colors hover:bg-base-200/50 hover:text-base-content"
+			>
+				<HelpCircle className="h-4 w-4" />
+				<span className="text-sm">検索構文ヘルプ</span>
+			</button>
+
+			{/* コンテンツ */}
+			{isOpen && (
+				<div className="border-base-300 border-t bg-base-200/30 p-4">
+					<div className="overflow-x-auto">
+						<table className="table-zebra table-sm table">
+							<thead>
+								<tr>
+									<th>構文</th>
+									<th>説明</th>
+									<th>例</th>
+									<th className="w-10" />
+								</tr>
+							</thead>
+							<tbody>
+								{searchSyntaxHelp.map((item) => (
+									<tr key={item.keyword}>
+										<td>
+											<code className="rounded bg-base-300 px-1.5 py-0.5 text-xs">
+												{item.keyword}
+											</code>
+										</td>
+										<td className="text-base-content/70">{item.description}</td>
+										<td>
+											<code className="rounded bg-primary/10 px-1.5 py-0.5 text-primary text-xs">
+												{item.example}
+											</code>
+										</td>
+										<td>
+											<button
+												type="button"
+												onClick={() => handleCopy(item.example, item.keyword)}
+												className="btn btn-ghost btn-xs"
+												title="例をコピー"
+											>
+												{copiedKeyword === item.keyword ? (
+													<Check className="h-3 w-3 text-success" />
+												) : (
+													<Copy className="h-3 w-3" />
+												)}
+											</button>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+
+					<p className="mt-3 text-base-content/50 text-xs">
+						複数の条件はスペースで区切ってAND検索できます。
+					</p>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/search/TextSearchFilter.tsx
+++ b/apps/web/src/components/search/TextSearchFilter.tsx
@@ -1,0 +1,98 @@
+import { Album, Disc3, Music, User } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { TextSearchFilters } from "./types";
+
+interface TextSearchFilterProps {
+	/** テキスト検索フィルター */
+	value: TextSearchFilters;
+	/** 変更ハンドラ */
+	onChange: (value: TextSearchFilters) => void;
+	/** カスタムクラス名 */
+	className?: string;
+}
+
+interface InputFieldProps {
+	label: string;
+	placeholder: string;
+	value: string;
+	onChange: (value: string) => void;
+	icon: React.ReactNode;
+}
+
+function InputField({
+	label,
+	placeholder,
+	value,
+	onChange,
+	icon,
+}: InputFieldProps) {
+	return (
+		<div className="form-control w-full">
+			<label className="label py-1">
+				<span className="label-text flex items-center gap-1.5 text-sm">
+					{icon}
+					{label}
+				</span>
+			</label>
+			<input
+				type="text"
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={placeholder}
+				className="input input-sm input-bordered w-full"
+			/>
+		</div>
+	);
+}
+
+/**
+ * テキスト検索フィルター
+ *
+ * 直接入力で検索できるフィールド群:
+ * - アーティスト名（名義）
+ * - サークル名
+ * - 作品名（リリース名）
+ * - トラック名
+ */
+export function TextSearchFilter({
+	value,
+	onChange,
+	className,
+}: TextSearchFilterProps) {
+	const handleChange = (field: keyof TextSearchFilters, newValue: string) => {
+		onChange({ ...value, [field]: newValue });
+	};
+
+	return (
+		<div className={cn("grid gap-3 sm:grid-cols-2", className)}>
+			<InputField
+				label="アーティスト名"
+				placeholder="例: miko、ARM"
+				value={value.artistName}
+				onChange={(v) => handleChange("artistName", v)}
+				icon={<User className="h-3.5 w-3.5" />}
+			/>
+			<InputField
+				label="サークル名"
+				placeholder="例: IOSYS、幽閉サテライト"
+				value={value.circleName}
+				onChange={(v) => handleChange("circleName", v)}
+				icon={<Disc3 className="h-3.5 w-3.5" />}
+			/>
+			<InputField
+				label="作品名"
+				placeholder="例: 東方紅魔郷アレンジ"
+				value={value.albumName}
+				onChange={(v) => handleChange("albumName", v)}
+				icon={<Album className="h-3.5 w-3.5" />}
+			/>
+			<InputField
+				label="トラック名"
+				placeholder="例: Bad Apple!!"
+				value={value.trackName}
+				onChange={(v) => handleChange("trackName", v)}
+				icon={<Music className="h-3.5 w-3.5" />}
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/components/search/index.ts
+++ b/apps/web/src/components/search/index.ts
@@ -1,0 +1,66 @@
+// Components
+export {
+	AdvancedSearchModal,
+	type AdvancedSearchModalRef,
+} from "./AdvancedSearchModal";
+export { AdvancedSearchPanel } from "./AdvancedSearchPanel";
+export { ArtistRoleFilter } from "./ArtistRoleFilter";
+export { CircleFilter } from "./CircleFilter";
+export { DateRangeFilter } from "./DateRangeFilter";
+export { EventFilter } from "./EventFilter";
+export { createFilterChip, FilterChips } from "./FilterChips";
+export { FilterSection } from "./FilterSection";
+// Mock Data (for development)
+export type {
+	MockArtist,
+	MockCircle,
+	MockEvent,
+	MockEventSeries,
+	MockSearchResult,
+	SearchSyntaxItem,
+} from "./mock-data";
+export {
+	mockArtists,
+	mockCircles,
+	mockEventSeries,
+	mockEvents,
+	mockOriginalSongs,
+	mockSearchResults,
+	originalSongCategoryOrder,
+	popularSearches,
+	searchSyntaxHelp,
+} from "./mock-data";
+export { OriginalSongCountFilter } from "./OriginalSongCountFilter";
+export { OriginalSongFilter } from "./OriginalSongFilter";
+export { RoleCountFilter } from "./RoleCountFilter";
+export { SearchSyntaxHelp } from "./SearchSyntaxHelp";
+export { TextSearchFilter } from "./TextSearchFilter";
+// Types
+export type {
+	AdvancedSearchFilters,
+	AdvancedSearchParams,
+	CreditRole,
+	DateRange,
+	FilterChip,
+	FilterChipType,
+	FilterSectionState,
+	RoleCountFilters,
+	RoleCountValue,
+	SelectedArtist,
+	SelectedCircle,
+	SelectedEvent,
+	SelectedOriginalSong,
+	SongCountFilter,
+	TextSearchFilters,
+} from "./types";
+// Constants
+export {
+	CHIP_COLORS,
+	DEFAULT_FILTERS,
+	DEFAULT_ROLE_COUNTS,
+	DEFAULT_SECTION_STATE,
+	DEFAULT_TEXT_SEARCH,
+	ROLE_LABELS,
+} from "./types";
+// Hooks
+export { useFilterChips } from "./useFilterChips";

--- a/apps/web/src/components/search/mock-data.ts
+++ b/apps/web/src/components/search/mock-data.ts
@@ -1,0 +1,434 @@
+/**
+ * 詳細検索UIのモックデータ
+ * APIが実装されるまでの間、UIデモ用に使用
+ */
+
+import type { NestedOption } from "../ui/nested-grouped-searchable-select";
+
+/** 原曲のモックデータ（3階層選択用） */
+export const mockOriginalSongs: NestedOption[] = [
+	// PC-98 - 東方靈異伝
+	{
+		value: "01001001",
+		label: "A Sacred Lot",
+		category: "PC-98",
+		subgroup: "東方靈異伝",
+	},
+	{
+		value: "01001002",
+		label: "永遠の巫女",
+		category: "PC-98",
+		subgroup: "東方靈異伝",
+	},
+	{
+		value: "01001003",
+		label: "The Positive and Negative",
+		category: "PC-98",
+		subgroup: "東方靈異伝",
+	},
+	// PC-98 - 東方封魔録
+	{
+		value: "01002001",
+		label: "博麗 〜Eastern Wind",
+		category: "PC-98",
+		subgroup: "東方封魔録",
+	},
+	{
+		value: "01002002",
+		label: "End of Daylight",
+		category: "PC-98",
+		subgroup: "東方封魔録",
+	},
+	// Windows - 東方紅魔郷
+	{
+		value: "07001001",
+		label: "赤より紅い夢",
+		category: "Windows",
+		subgroup: "東方紅魔郷",
+	},
+	{
+		value: "07001002",
+		label: "ほおずきみたいに紅い魂",
+		category: "Windows",
+		subgroup: "東方紅魔郷",
+	},
+	{
+		value: "07001003",
+		label: "上海紅茶館　〜 Chinese Tea",
+		category: "Windows",
+		subgroup: "東方紅魔郷",
+	},
+	{
+		value: "07001004",
+		label: "U.N.オーエンは彼女なのか？",
+		category: "Windows",
+		subgroup: "東方紅魔郷",
+	},
+	// Windows - 東方妖々夢
+	{
+		value: "07002001",
+		label: "無何有の郷 〜 Deep Mountain",
+		category: "Windows",
+		subgroup: "東方妖々夢",
+	},
+	{
+		value: "07002002",
+		label: "幽霊楽団　〜 Phantom Ensemble",
+		category: "Windows",
+		subgroup: "東方妖々夢",
+	},
+	{
+		value: "07002003",
+		label: "東方妖々夢 〜 Ancient Temple",
+		category: "Windows",
+		subgroup: "東方妖々夢",
+	},
+	// Windows - 東方永夜抄
+	{
+		value: "07003001",
+		label: "永夜抄 〜 Eastern Night.",
+		category: "Windows",
+		subgroup: "東方永夜抄",
+	},
+	{
+		value: "07003002",
+		label: "竹取飛翔 〜 Lunatic Princess",
+		category: "Windows",
+		subgroup: "東方永夜抄",
+	},
+	// Windows - 東方花映塚
+	{
+		value: "07004001",
+		label: "花映塚 〜 Higan Retour",
+		category: "Windows",
+		subgroup: "東方花映塚",
+	},
+	// Windows - 東方風神録
+	{
+		value: "07005001",
+		label: "神々が恋した幻想郷",
+		category: "Windows",
+		subgroup: "東方風神録",
+	},
+	{
+		value: "07005002",
+		label: "ネイティブフェイス",
+		category: "Windows",
+		subgroup: "東方風神録",
+	},
+	// CD - 蓬莱人形
+	{
+		value: "08001001",
+		label: "蓬莱伝説",
+		category: "CD",
+		subgroup: "蓬莱人形",
+	},
+	// その他
+	{
+		value: "99001001",
+		label: "Bad Apple!!",
+		category: "その他",
+		subgroup: "作品なし",
+	},
+];
+
+/** カテゴリの表示順序 */
+export const originalSongCategoryOrder = [
+	"PC-98",
+	"Windows",
+	"CD",
+	"書籍",
+	"その他",
+];
+
+/** サークルのモックデータ */
+export interface MockCircle {
+	id: string;
+	name: string;
+	nameJa?: string;
+}
+
+export const mockCircles: MockCircle[] = [
+	{ id: "c001", name: "IOSYS", nameJa: "イオシス" },
+	{ id: "c002", name: "幽閉サテライト" },
+	{ id: "c003", name: "SOUND HOLIC" },
+	{ id: "c004", name: "Silver Forest" },
+	{ id: "c005", name: "Alstroemeria Records" },
+	{ id: "c006", name: "凋叶棕" },
+	{ id: "c007", name: "東方アレンジ" },
+	{ id: "c008", name: "魂音泉" },
+	{ id: "c009", name: "CROW'SCLAW" },
+	{ id: "c010", name: "FELT" },
+	{ id: "c011", name: "暁Records" },
+	{ id: "c012", name: "A-One" },
+];
+
+/** アーティストのモックデータ */
+export interface MockArtist {
+	id: string;
+	name: string;
+	nameJa?: string;
+}
+
+export const mockArtists: MockArtist[] = [
+	{ id: "a001", name: "miko", nameJa: "みこ" },
+	{ id: "a002", name: "ARM" },
+	{ id: "a003", name: "夕野ヨシミ" },
+	{ id: "a004", name: "senya" },
+	{ id: "a005", name: "Nana Takahashi", nameJa: "高橋菜々" },
+	{ id: "a006", name: "あよ" },
+	{ id: "a007", name: "709sec." },
+	{ id: "a008", name: "Stack Bros." },
+	{ id: "a009", name: "D.watt" },
+	{ id: "a010", name: "あさな" },
+	{ id: "a011", name: "小峠舞" },
+	{ id: "a012", name: "IZNA" },
+	{ id: "a013", name: "山本椛" },
+	{ id: "a014", name: "Vivienne" },
+	{ id: "a015", name: "めらみぽっぷ" },
+];
+
+/** イベントシリーズのモックデータ */
+export interface MockEventSeries {
+	id: string;
+	name: string;
+}
+
+export interface MockEvent {
+	id: string;
+	name: string;
+	seriesId: string;
+	seriesName: string;
+	date?: string;
+}
+
+export const mockEventSeries: MockEventSeries[] = [
+	{ id: "es001", name: "コミックマーケット" },
+	{ id: "es002", name: "博麗神社例大祭" },
+	{ id: "es003", name: "東方紅楼夢" },
+	{ id: "es004", name: "M3" },
+];
+
+export const mockEvents: MockEvent[] = [
+	// コミックマーケット
+	{
+		id: "e001",
+		name: "C103",
+		seriesId: "es001",
+		seriesName: "コミックマーケット",
+		date: "2023-12",
+	},
+	{
+		id: "e002",
+		name: "C102",
+		seriesId: "es001",
+		seriesName: "コミックマーケット",
+		date: "2023-08",
+	},
+	{
+		id: "e003",
+		name: "C101",
+		seriesId: "es001",
+		seriesName: "コミックマーケット",
+		date: "2022-12",
+	},
+	{
+		id: "e004",
+		name: "C100",
+		seriesId: "es001",
+		seriesName: "コミックマーケット",
+		date: "2022-08",
+	},
+	{
+		id: "e005",
+		name: "C99",
+		seriesId: "es001",
+		seriesName: "コミックマーケット",
+		date: "2021-12",
+	},
+	// 博麗神社例大祭
+	{
+		id: "e010",
+		name: "例大祭20",
+		seriesId: "es002",
+		seriesName: "博麗神社例大祭",
+		date: "2023-05",
+	},
+	{
+		id: "e011",
+		name: "例大祭19",
+		seriesId: "es002",
+		seriesName: "博麗神社例大祭",
+		date: "2022-05",
+	},
+	// 東方紅楼夢
+	{
+		id: "e020",
+		name: "紅楼夢19",
+		seriesId: "es003",
+		seriesName: "東方紅楼夢",
+		date: "2023-10",
+	},
+	{
+		id: "e021",
+		name: "紅楼夢18",
+		seriesId: "es003",
+		seriesName: "東方紅楼夢",
+		date: "2022-10",
+	},
+	// M3
+	{
+		id: "e030",
+		name: "M3-2023秋",
+		seriesId: "es004",
+		seriesName: "M3",
+		date: "2023-10",
+	},
+	{
+		id: "e031",
+		name: "M3-2023春",
+		seriesId: "es004",
+		seriesName: "M3",
+		date: "2023-04",
+	},
+];
+
+/** 検索構文のヘルプ情報 */
+export interface SearchSyntaxItem {
+	keyword: string;
+	description: string;
+	example: string;
+}
+
+export const searchSyntaxHelp: SearchSyntaxItem[] = [
+	{
+		keyword: "arranger:",
+		description: "編曲者で検索",
+		example: "arranger:ARM",
+	},
+	{
+		keyword: "vocalist:",
+		description: "ボーカルで検索",
+		example: "vocalist:miko",
+	},
+	{
+		keyword: "lyricist:",
+		description: "作詞者で検索",
+		example: "lyricist:夕野ヨシミ",
+	},
+	{
+		keyword: "circle:",
+		description: "サークル名で検索",
+		example: "circle:IOSYS",
+	},
+	{
+		keyword: "originalsong:",
+		description: "原曲名で検索",
+		example: "originalsong:大吉キトゥン",
+	},
+	{
+		keyword: "year:",
+		description: "リリース年で検索",
+		example: "year:2023",
+	},
+	{
+		keyword: "songcount:",
+		description: "原曲数で検索",
+		example: "songcount:2",
+	},
+	{
+		keyword: "songcount:>=",
+		description: "原曲数（以上）で検索",
+		example: "songcount:>=3",
+	},
+];
+
+/** 検索結果のモックデータ */
+export interface MockSearchResult {
+	id: string;
+	type: "artist" | "circle" | "track";
+	title: string;
+	subtitle: string;
+}
+
+export const mockSearchResults: MockSearchResult[] = [
+	// Circles
+	{
+		id: "c001",
+		type: "circle",
+		title: "IOSYS",
+		subtitle: "東方アレンジサークル",
+	},
+	{
+		id: "c002",
+		type: "circle",
+		title: "幽閉サテライト",
+		subtitle: "東方ボーカルアレンジ",
+	},
+	{
+		id: "c003",
+		type: "circle",
+		title: "SOUND HOLIC",
+		subtitle: "ユーロビート、トランス系アレンジ",
+	},
+	// Artists
+	{ id: "a001", type: "artist", title: "miko", subtitle: "IOSYS所属ボーカル" },
+	{
+		id: "a002",
+		type: "artist",
+		title: "ARM",
+		subtitle: "IOSYS代表・アレンジャー",
+	},
+	{
+		id: "a003",
+		type: "artist",
+		title: "夕野ヨシミ",
+		subtitle: "作詞家・シンガー",
+	},
+	{
+		id: "a004",
+		type: "artist",
+		title: "senya",
+		subtitle: "幽閉サテライト所属",
+	},
+	// Tracks
+	{
+		id: "t001",
+		type: "track",
+		title: "チルノのパーフェクトさんすう教室",
+		subtitle: "IOSYS - U.N.オーエンは彼女なのか？",
+	},
+	{
+		id: "t002",
+		type: "track",
+		title: "Bad Apple!! feat. nomico",
+		subtitle: "Alstroemeria Records - Bad Apple!!",
+	},
+	{
+		id: "t003",
+		type: "track",
+		title: "ナイト・オブ・ナイツ",
+		subtitle: "COOL&CREATE - 月時計 〜 ルナ・ダイアル",
+	},
+	{
+		id: "t004",
+		type: "track",
+		title: "魔理沙は大変なものを盗んでいきました",
+		subtitle: "IOSYS - 人形裁判 〜 人の形弄びし少女",
+	},
+	{
+		id: "t005",
+		type: "track",
+		title: "色は匂へど散りぬるを",
+		subtitle: "幽閉サテライト - 亡き王女の為のセプテット",
+	},
+];
+
+/** 人気の検索キーワード */
+export const popularSearches = [
+	"Bad Apple!!",
+	"IOSYS",
+	"ナイト・オブ・ナイツ",
+	"ZUN",
+	"幽閉サテライト",
+];

--- a/apps/web/src/components/search/types.ts
+++ b/apps/web/src/components/search/types.ts
@@ -1,0 +1,222 @@
+/**
+ * 詳細検索フィルターの型定義
+ */
+
+/** 検索カテゴリ */
+export type SearchCategory = "all" | "artist" | "circle" | "track";
+
+/** クレジットロール（役割） */
+export type CreditRole =
+	| "vocalist"
+	| "lyricist"
+	| "arranger"
+	| "composer"
+	| "performer"
+	| "mixer"
+	| "producer";
+
+/** 原曲数フィルターの値 */
+export type SongCountFilter = "any" | "1" | "2" | "3+" | number;
+
+/** 選択された原曲 */
+export interface SelectedOriginalSong {
+	id: string;
+	name: string;
+	workName?: string;
+	categoryName?: string;
+}
+
+/** 選択されたサークル */
+export interface SelectedCircle {
+	id: string;
+	name: string;
+}
+
+/** 選択されたアーティスト（役割付き） */
+export interface SelectedArtist {
+	id: string;
+	name: string;
+	role: CreditRole;
+}
+
+/** 選択されたイベント */
+export interface SelectedEvent {
+	id: string;
+	name: string;
+	seriesName?: string;
+}
+
+/** 日付範囲 */
+export interface DateRange {
+	from?: string; // YYYY-MM形式
+	to?: string; // YYYY-MM形式
+}
+
+/** テキスト検索フィルター（直接入力） */
+export interface TextSearchFilters {
+	artistName: string;
+	circleName: string;
+	albumName: string;
+	trackName: string;
+}
+
+/** 役割者数のマッチタイプ */
+export type RoleCountMatchType = "exact" | "gte" | "lte"; // exact = 一致, gte = 以上, lte = 以下
+
+/** 役割者数フィルターのエントリ */
+export interface RoleCountEntry {
+	count: number;
+	matchType: RoleCountMatchType;
+}
+
+/** 役割者数フィルターの値 */
+export type RoleCountValue = "any" | RoleCountEntry;
+
+/** 役割者数フィルター */
+export interface RoleCountFilters {
+	vocalistCount: RoleCountValue;
+	lyricistCount: RoleCountValue;
+	composerCount: RoleCountValue;
+	arrangerCount: RoleCountValue;
+}
+
+/** 詳細検索フィルター */
+export interface AdvancedSearchFilters {
+	/** テキスト検索（直接入力） */
+	textSearch: TextSearchFilters;
+	/** 選択された原曲 */
+	originalSongs: SelectedOriginalSong[];
+	/** 選択されたアーティスト（役割付き） */
+	artists: SelectedArtist[];
+	/** 選択されたサークル */
+	circles: SelectedCircle[];
+	/** 役割者数フィルター */
+	roleCounts: RoleCountFilters;
+	/** 原曲数フィルター */
+	songCount: SongCountFilter;
+	/** 日付範囲 */
+	dateRange: DateRange;
+	/** 選択されたイベント */
+	event: SelectedEvent | null;
+}
+
+/** URLパラメータ用の検索パラメータ */
+export interface AdvancedSearchParams {
+	// 基本
+	q?: string;
+	category?: SearchCategory;
+
+	// 詳細フィルター
+	originals?: string[]; // 原曲ID配列
+	circles?: string[]; // サークルID配列
+	vocalist?: string[]; // ボーカルアーティストID
+	lyricist?: string[]; // 作詞者ID
+	arranger?: string[]; // 編曲者ID
+	composer?: string[]; // 作曲者ID
+
+	// 期間
+	dateFrom?: string; // YYYY-MM
+	dateTo?: string; // YYYY-MM
+	event?: string; // イベントID
+
+	// その他
+	songCount?: SongCountFilter;
+
+	// UI状態
+	mode?: "simple" | "advanced";
+}
+
+/** フィルターチップの種類 */
+export type FilterChipType =
+	| "textSearch"
+	| "originalSong"
+	| "artist"
+	| "circle"
+	| "roleCount"
+	| "songCount"
+	| "date"
+	| "event";
+
+/** フィルターチップのデータ */
+export interface FilterChip {
+	id: string;
+	type: FilterChipType;
+	label: string;
+	sublabel?: string;
+	value: string | number;
+}
+
+/** フィルターセクションの開閉状態 */
+export interface FilterSectionState {
+	textSearch: boolean;
+	originalSongs: boolean;
+	artists: boolean;
+	circles: boolean;
+	roleCounts: boolean;
+	songCount: boolean;
+	dateRange: boolean;
+	event: boolean;
+}
+
+/** 役割ラベルのマッピング */
+export const ROLE_LABELS: Record<CreditRole, string> = {
+	vocalist: "ボーカル",
+	lyricist: "作詞",
+	arranger: "編曲",
+	composer: "作曲",
+	performer: "演奏",
+	mixer: "ミキサー",
+	producer: "プロデューサー",
+};
+
+/** フィルターチップの色マッピング */
+export const CHIP_COLORS: Record<FilterChipType, string> = {
+	textSearch: "badge-neutral",
+	originalSong: "badge-primary",
+	artist: "badge-accent",
+	circle: "badge-secondary",
+	roleCount: "badge-warning",
+	songCount: "badge-ghost",
+	date: "badge-info",
+	event: "badge-info",
+};
+
+/** デフォルトのテキスト検索状態 */
+export const DEFAULT_TEXT_SEARCH: TextSearchFilters = {
+	artistName: "",
+	circleName: "",
+	albumName: "",
+	trackName: "",
+};
+
+/** デフォルトの役割者数状態 */
+export const DEFAULT_ROLE_COUNTS: RoleCountFilters = {
+	vocalistCount: "any",
+	lyricistCount: "any",
+	composerCount: "any",
+	arrangerCount: "any",
+};
+
+/** デフォルトのフィルター状態 */
+export const DEFAULT_FILTERS: AdvancedSearchFilters = {
+	textSearch: DEFAULT_TEXT_SEARCH,
+	originalSongs: [],
+	artists: [],
+	circles: [],
+	roleCounts: DEFAULT_ROLE_COUNTS,
+	songCount: "any",
+	dateRange: {},
+	event: null,
+};
+
+/** デフォルトのセクション開閉状態 */
+export const DEFAULT_SECTION_STATE: FilterSectionState = {
+	textSearch: true, // デフォルト展開
+	originalSongs: true, // デフォルト展開
+	artists: false,
+	circles: false,
+	roleCounts: false,
+	songCount: false,
+	dateRange: false,
+	event: false,
+};

--- a/apps/web/src/components/search/useFilterChips.ts
+++ b/apps/web/src/components/search/useFilterChips.ts
@@ -1,0 +1,243 @@
+import { useCallback, useMemo } from "react";
+import { createFilterChip } from "./FilterChips";
+import type { AdvancedSearchFilters, FilterChip } from "./types";
+import { DEFAULT_FILTERS, ROLE_LABELS } from "./types";
+
+/**
+ * フィルターチップの生成・削除ロジックを提供するカスタムフック
+ *
+ * 詳細検索モーダルと検索ページの両方で使用可能
+ */
+export function useFilterChips(
+	filters: AdvancedSearchFilters,
+	onFiltersChange: (filters: AdvancedSearchFilters) => void,
+) {
+	// フィルターチップの生成
+	const chips = useMemo<FilterChip[]>(() => {
+		const result: FilterChip[] = [];
+
+		// テキスト検索
+		if (filters.textSearch.artistName) {
+			result.push(
+				createFilterChip(
+					"textSearch",
+					"artistName",
+					`アーティスト: ${filters.textSearch.artistName}`,
+					"artistName",
+				),
+			);
+		}
+		if (filters.textSearch.circleName) {
+			result.push(
+				createFilterChip(
+					"textSearch",
+					"circleName",
+					`サークル: ${filters.textSearch.circleName}`,
+					"circleName",
+				),
+			);
+		}
+		if (filters.textSearch.albumName) {
+			result.push(
+				createFilterChip(
+					"textSearch",
+					"albumName",
+					`作品: ${filters.textSearch.albumName}`,
+					"albumName",
+				),
+			);
+		}
+		if (filters.textSearch.trackName) {
+			result.push(
+				createFilterChip(
+					"textSearch",
+					"trackName",
+					`トラック: ${filters.textSearch.trackName}`,
+					"trackName",
+				),
+			);
+		}
+
+		// 原曲
+		for (const song of filters.originalSongs) {
+			result.push(
+				createFilterChip("originalSong", song.id, song.name, song.id),
+			);
+		}
+
+		// アーティスト
+		for (const artist of filters.artists) {
+			result.push(
+				createFilterChip(
+					"artist",
+					`${artist.role}-${artist.id}`,
+					`${ROLE_LABELS[artist.role]}: ${artist.name}`,
+					artist.id,
+				),
+			);
+		}
+
+		// サークル
+		for (const circle of filters.circles) {
+			result.push(
+				createFilterChip("circle", circle.id, circle.name, circle.id),
+			);
+		}
+
+		// 役割者数
+		const getMatchSuffix = (matchType: "exact" | "gte" | "lte") => {
+			if (matchType === "gte") return "以上";
+			if (matchType === "lte") return "以下";
+			return "";
+		};
+		if (filters.roleCounts.vocalistCount !== "any") {
+			const entry = filters.roleCounts.vocalistCount;
+			const suffix = getMatchSuffix(entry.matchType);
+			const label = `ボーカル: ${entry.count}人${suffix}`;
+			result.push(createFilterChip("roleCount", "vocalist", label, "vocalist"));
+		}
+		if (filters.roleCounts.lyricistCount !== "any") {
+			const entry = filters.roleCounts.lyricistCount;
+			const suffix = getMatchSuffix(entry.matchType);
+			const label = `作詞者: ${entry.count}人${suffix}`;
+			result.push(createFilterChip("roleCount", "lyricist", label, "lyricist"));
+		}
+		if (filters.roleCounts.composerCount !== "any") {
+			const entry = filters.roleCounts.composerCount;
+			const suffix = getMatchSuffix(entry.matchType);
+			const label = `作曲者: ${entry.count}人${suffix}`;
+			result.push(createFilterChip("roleCount", "composer", label, "composer"));
+		}
+		if (filters.roleCounts.arrangerCount !== "any") {
+			const entry = filters.roleCounts.arrangerCount;
+			const suffix = getMatchSuffix(entry.matchType);
+			const label = `編曲者: ${entry.count}人${suffix}`;
+			result.push(createFilterChip("roleCount", "arranger", label, "arranger"));
+		}
+
+		// 原曲数
+		if (filters.songCount !== "any") {
+			const label =
+				typeof filters.songCount === "number"
+					? `${filters.songCount}曲以上`
+					: filters.songCount === "3+"
+						? "3曲以上"
+						: `${filters.songCount}曲`;
+			result.push(
+				createFilterChip("songCount", "count", label, filters.songCount),
+			);
+		}
+
+		// 日付範囲
+		if (filters.dateRange.from || filters.dateRange.to) {
+			const from = filters.dateRange.from || "...";
+			const to = filters.dateRange.to || "...";
+			result.push(
+				createFilterChip("date", "range", `${from} 〜 ${to}`, "date"),
+			);
+		}
+
+		// イベント
+		if (filters.event) {
+			result.push(
+				createFilterChip(
+					"event",
+					filters.event.id,
+					filters.event.name,
+					filters.event.id,
+					filters.event.seriesName,
+				),
+			);
+		}
+
+		return result;
+	}, [filters]);
+
+	// チップ削除
+	const handleRemoveChip = useCallback(
+		(chip: FilterChip) => {
+			switch (chip.type) {
+				case "textSearch":
+					onFiltersChange({
+						...filters,
+						textSearch: {
+							...filters.textSearch,
+							[chip.value as keyof typeof filters.textSearch]: "",
+						},
+					});
+					break;
+				case "originalSong":
+					onFiltersChange({
+						...filters,
+						originalSongs: filters.originalSongs.filter(
+							(s) => s.id !== chip.value,
+						),
+					});
+					break;
+				case "artist":
+					onFiltersChange({
+						...filters,
+						artists: filters.artists.filter(
+							(a) => `artist-${a.role}-${a.id}` !== chip.id,
+						),
+					});
+					break;
+				case "circle":
+					onFiltersChange({
+						...filters,
+						circles: filters.circles.filter((c) => c.id !== chip.value),
+					});
+					break;
+				case "roleCount":
+					if (chip.value === "vocalist") {
+						onFiltersChange({
+							...filters,
+							roleCounts: { ...filters.roleCounts, vocalistCount: "any" },
+						});
+					} else if (chip.value === "lyricist") {
+						onFiltersChange({
+							...filters,
+							roleCounts: { ...filters.roleCounts, lyricistCount: "any" },
+						});
+					} else if (chip.value === "composer") {
+						onFiltersChange({
+							...filters,
+							roleCounts: { ...filters.roleCounts, composerCount: "any" },
+						});
+					} else if (chip.value === "arranger") {
+						onFiltersChange({
+							...filters,
+							roleCounts: { ...filters.roleCounts, arrangerCount: "any" },
+						});
+					}
+					break;
+				case "songCount":
+					onFiltersChange({
+						...filters,
+						songCount: "any",
+					});
+					break;
+				case "date":
+					onFiltersChange({
+						...filters,
+						dateRange: {},
+					});
+					break;
+				case "event":
+					onFiltersChange({
+						...filters,
+						event: null,
+					});
+					break;
+			}
+		},
+		[filters, onFiltersChange],
+	);
+
+	// すべてクリア
+	const handleClearAll = useCallback(() => {
+		onFiltersChange(DEFAULT_FILTERS);
+	}, [onFiltersChange]);
+
+	return { chips, handleRemoveChip, handleClearAll };
+}

--- a/apps/web/src/components/ui/nested-grouped-searchable-select.tsx
+++ b/apps/web/src/components/ui/nested-grouped-searchable-select.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 
-interface NestedOption {
+export interface NestedOption {
 	value: string;
 	label: string;
 	category?: string;


### PR DESCRIPTION
## 概要

詳細検索機能のコンポーネント群を新規作成し、選択したフィルターを検索フォーム下部にチップとして表示する機能を実装。

## 変更内容

### 新規コンポーネント
* **AdvancedSearchModal** - 詳細検索モーダル（全フィルターを統合）
* **AdvancedSearchPanel** - 詳細検索パネル（代替UI）
* **FilterChips** - 選択中のフィルターをチップ表示
* **FilterSection** - アコーディオン形式のフィルターセクション

### フィルターコンポーネント
* **TextSearchFilter** - テキスト検索（アーティスト名、サークル名、作品名、トラック名）
* **OriginalSongFilter** - 原曲選択（カテゴリ別グループ化）
* **ArtistRoleFilter** - 役割別アーティスト選択（ボーカル、作詞、作曲、編曲）
* **CircleFilter** - サークル選択
* **RoleCountFilter** - 役割者数フィルター（任意の数値入力、一致/以上の比較）
* **OriginalSongCountFilter** - 原曲数フィルター
* **DateRangeFilter** - リリース日範囲
* **EventFilter** - イベント選択

### ロジック共通化
* **useFilterChips** - チップ生成・削除ロジックをカスタムフックとして抽出
  - モーダル内と検索ページで同じロジックを共有
  - チップから直接フィルターを削除可能

### 検索ページの改善
* 検索フォーム下部に選択中のフィルターをチップ表示
* フィルターが選択されていない場合のみ「人気の検索」を表示

## 影響範囲

* `/search` ページ
* 新規追加のコンポーネント群（`apps/web/src/components/search/`）

## 補足事項

* モックデータを使用しているため、実際のAPI連携は別途実装が必要