### PR TITLE
feat: サークル一覧・詳細の公開APIを実装

### DIFF
--- a/apps/server/src/routes/public/circles.ts
+++ b/apps/server/src/routes/public/circles.ts
@@ -1,0 +1,545 @@
+import {
+	and,
+	artists,
+	asc,
+	circleLinks,
+	circles,
+	count,
+	countDistinct,
+	creditRoles,
+	db,
+	desc,
+	eq,
+	events,
+	inArray,
+	like,
+	officialSongs,
+	or,
+	platforms,
+	releaseCircles,
+	releases,
+	sql,
+	trackCreditRoles,
+	trackCredits,
+	trackOfficialSongs,
+	tracks,
+} from "@thac/db";
+import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../constants/error-messages";
+import { handleDbError } from "../../utils/api-error";
+import {
+	CACHE_TTL,
+	cacheKeys,
+	getCache,
+	setCache,
+	setCacheHeaders,
+} from "../../utils/cache";
+
+const circlesRouter = new Hono();
+
+// 頭文字の文字種マッピング
+const SCRIPT_CATEGORY_MAP: Record<string, string[]> = {
+	alphabet: ["latin"],
+	kana: ["hiragana", "katakana"],
+	kanji: ["kanji"],
+	other: ["digit", "symbol", "other"],
+};
+
+// かな行のパターン
+const KANA_ROW_PATTERNS: Record<string, string[]> = {
+	あ: ["あ", "い", "う", "え", "お", "ア", "イ", "ウ", "エ", "オ"],
+	か: ["か", "き", "く", "け", "こ", "カ", "キ", "ク", "ケ", "コ"],
+	さ: ["さ", "し", "す", "せ", "そ", "サ", "シ", "ス", "セ", "ソ"],
+	た: ["た", "ち", "つ", "て", "と", "タ", "チ", "ツ", "テ", "ト"],
+	な: ["な", "に", "ぬ", "ね", "の", "ナ", "ニ", "ヌ", "ネ", "ノ"],
+	は: ["は", "ひ", "ふ", "へ", "ほ", "ハ", "ヒ", "フ", "ヘ", "ホ"],
+	ま: ["ま", "み", "む", "め", "も", "マ", "ミ", "ム", "メ", "モ"],
+	や: ["や", "ゆ", "よ", "ヤ", "ユ", "ヨ"],
+	ら: ["ら", "り", "る", "れ", "ろ", "ラ", "リ", "ル", "レ", "ロ"],
+	わ: ["わ", "を", "ん", "ワ", "ヲ", "ン"],
+};
+
+/**
+ * GET /api/public/circles
+ * サークル一覧を取得（ページネーション、フィルタ、検索対応）
+ */
+circlesRouter.get("/", async (c) => {
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const initialScript = c.req.query("initialScript"); // all | alphabet | kana | kanji | other
+		const initial = c.req.query("initial"); // A-Z
+		const row = c.req.query("row"); // あ, か, さ, ...
+		const search = c.req.query("search");
+		const sortBy = c.req.query("sortBy") || "releaseCount";
+		const sortOrder = c.req.query("sortOrder") || "desc";
+
+		const cacheKey = cacheKeys.circlesList({
+			page,
+			limit,
+			initialScript,
+			initial,
+			row,
+			search,
+			sortBy,
+			sortOrder,
+		});
+
+		// キャッシュチェック
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.CIRCLES_LIST });
+			return c.json(cached);
+		}
+
+		const offset = (page - 1) * limit;
+
+		// 条件を構築
+		const conditions = [];
+
+		// 文字種フィルター
+		if (initialScript && initialScript !== "all") {
+			const scripts = SCRIPT_CATEGORY_MAP[initialScript];
+			if (scripts) {
+				conditions.push(inArray(circles.initialScript, scripts));
+			}
+		}
+
+		// アルファベット頭文字フィルター
+		if (initial && /^[A-Z]$/.test(initial)) {
+			conditions.push(eq(circles.nameInitial, initial));
+		}
+
+		// かな行フィルター
+		if (row && KANA_ROW_PATTERNS[row]) {
+			const kanaChars = KANA_ROW_PATTERNS[row];
+			conditions.push(inArray(circles.nameInitial, kanaChars));
+		}
+
+		// 検索
+		if (search) {
+			const searchPattern = `%${search}%`;
+			conditions.push(
+				or(
+					like(circles.name, searchPattern),
+					like(circles.nameJa, searchPattern),
+					like(circles.nameEn, searchPattern),
+				),
+			);
+		}
+
+		const whereCondition =
+			conditions.length > 0 ? and(...conditions) : undefined;
+
+		// releaseCountサブクエリ
+		const releaseCountSubquery = db
+			.select({ count: countDistinct(releaseCircles.releaseId) })
+			.from(releaseCircles)
+			.where(eq(releaseCircles.circleId, circles.id));
+
+		// trackCountサブクエリ
+		const trackCountSubquery = db
+			.select({ count: countDistinct(tracks.id) })
+			.from(releaseCircles)
+			.innerJoin(releases, eq(releaseCircles.releaseId, releases.id))
+			.innerJoin(tracks, eq(tracks.releaseId, releases.id))
+			.where(eq(releaseCircles.circleId, circles.id));
+
+		// ソート条件を構築
+		const sortColumn =
+			sortBy === "name" ? circles.name : sql<number>`(${releaseCountSubquery})`;
+		const orderByClause =
+			sortOrder === "asc" ? asc(sortColumn) : desc(sortColumn);
+
+		// データ取得
+		const [data, totalResult] = await Promise.all([
+			db
+				.select({
+					id: circles.id,
+					name: circles.name,
+					nameJa: circles.nameJa,
+					nameEn: circles.nameEn,
+					sortName: circles.sortName,
+					nameInitial: circles.nameInitial,
+					initialScript: circles.initialScript,
+					releaseCount: sql<number>`(${releaseCountSubquery})`,
+					trackCount: sql<number>`(${trackCountSubquery})`,
+				})
+				.from(circles)
+				.where(whereCondition)
+				.orderBy(orderByClause)
+				.limit(limit)
+				.offset(offset),
+			db.select({ count: count() }).from(circles).where(whereCondition),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		const response = {
+			data,
+			total,
+			page,
+			limit,
+		};
+
+		// キャッシュに保存
+		setCache(cacheKey, response, CACHE_TTL.CIRCLES_LIST);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.CIRCLES_LIST });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/circles");
+	}
+});
+
+/**
+ * GET /api/public/circles/:id
+ * サークル詳細を取得（リンク情報、統計情報含む）
+ */
+circlesRouter.get("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+		const cacheKey = cacheKeys.circleDetail(id);
+
+		// キャッシュチェック
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.CIRCLE_DETAIL });
+			return c.json(cached);
+		}
+
+		// サークル基本情報を取得
+		const circleResult = await db
+			.select({
+				id: circles.id,
+				name: circles.name,
+				nameJa: circles.nameJa,
+				nameEn: circles.nameEn,
+				sortName: circles.sortName,
+				nameInitial: circles.nameInitial,
+				initialScript: circles.initialScript,
+				notes: circles.notes,
+			})
+			.from(circles)
+			.where(eq(circles.id, id))
+			.limit(1);
+
+		if (circleResult.length === 0) {
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
+		}
+
+		const circle = circleResult[0];
+
+		// 関連データを並列取得
+		const [linksData, statsData] = await Promise.all([
+			// 外部リンク
+			db
+				.select({
+					id: circleLinks.id,
+					platformCode: circleLinks.platformCode,
+					platformName: platforms.name,
+					url: circleLinks.url,
+					isOfficial: circleLinks.isOfficial,
+					isPrimary: circleLinks.isPrimary,
+				})
+				.from(circleLinks)
+				.leftJoin(platforms, eq(circleLinks.platformCode, platforms.code))
+				.where(eq(circleLinks.circleId, id)),
+
+			// 統計情報
+			db
+				.select({
+					releaseCount: countDistinct(releaseCircles.releaseId),
+					trackCount: countDistinct(tracks.id),
+				})
+				.from(releaseCircles)
+				.leftJoin(releases, eq(releaseCircles.releaseId, releases.id))
+				.leftJoin(tracks, eq(tracks.releaseId, releases.id))
+				.where(eq(releaseCircles.circleId, id)),
+		]);
+
+		const stats = statsData[0] ?? { releaseCount: 0, trackCount: 0 };
+
+		const response = {
+			...circle,
+			links: linksData,
+			stats: {
+				releaseCount: stats.releaseCount,
+				trackCount: stats.trackCount,
+			},
+		};
+
+		// キャッシュに保存
+		setCache(cacheKey, response, CACHE_TTL.CIRCLE_DETAIL);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.CIRCLE_DETAIL });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/circles/:id");
+	}
+});
+
+/**
+ * GET /api/public/circles/:id/releases
+ * サークルのリリース一覧を取得（遅延読み込み用）
+ */
+circlesRouter.get("/:id/releases", async (c) => {
+	try {
+		const circleId = c.req.param("id");
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+
+		const cacheKey = cacheKeys.circleReleases({ circleId, page, limit });
+
+		// キャッシュチェック
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.CIRCLE_RELEASES });
+			return c.json(cached);
+		}
+
+		// サークル存在チェック
+		const circleExists = await db
+			.select({ id: circles.id })
+			.from(circles)
+			.where(eq(circles.id, circleId))
+			.limit(1);
+
+		if (circleExists.length === 0) {
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
+		}
+
+		const offset = (page - 1) * limit;
+
+		// トラック数サブクエリ
+		const trackCountSubquery = db
+			.select({ count: count() })
+			.from(tracks)
+			.where(eq(tracks.releaseId, releases.id));
+
+		// データ取得
+		const [data, totalResult] = await Promise.all([
+			db
+				.select({
+					id: releases.id,
+					name: releases.name,
+					nameJa: releases.nameJa,
+					releaseDate: releases.releaseDate,
+					releaseType: releases.releaseType,
+					participationType: releaseCircles.participationType,
+					eventId: events.id,
+					eventName: events.name,
+					trackCount: sql<number>`(${trackCountSubquery})`,
+				})
+				.from(releaseCircles)
+				.innerJoin(releases, eq(releaseCircles.releaseId, releases.id))
+				.leftJoin(events, eq(releases.eventId, events.id))
+				.where(eq(releaseCircles.circleId, circleId))
+				.orderBy(desc(releases.releaseDate))
+				.limit(limit)
+				.offset(offset),
+			db
+				.select({ count: countDistinct(releaseCircles.releaseId) })
+				.from(releaseCircles)
+				.where(eq(releaseCircles.circleId, circleId)),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		// イベント情報を整形
+		const formattedData = data.map((item) => ({
+			id: item.id,
+			name: item.name,
+			nameJa: item.nameJa,
+			releaseDate: item.releaseDate,
+			releaseType: item.releaseType,
+			participationType: item.participationType,
+			event: item.eventId ? { id: item.eventId, name: item.eventName } : null,
+			trackCount: item.trackCount,
+		}));
+
+		const response = {
+			data: formattedData,
+			total,
+			page,
+			limit,
+		};
+
+		// キャッシュに保存
+		setCache(cacheKey, response, CACHE_TTL.CIRCLE_RELEASES);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.CIRCLE_RELEASES });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/circles/:id/releases");
+	}
+});
+
+/**
+ * GET /api/public/circles/:id/tracks
+ * サークルのトラック一覧を取得（バッチフェッチでN+1回避）
+ */
+circlesRouter.get("/:id/tracks", async (c) => {
+	try {
+		const circleId = c.req.param("id");
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+
+		const cacheKey = cacheKeys.circleTracks({ circleId, page, limit });
+
+		// キャッシュチェック
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.CIRCLE_TRACKS });
+			return c.json(cached);
+		}
+
+		// サークル存在チェック
+		const circleExists = await db
+			.select({ id: circles.id })
+			.from(circles)
+			.where(eq(circles.id, circleId))
+			.limit(1);
+
+		if (circleExists.length === 0) {
+			return c.json({ error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }, 404);
+		}
+
+		const offset = (page - 1) * limit;
+
+		// Step 1: トラック基本情報を取得
+		const [tracksData, totalResult] = await Promise.all([
+			db
+				.select({
+					trackId: tracks.id,
+					trackName: tracks.name,
+					trackNumber: tracks.trackNumber,
+					releaseId: releases.id,
+					releaseName: releases.name,
+				})
+				.from(releaseCircles)
+				.innerJoin(releases, eq(releaseCircles.releaseId, releases.id))
+				.innerJoin(tracks, eq(tracks.releaseId, releases.id))
+				.where(eq(releaseCircles.circleId, circleId))
+				.orderBy(desc(releases.releaseDate), asc(tracks.trackNumber))
+				.limit(limit)
+				.offset(offset),
+			db
+				.select({ count: countDistinct(tracks.id) })
+				.from(releaseCircles)
+				.innerJoin(releases, eq(releaseCircles.releaseId, releases.id))
+				.innerJoin(tracks, eq(tracks.releaseId, releases.id))
+				.where(eq(releaseCircles.circleId, circleId)),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		if (tracksData.length === 0) {
+			const response = { data: [], total, page, limit };
+			setCache(cacheKey, response, CACHE_TTL.CIRCLE_TRACKS);
+			setCacheHeaders(c, { maxAge: CACHE_TTL.CIRCLE_TRACKS });
+			return c.json(response);
+		}
+
+		// Step 2: バッチフェッチ用のIDリストを作成
+		const trackIds = tracksData.map((t) => t.trackId);
+
+		// Step 3: 関連データをバッチ取得（N+1回避）
+		const [creditsData, originalSongsData] = await Promise.all([
+			// クレジット情報を一括取得（ロール含む）
+			db
+				.select({
+					trackId: trackCredits.trackId,
+					artistId: artists.id,
+					creditName: trackCredits.creditName,
+					roleCode: trackCreditRoles.roleCode,
+					roleName: creditRoles.label,
+				})
+				.from(trackCredits)
+				.innerJoin(artists, eq(trackCredits.artistId, artists.id))
+				.leftJoin(
+					trackCreditRoles,
+					eq(trackCreditRoles.trackCreditId, trackCredits.id),
+				)
+				.leftJoin(creditRoles, eq(trackCreditRoles.roleCode, creditRoles.code))
+				.where(inArray(trackCredits.trackId, trackIds)),
+
+			// 原曲情報を一括取得
+			db
+				.select({
+					trackId: trackOfficialSongs.trackId,
+					songId: officialSongs.id,
+					songName: officialSongs.nameJa,
+				})
+				.from(trackOfficialSongs)
+				.innerJoin(
+					officialSongs,
+					eq(trackOfficialSongs.officialSongId, officialSongs.id),
+				)
+				.where(inArray(trackOfficialSongs.trackId, trackIds)),
+		]);
+
+		// Step 4: メモリ上でマージ
+		// クレジットをトラックIDでグルーピング（ロールをまとめる）
+		const creditsByTrack = new Map<
+			string,
+			Array<{ id: string; creditName: string; roles: string[] }>
+		>();
+		for (const cr of creditsData) {
+			const key = cr.trackId;
+			const existing = creditsByTrack.get(key) ?? [];
+			if (!creditsByTrack.has(key)) {
+				creditsByTrack.set(key, existing);
+			}
+			const artist = existing.find((a) => a.id === cr.artistId);
+			if (artist) {
+				if (cr.roleName && !artist.roles.includes(cr.roleName)) {
+					artist.roles.push(cr.roleName);
+				}
+			} else {
+				existing.push({
+					id: cr.artistId,
+					creditName: cr.creditName,
+					roles: cr.roleName ? [cr.roleName] : [],
+				});
+			}
+		}
+
+		// 原曲をトラックIDでグルーピング（1トラックに複数原曲の可能性）
+		const originalSongsByTrack = new Map<
+			string,
+			Array<{ id: string; name: string | null }>
+		>();
+		for (const os of originalSongsData) {
+			const key = os.trackId;
+			const existing = originalSongsByTrack.get(key) ?? [];
+			if (!originalSongsByTrack.has(key)) {
+				originalSongsByTrack.set(key, existing);
+			}
+			existing.push({ id: os.songId, name: os.songName });
+		}
+
+		// 最終結果を構築
+		const data = tracksData.map((track) => ({
+			id: track.trackId,
+			name: track.trackName,
+			releaseId: track.releaseId,
+			releaseName: track.releaseName,
+			trackNumber: track.trackNumber,
+			artists: creditsByTrack.get(track.trackId) ?? [],
+			originalSong: originalSongsByTrack.get(track.trackId)?.[0] ?? null,
+		}));
+
+		const response = { data, total, page, limit };
+
+		// キャッシュに保存
+		setCache(cacheKey, response, CACHE_TTL.CIRCLE_TRACKS);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.CIRCLE_TRACKS });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/circles/:id/tracks");
+	}
+});
+
+export { circlesRouter };

--- a/apps/server/src/routes/public/index.ts
+++ b/apps/server/src/routes/public/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { categoriesRouter } from "./categories";
+import { circlesRouter } from "./circles";
 import { officialWorksRouter } from "./official-works";
 import { originalSongsRouter } from "./original-songs";
 
@@ -9,5 +10,6 @@ const publicRouter = new Hono();
 publicRouter.route("/official-work-categories", categoriesRouter);
 publicRouter.route("/official-works", officialWorksRouter);
 publicRouter.route("/original-songs", originalSongsRouter);
+publicRouter.route("/circles", circlesRouter);
 
 export { publicRouter };

--- a/apps/server/src/utils/cache.ts
+++ b/apps/server/src/utils/cache.ts
@@ -21,6 +21,10 @@ export const CACHE_TTL = {
 	SONGS_LIST: 5 * 60, // 5分
 	SONG_DETAIL: 5 * 60, // 5分
 	TRACKS_LIST: 60, // 1分
+	CIRCLES_LIST: 5 * 60, // 5分
+	CIRCLE_DETAIL: 5 * 60, // 5分
+	CIRCLE_RELEASES: 5 * 60, // 5分
+	CIRCLE_TRACKS: 5 * 60, // 5分
 } as const;
 
 /**
@@ -152,4 +156,24 @@ export const cacheKeys = {
 
 	tracksList: (params: { songId: string; page: number; limit: number }) =>
 		`public:songs:${params.songId}:tracks:page=${params.page}:limit=${params.limit}`,
+
+	circlesList: (params: {
+		page: number;
+		limit: number;
+		initialScript?: string;
+		initial?: string;
+		row?: string;
+		search?: string;
+		sortBy?: string;
+		sortOrder?: string;
+	}) =>
+		`public:circles:page=${params.page}:limit=${params.limit}:script=${params.initialScript || ""}:initial=${params.initial || ""}:row=${params.row || ""}:search=${params.search || ""}:sortBy=${params.sortBy || ""}:sortOrder=${params.sortOrder || ""}`,
+
+	circleDetail: (circleId: string) => `public:circles:${circleId}`,
+
+	circleReleases: (params: { circleId: string; page: number; limit: number }) =>
+		`public:circles:${params.circleId}:releases:page=${params.page}:limit=${params.limit}`,
+
+	circleTracks: (params: { circleId: string; page: number; limit: number }) =>
+		`public:circles:${params.circleId}:tracks:page=${params.page}:limit=${params.limit}`,
 };

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -156,6 +156,70 @@ export interface PaginatedResponse<T> {
 	limit: number;
 }
 
+/** サークル一覧項目 */
+export interface PublicCircleItem {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+	sortName: string | null;
+	nameInitial: string | null;
+	initialScript: string;
+	releaseCount: number;
+	trackCount: number;
+}
+
+/** サークル詳細 */
+export interface PublicCircleDetail {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+	sortName: string | null;
+	nameInitial: string | null;
+	initialScript: string;
+	notes: string | null;
+	links: Array<{
+		id: string;
+		platformCode: string;
+		platformName: string | null;
+		url: string;
+		isOfficial: boolean;
+		isPrimary: boolean;
+	}>;
+	stats: {
+		releaseCount: number;
+		trackCount: number;
+	};
+}
+
+/** サークルリリース */
+export interface PublicCircleRelease {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	releaseDate: string | null;
+	releaseType: string | null;
+	participationType: string;
+	event: { id: string; name: string | null } | null;
+	trackCount: number;
+}
+
+/** サークルトラック */
+export interface PublicCircleTrack {
+	id: string;
+	name: string;
+	releaseId: string;
+	releaseName: string | null;
+	trackNumber: number;
+	artists: Array<{
+		id: string;
+		creditName: string;
+		roles: string[];
+	}>;
+	originalSong: { id: string; name: string | null } | null;
+}
+
 // =============================================================================
 // API関数
 // =============================================================================
@@ -230,6 +294,72 @@ export const publicApi = {
 			const query = sp.toString();
 			return publicFetch<PaginatedResponse<PublicArrangeTrack>>(
 				`/api/public/original-songs/${id}/tracks${query ? `?${query}` : ""}`,
+			);
+		},
+	},
+
+	circles: {
+		/** サークル一覧を取得 */
+		list: (params?: {
+			page?: number;
+			limit?: number;
+			initialScript?: string;
+			initial?: string;
+			row?: string;
+			search?: string;
+			sortBy?: string;
+			sortOrder?: string;
+		}) => {
+			const sp = new URLSearchParams();
+			if (params?.page) sp.set("page", String(params.page));
+			if (params?.limit) sp.set("limit", String(params.limit));
+			if (params?.initialScript) sp.set("initialScript", params.initialScript);
+			if (params?.initial) sp.set("initial", params.initial);
+			if (params?.row) sp.set("row", params.row);
+			if (params?.search) sp.set("search", params.search);
+			if (params?.sortBy) sp.set("sortBy", params.sortBy);
+			if (params?.sortOrder) sp.set("sortOrder", params.sortOrder);
+			const query = sp.toString();
+			return publicFetch<PaginatedResponse<PublicCircleItem>>(
+				`/api/public/circles${query ? `?${query}` : ""}`,
+			);
+		},
+
+		/** サークル詳細を取得 */
+		get: (id: string) =>
+			publicFetch<PublicCircleDetail>(`/api/public/circles/${id}`),
+
+		/** サークルのリリース一覧を取得 */
+		releases: (
+			id: string,
+			params?: {
+				page?: number;
+				limit?: number;
+			},
+		) => {
+			const sp = new URLSearchParams();
+			if (params?.page) sp.set("page", String(params.page));
+			if (params?.limit) sp.set("limit", String(params.limit));
+			const query = sp.toString();
+			return publicFetch<PaginatedResponse<PublicCircleRelease>>(
+				`/api/public/circles/${id}/releases${query ? `?${query}` : ""}`,
+			);
+		},
+
+		/** サークルのトラック一覧を取得 */
+		tracks: (
+			id: string,
+			params?: {
+				page?: number;
+				limit?: number;
+			},
+		) => {
+			const sp = new URLSearchParams();
+			if (params?.page) sp.set("page", String(params.page));
+			if (params?.limit) sp.set("limit", String(params.limit));
+			const query = sp.toString();
+			return publicFetch<PaginatedResponse<PublicCircleTrack>>(
+				`/api/public/circles/${id}/tracks${query ? `?${query}` : ""}`,
 			);
 		},
 	},

--- a/apps/web/src/routes/_public/circles_.$id.tsx
+++ b/apps/web/src/routes/_public/circles_.$id.tsx
@@ -1,228 +1,36 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Calendar, Disc3, ExternalLink, Music, Users } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Calendar, Disc3, Loader2, Music, Users } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import {
 	EmptyState,
+	ExternalLink,
 	PublicBreadcrumb,
 	type ViewMode,
 	ViewToggle,
 } from "@/components/public";
+import { formatNumber } from "@/lib/format";
 import { createPublicCircleHead } from "@/lib/head";
-
-// モックサークル取得関数（loader用）
-function getCircle(id: string) {
-	return mockCircles[id] ?? null;
-}
+import {
+	type PublicCircleRelease,
+	type PublicCircleTrack,
+	publicApi,
+} from "@/lib/public-api";
 
 export const Route = createFileRoute("/_public/circles_/$id")({
-	loader: ({ params }) => ({ circle: getCircle(params.id) }),
+	loader: async ({ params }) => {
+		try {
+			const circle = await publicApi.circles.get(params.id);
+			return { circle };
+		} catch {
+			return { circle: null };
+		}
+	},
 	head: ({ loaderData }) => createPublicCircleHead(loaderData?.circle?.name),
 	component: CircleDetailPage,
 });
 
 const STORAGE_KEY_VIEW = "circle-detail-view-mode";
-
-// サークルデータ型（スキーマ準拠）
-interface Circle {
-	id: string;
-	name: string;
-	nameJa: string | null;
-	nameEn: string | null;
-	sortName: string | null;
-	nameInitial: string | null;
-	initialScript: string;
-	notes: string | null;
-}
-
-// 外部リンクデータ型
-interface CircleLink {
-	id: string;
-	circleId: string;
-	platformCode: string;
-	url: string;
-	isOfficial: boolean;
-	isPrimary: boolean;
-}
-
-// リリースデータ型
-interface Release {
-	id: string;
-	name: string;
-	nameJa: string | null;
-	releaseDate: string | null;
-	releaseType: string | null;
-	participationType: string;
-	event: {
-		id: string;
-		name: string;
-	} | null;
-	trackCount: number;
-}
-
-// トラックデータ型
-interface Track {
-	id: string;
-	name: string;
-	releaseId: string;
-	releaseName: string;
-	trackNumber: number;
-	artists: Array<{
-		id: string;
-		creditName: string;
-		roles: string[];
-	}>;
-	originalSong: {
-		id: string;
-		name: string;
-	} | null;
-}
-
-// モックデータ - サークル
-const mockCircles: Record<string, Circle> = {
-	"circle-iosys": {
-		id: "circle-iosys",
-		name: "IOSYS",
-		nameJa: "イオシス",
-		nameEn: "IOSYS",
-		sortName: "IOSYS",
-		nameInitial: "I",
-		initialScript: "latin",
-		notes: "2000年設立の同人音楽サークル。東方アレンジの先駆者的存在。",
-	},
-	"circle-alst": {
-		id: "circle-alst",
-		name: "Alstroemeria Records",
-		nameJa: null,
-		nameEn: "Alstroemeria Records",
-		sortName: "Alstroemeria Records",
-		nameInitial: "A",
-		initialScript: "latin",
-		notes: "Masayoshi Minoshima主宰の同人音楽サークル。",
-	},
-	"circle-cool": {
-		id: "circle-cool",
-		name: "COOL&CREATE",
-		nameJa: null,
-		nameEn: "COOL&CREATE",
-		sortName: "COOL&CREATE",
-		nameInitial: "C",
-		initialScript: "latin",
-		notes: "ビートまりお主宰のサークル。",
-	},
-};
-
-// モックデータ - 外部リンク
-const mockCircleLinks: Record<string, CircleLink[]> = {
-	"circle-iosys": [
-		{
-			id: "cl-1",
-			circleId: "circle-iosys",
-			platformCode: "twitter",
-			url: "https://twitter.com/iosys_info",
-			isOfficial: true,
-			isPrimary: true,
-		},
-		{
-			id: "cl-2",
-			circleId: "circle-iosys",
-			platformCode: "official",
-			url: "https://www.iosysos.com/",
-			isOfficial: true,
-			isPrimary: false,
-		},
-		{
-			id: "cl-3",
-			circleId: "circle-iosys",
-			platformCode: "youtube",
-			url: "https://www.youtube.com/@iosys_official",
-			isOfficial: true,
-			isPrimary: false,
-		},
-	],
-};
-
-// モックデータ - リリース（mocks/release.tsと統一されたID）
-const mockReleases: Record<string, Release[]> = {
-	"circle-iosys": [
-		{
-			id: "rel-iosys-001",
-			name: "東方乙女囃子",
-			nameJa: "東方乙女囃子",
-			releaseDate: "2006-12-31",
-			releaseType: "album",
-			participationType: "host",
-			event: { id: "c71", name: "C71" },
-			trackCount: 4,
-		},
-		{
-			id: "rel-single-001",
-			name: "チルノのパーフェクトさんすう教室",
-			nameJa: "チルノのパーフェクトさんすう教室",
-			releaseDate: "2008-08-16",
-			releaseType: "single",
-			participationType: "host",
-			event: { id: "c74", name: "C74" },
-			trackCount: 1,
-		},
-	],
-};
-
-// モックデータ - トラック（mocks/release.tsと統一されたID）
-const mockTracks: Record<string, Track[]> = {
-	"circle-iosys": [
-		{
-			id: "track-001",
-			name: "最終鬼畜妹フランドール・S",
-			releaseId: "rel-iosys-001",
-			releaseName: "東方乙女囃子",
-			trackNumber: 1,
-			artists: [
-				{ id: "artist-arm", creditName: "ARM", roles: ["arrange", "lyrics"] },
-				{ id: "artist-miko", creditName: "miko", roles: ["vocal"] },
-			],
-			originalSong: { id: "02010015", name: "U.N.オーエンは彼女なのか？" },
-		},
-		{
-			id: "track-002",
-			name: "魔理沙は大変なものを盗んでいきました",
-			releaseId: "rel-iosys-001",
-			releaseName: "東方乙女囃子",
-			trackNumber: 2,
-			artists: [
-				{ id: "artist-arm", creditName: "ARM", roles: ["arrange", "lyrics"] },
-				{ id: "artist-fu-rin", creditName: "藤咲かりん", roles: ["vocal"] },
-			],
-			originalSong: { id: "02010008", name: "人形裁判 ～ 人の形弄びし少女" },
-		},
-		{
-			id: "track-003",
-			name: "患部で止まってすぐ溶ける ～ 狂気の優曇華院",
-			releaseId: "rel-iosys-001",
-			releaseName: "東方乙女囃子",
-			trackNumber: 3,
-			artists: [
-				{ id: "artist-arm", creditName: "ARM", roles: ["arrange", "lyrics"] },
-				{ id: "artist-uno", creditName: "uno", roles: ["vocal"] },
-			],
-			originalSong: {
-				id: "02080008",
-				name: "狂気の瞳　～ Invisible Full Moon",
-			},
-		},
-		{
-			id: "track-single-001",
-			name: "チルノのパーフェクトさんすう教室",
-			releaseId: "rel-single-001",
-			releaseName: "チルノのパーフェクトさんすう教室",
-			trackNumber: 1,
-			artists: [
-				{ id: "artist-arm", creditName: "ARM", roles: ["arrange", "lyrics"] },
-				{ id: "artist-miko", creditName: "miko", roles: ["vocal"] },
-			],
-			originalSong: { id: "02020004", name: "おてんば恋娘" },
-		},
-	],
-};
+const PAGE_SIZE = 20;
 
 // プラットフォーム名
 const platformNames: Record<string, string> = {
@@ -260,6 +68,21 @@ function CircleDetailPage() {
 	const [activeTab, setActiveTab] = useState<TabType>("releases");
 	const [viewMode, setViewModeState] = useState<ViewMode>("list");
 
+	// リリース一覧の状態
+	const [releases, setReleases] = useState<PublicCircleRelease[]>([]);
+	const [releasesTotal, setReleasesTotal] = useState(0);
+	const [releasesPage, setReleasesPage] = useState(1);
+	const [releasesLoading, setReleasesLoading] = useState(false);
+	const [releasesLoaded, setReleasesLoaded] = useState(false);
+
+	// トラック一覧の状態
+	const [tracks, setTracks] = useState<PublicCircleTrack[]>([]);
+	const [tracksTotal, setTracksTotal] = useState(0);
+	const [tracksPage, setTracksPage] = useState(1);
+	const [tracksLoading, setTracksLoading] = useState(false);
+	const [tracksLoaded, setTracksLoaded] = useState(false);
+
+	// ビューモードの保存
 	useEffect(() => {
 		const saved = localStorage.getItem(STORAGE_KEY_VIEW) as ViewMode;
 		if (saved) setViewModeState(saved);
@@ -269,15 +92,68 @@ function CircleDetailPage() {
 		setViewModeState(view);
 		localStorage.setItem(STORAGE_KEY_VIEW, view);
 	};
-	const links = mockCircleLinks[id] || [];
-	const releases = mockReleases[id] || [];
-	const tracks = mockTracks[id] || [];
 
-	// 統計計算
-	const stats = {
-		releaseCount: releases.length,
-		trackCount: tracks.length,
-	};
+	// リリース一覧を取得
+	const fetchReleases = useCallback(
+		async (page: number) => {
+			if (!circle) return;
+			setReleasesLoading(true);
+			try {
+				const res = await publicApi.circles.releases(id, {
+					page,
+					limit: PAGE_SIZE,
+				});
+				setReleases(res.data);
+				setReleasesTotal(res.total);
+				setReleasesPage(page);
+				setReleasesLoaded(true);
+			} catch {
+				// エラー時は空配列
+			} finally {
+				setReleasesLoading(false);
+			}
+		},
+		[circle, id],
+	);
+
+	// トラック一覧を取得
+	const fetchTracks = useCallback(
+		async (page: number) => {
+			if (!circle) return;
+			setTracksLoading(true);
+			try {
+				const res = await publicApi.circles.tracks(id, {
+					page,
+					limit: PAGE_SIZE,
+				});
+				setTracks(res.data);
+				setTracksTotal(res.total);
+				setTracksPage(page);
+				setTracksLoaded(true);
+			} catch {
+				// エラー時は空配列
+			} finally {
+				setTracksLoading(false);
+			}
+		},
+		[circle, id],
+	);
+
+	// タブ切替時に遅延読み込み
+	useEffect(() => {
+		if (activeTab === "releases" && !releasesLoaded && circle) {
+			fetchReleases(1);
+		} else if (activeTab === "tracks" && !tracksLoaded && circle) {
+			fetchTracks(1);
+		}
+	}, [
+		activeTab,
+		releasesLoaded,
+		tracksLoaded,
+		circle,
+		fetchReleases,
+		fetchTracks,
+	]);
 
 	// サークルが見つからない場合
 	if (!circle) {
@@ -298,6 +174,9 @@ function CircleDetailPage() {
 			</div>
 		);
 	}
+
+	const releasesTotalPages = Math.ceil(releasesTotal / PAGE_SIZE);
+	const tracksTotalPages = Math.ceil(tracksTotal / PAGE_SIZE);
 
 	return (
 		<div className="space-y-6">
@@ -332,19 +211,18 @@ function CircleDetailPage() {
 					</div>
 
 					{/* 外部リンク */}
-					{links.length > 0 && (
+					{circle.links.length > 0 && (
 						<div className="flex flex-wrap gap-2">
-							{links.map((link) => (
-								<a
+							{circle.links.map((link) => (
+								<ExternalLink
 									key={link.id}
 									href={link.url}
-									target="_blank"
-									rel="noopener noreferrer"
 									className="btn btn-outline btn-sm gap-1"
 								>
-									<ExternalLink className="size-3" />
-									{platformNames[link.platformCode] || link.platformCode}
-								</a>
+									{platformNames[link.platformCode] ||
+										link.platformName ||
+										link.platformCode}
+								</ExternalLink>
 							))}
 						</div>
 					)}
@@ -355,14 +233,18 @@ function CircleDetailPage() {
 					<div className="rounded-lg bg-base-200/50 p-4 text-center">
 						<div className="flex items-center justify-center gap-2 text-primary">
 							<Disc3 className="size-5" />
-							<span className="font-bold text-2xl">{stats.releaseCount}</span>
+							<span className="font-bold text-2xl">
+								{formatNumber(circle.stats.releaseCount)}
+							</span>
 						</div>
 						<p className="mt-1 text-base-content/70 text-sm">リリース</p>
 					</div>
 					<div className="rounded-lg bg-base-200/50 p-4 text-center">
 						<div className="flex items-center justify-center gap-2 text-secondary">
 							<Music className="size-5" />
-							<span className="font-bold text-2xl">{stats.trackCount}</span>
+							<span className="font-bold text-2xl">
+								{formatNumber(circle.stats.trackCount)}
+							</span>
 						</div>
 						<p className="mt-1 text-base-content/70 text-sm">トラック</p>
 					</div>
@@ -395,99 +277,39 @@ function CircleDetailPage() {
 			</div>
 
 			{/* リリース一覧 */}
-			{activeTab === "releases" &&
-				(releases.length === 0 ? (
-					<EmptyState type="empty" title="リリースがありません" />
-				) : viewMode === "grid" ? (
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-						{releases.map((release) => (
-							<div
-								key={release.id}
-								className="card bg-base-100 shadow-sm transition-shadow hover:shadow-md"
-							>
-								<div className="card-body p-4">
-									<Link
-										to="/releases/$id"
-										params={{ id: release.id }}
-										className="card-title text-base hover:text-primary"
-									>
-										{release.name}
-									</Link>
-									<div className="flex flex-wrap items-center gap-2 text-base-content/60 text-sm">
-										{release.event && (
-											<Link
-												to="/events/$id"
-												params={{ id: release.event.id }}
-												className="badge badge-outline badge-sm hover:badge-primary"
-											>
-												{release.event.name}
-											</Link>
-										)}
-										<span
-											className={`badge badge-sm ${
-												release.participationType === "host"
-													? "badge-primary"
-													: "badge-ghost"
-											}`}
+			{activeTab === "releases" && (
+				<>
+					{releasesLoading ? (
+						<div className="flex items-center justify-center py-12">
+							<Loader2 className="size-8 animate-spin text-primary" />
+						</div>
+					) : releases.length === 0 ? (
+						<EmptyState type="empty" title="リリースがありません" />
+					) : viewMode === "grid" ? (
+						<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+							{releases.map((release) => (
+								<div
+									key={release.id}
+									className="card bg-base-100 shadow-sm transition-shadow hover:shadow-md"
+								>
+									<div className="card-body p-4">
+										<Link
+											to="/releases/$id"
+											params={{ id: release.id }}
+											className="card-title text-base hover:text-primary"
 										>
-											{participationTypeNames[release.participationType] ||
-												release.participationType}
-										</span>
-									</div>
-									<div className="mt-2 flex items-center gap-4 text-base-content/50 text-sm">
-										{release.releaseDate && (
-											<span className="flex items-center gap-1">
-												<Calendar className="size-3" />
-												{release.releaseDate}
-											</span>
-										)}
-										<span className="flex items-center gap-1">
-											<Music className="size-3" />
-											{release.trackCount}曲
-										</span>
-									</div>
-								</div>
-							</div>
-						))}
-					</div>
-				) : (
-					<div className="overflow-x-auto rounded-lg bg-base-100 shadow-sm">
-						<table className="table">
-							<thead>
-								<tr>
-									<th>タイトル</th>
-									<th>イベント</th>
-									<th className="hidden sm:table-cell">参加種別</th>
-									<th className="hidden sm:table-cell">発売日</th>
-									<th>曲数</th>
-								</tr>
-							</thead>
-							<tbody>
-								{releases.map((release) => (
-									<tr key={release.id} className="hover:bg-base-200/50">
-										<td>
-											<Link
-												to="/releases/$id"
-												params={{ id: release.id }}
-												className="font-medium hover:text-primary"
-											>
-												{release.name}
-											</Link>
-										</td>
-										<td>
-											{release.event ? (
+											{release.name}
+										</Link>
+										<div className="flex flex-wrap items-center gap-2 text-base-content/60 text-sm">
+											{release.event && (
 												<Link
 													to="/events/$id"
 													params={{ id: release.event.id }}
-													className="hover:text-primary"
+													className="badge badge-outline badge-sm hover:badge-primary"
 												>
 													{release.event.name}
 												</Link>
-											) : (
-												"-"
 											)}
-										</td>
-										<td className="hidden sm:table-cell">
 											<span
 												className={`badge badge-sm ${
 													release.participationType === "host"
@@ -498,85 +320,209 @@ function CircleDetailPage() {
 												{participationTypeNames[release.participationType] ||
 													release.participationType}
 											</span>
-										</td>
-										<td className="hidden text-base-content/70 sm:table-cell">
-											{release.releaseDate || "-"}
-										</td>
-										<td className="text-base-content/70">
-											{release.trackCount}曲
-										</td>
+										</div>
+										<div className="mt-2 flex items-center gap-4 text-base-content/50 text-sm">
+											{release.releaseDate && (
+												<span className="flex items-center gap-1">
+													<Calendar className="size-3" />
+													{release.releaseDate}
+												</span>
+											)}
+											<span className="flex items-center gap-1">
+												<Music className="size-3" />
+												{release.trackCount}曲
+											</span>
+										</div>
+									</div>
+								</div>
+							))}
+						</div>
+					) : (
+						<div className="overflow-x-auto rounded-lg bg-base-100 shadow-sm">
+							<table className="table">
+								<thead>
+									<tr>
+										<th>タイトル</th>
+										<th>イベント</th>
+										<th className="hidden sm:table-cell">参加種別</th>
+										<th className="hidden sm:table-cell">発売日</th>
+										<th>曲数</th>
 									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
-				))}
+								</thead>
+								<tbody>
+									{releases.map((release) => (
+										<tr key={release.id} className="hover:bg-base-200/50">
+											<td>
+												<Link
+													to="/releases/$id"
+													params={{ id: release.id }}
+													className="font-medium hover:text-primary"
+												>
+													{release.name}
+												</Link>
+											</td>
+											<td>
+												{release.event ? (
+													<Link
+														to="/events/$id"
+														params={{ id: release.event.id }}
+														className="hover:text-primary"
+													>
+														{release.event.name}
+													</Link>
+												) : (
+													"-"
+												)}
+											</td>
+											<td className="hidden sm:table-cell">
+												<span
+													className={`badge badge-sm ${
+														release.participationType === "host"
+															? "badge-primary"
+															: "badge-ghost"
+													}`}
+												>
+													{participationTypeNames[release.participationType] ||
+														release.participationType}
+												</span>
+											</td>
+											<td className="hidden text-base-content/70 sm:table-cell">
+												{release.releaseDate || "-"}
+											</td>
+											<td className="text-base-content/70">
+												{release.trackCount}曲
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					)}
+
+					{/* ページネーション */}
+					{releasesTotalPages > 1 && (
+						<div className="flex justify-center gap-2">
+							<button
+								type="button"
+								className="btn btn-sm"
+								disabled={releasesPage <= 1}
+								onClick={() => fetchReleases(releasesPage - 1)}
+							>
+								前へ
+							</button>
+							<span className="flex items-center px-2 text-sm">
+								{releasesPage} / {releasesTotalPages}
+							</span>
+							<button
+								type="button"
+								className="btn btn-sm"
+								disabled={releasesPage >= releasesTotalPages}
+								onClick={() => fetchReleases(releasesPage + 1)}
+							>
+								次へ
+							</button>
+						</div>
+					)}
+				</>
+			)}
 
 			{/* トラック一覧 */}
-			{activeTab === "tracks" &&
-				(tracks.length === 0 ? (
-					<EmptyState type="empty" title="トラックがありません" />
-				) : (
-					<div className="overflow-x-auto rounded-lg bg-base-100 shadow-sm">
-						<table className="table">
-							<thead>
-								<tr>
-									<th>曲名</th>
-									<th>リリース</th>
-									<th className="hidden md:table-cell">アーティスト</th>
-									<th className="hidden sm:table-cell">原曲</th>
-								</tr>
-							</thead>
-							<tbody>
-								{tracks.map((track) => (
-									<tr key={track.id} className="hover:bg-base-200/50">
-										<td>
-											<div className="font-medium">{track.name}</div>
-										</td>
-										<td className="text-base-content/70">
-											{track.releaseName}
-										</td>
-										<td className="hidden md:table-cell">
-											<div className="flex flex-wrap gap-1">
-												{track.artists.map((artist) => (
-													<Link
-														key={artist.id}
-														to="/artists/$id"
-														params={{ id: artist.id }}
-														className="inline-flex items-center gap-1 hover:text-primary"
-													>
-														<Users className="size-3" />
-														<span>{artist.creditName}</span>
-														<span className="text-base-content/50 text-xs">
-															(
-															{artist.roles
-																.map((r) => roleNames[r] || r)
-																.join("/")}
-															)
-														</span>
-													</Link>
-												))}
-											</div>
-										</td>
-										<td className="hidden sm:table-cell">
-											{track.originalSong ? (
-												<Link
-													to="/original-songs/$id"
-													params={{ id: track.originalSong.id }}
-													className="text-base-content/70 hover:text-primary"
-												>
-													{track.originalSong.name}
-												</Link>
-											) : (
-												"-"
-											)}
-										</td>
+			{activeTab === "tracks" && (
+				<>
+					{tracksLoading ? (
+						<div className="flex items-center justify-center py-12">
+							<Loader2 className="size-8 animate-spin text-primary" />
+						</div>
+					) : tracks.length === 0 ? (
+						<EmptyState type="empty" title="トラックがありません" />
+					) : (
+						<div className="overflow-x-auto rounded-lg bg-base-100 shadow-sm">
+							<table className="table">
+								<thead>
+									<tr>
+										<th>曲名</th>
+										<th>リリース</th>
+										<th className="hidden md:table-cell">アーティスト</th>
+										<th className="hidden sm:table-cell">原曲</th>
 									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
-				))}
+								</thead>
+								<tbody>
+									{tracks.map((track) => (
+										<tr key={track.id} className="hover:bg-base-200/50">
+											<td>
+												<div className="font-medium">{track.name}</div>
+											</td>
+											<td className="text-base-content/70">
+												{track.releaseName || "-"}
+											</td>
+											<td className="hidden md:table-cell">
+												<div className="flex flex-wrap gap-1">
+													{track.artists.map((artist) => (
+														<Link
+															key={artist.id}
+															to="/artists/$id"
+															params={{ id: artist.id }}
+															className="inline-flex items-center gap-1 hover:text-primary"
+														>
+															<Users className="size-3" />
+															<span>{artist.creditName}</span>
+															<span className="text-base-content/50 text-xs">
+																(
+																{artist.roles
+																	.map((r) => roleNames[r] || r)
+																	.join("/")}
+																)
+															</span>
+														</Link>
+													))}
+												</div>
+											</td>
+											<td className="hidden sm:table-cell">
+												{track.originalSong ? (
+													<Link
+														to="/original-songs/$id"
+														params={{ id: track.originalSong.id }}
+														className="text-base-content/70 hover:text-primary"
+													>
+														{track.originalSong.name}
+													</Link>
+												) : (
+													"-"
+												)}
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					)}
+
+					{/* ページネーション */}
+					{tracksTotalPages > 1 && (
+						<div className="flex justify-center gap-2">
+							<button
+								type="button"
+								className="btn btn-sm"
+								disabled={tracksPage <= 1}
+								onClick={() => fetchTracks(tracksPage - 1)}
+							>
+								前へ
+							</button>
+							<span className="flex items-center px-2 text-sm">
+								{tracksPage} / {tracksTotalPages}
+							</span>
+							<button
+								type="button"
+								className="btn btn-sm"
+								disabled={tracksPage >= tracksTotalPages}
+								onClick={() => fetchTracks(tracksPage + 1)}
+							>
+								次へ
+							</button>
+						</div>
+					)}
+				</>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## 概要

サークル一覧ページ（/circles）と詳細ページ（/circles/:id）を実際の公開APIに接続する。

## 変更内容

### サーバー側（公開API）
* 新規作成: `apps/server/src/routes/public/circles.ts`
  * `GET /api/public/circles` - サークル一覧（文字種フィルター、ページネーション、ソート対応）
  * `GET /api/public/circles/:id` - サークル詳細（リンク情報、統計情報）
  * `GET /api/public/circles/:id/releases` - リリース一覧（遅延読み込み用）
  * `GET /api/public/circles/:id/tracks` - トラック一覧（N+1回避のバッチフェッチ）
* キャッシュ設定追加（TTL: 5分）

### フロントエンド側
* `apps/web/src/lib/public-api.ts` にサークル関連の型定義とAPIクライアントを追加
* `circles.tsx` - モックデータをAPI接続に変更
* `circles_.$id.tsx` - モックデータをAPI接続に変更
  * リリース一覧・トラック一覧をタブ切替時の遅延読み込みに変更
  * 外部リンクをExternalLinkコンポーネントに統一

## 影響範囲

* `/circles` - サークル一覧ページ
* `/circles/:id` - サークル詳細ページ
* 公開API: `/api/public/circles/*`

## 補足事項

* 既存のUI構造（文字種フィルター、グリッド/リスト表示、ページネーション）は維持
* 詳細ページのリリース・トラック一覧はタブ切替時に遅延読み込みすることでパフォーマンスを最適化