### PR TITLE
feat: イベント一覧・詳細の公開APIを実装

### DIFF
--- a/apps/server/src/routes/public/events.ts
+++ b/apps/server/src/routes/public/events.ts
@@ -1,0 +1,363 @@
+import {
+	asc,
+	circles,
+	count,
+	countDistinct,
+	db,
+	desc,
+	eq,
+	eventDays,
+	eventSeries,
+	events,
+	inArray,
+	like,
+	or,
+	releaseCircles,
+	releases,
+	sql,
+	tracks,
+} from "@thac/db";
+import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../constants/error-messages";
+import { handleDbError } from "../../utils/api-error";
+import {
+	CACHE_TTL,
+	cacheKeys,
+	getCache,
+	setCache,
+	setCacheHeaders,
+} from "../../utils/cache";
+
+const eventsRouter = new Hono();
+
+/**
+ * GET /api/public/events
+ * イベント一覧を取得（ページネーション、フィルタ、検索対応）
+ */
+eventsRouter.get("/", async (c) => {
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const seriesId = c.req.query("seriesId");
+		const search = c.req.query("search");
+		const sortBy = c.req.query("sortBy") || "startDate";
+		const sortOrder = c.req.query("sortOrder") || "desc";
+
+		const cacheKey = cacheKeys.eventsList({
+			page,
+			limit,
+			seriesId,
+			search,
+			sortBy,
+			sortOrder,
+		});
+
+		// キャッシュチェック
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.EVENTS_LIST });
+			return c.json(cached);
+		}
+
+		const offset = (page - 1) * limit;
+
+		// 条件を構築
+		const conditions = [];
+
+		// シリーズフィルター
+		if (seriesId) {
+			conditions.push(eq(events.eventSeriesId, seriesId));
+		}
+
+		// 検索
+		if (search) {
+			const searchPattern = `%${search}%`;
+			conditions.push(
+				or(like(events.name, searchPattern), like(events.venue, searchPattern)),
+			);
+		}
+
+		const whereCondition =
+			conditions.length > 0
+				? conditions.length === 1
+					? conditions[0]
+					: sql`${conditions[0]} AND ${conditions[1]}`
+				: undefined;
+
+		// releaseCountサブクエリ（N+1回避）
+		const releaseCountSubquery = db
+			.select({ count: count() })
+			.from(releases)
+			.where(eq(releases.eventId, events.id));
+
+		// ソート条件を構築
+		const sortColumn =
+			sortBy === "name"
+				? events.name
+				: sortBy === "releaseCount"
+					? sql<number>`(${releaseCountSubquery})`
+					: events.startDate;
+		const orderByClause =
+			sortOrder === "asc" ? asc(sortColumn) : desc(sortColumn);
+
+		// データ取得（JOINでシリーズ情報を一括取得）
+		const [data, totalResult] = await Promise.all([
+			db
+				.select({
+					id: events.id,
+					name: events.name,
+					eventSeriesId: events.eventSeriesId,
+					eventSeriesName: eventSeries.name,
+					edition: events.edition,
+					startDate: events.startDate,
+					endDate: events.endDate,
+					totalDays: events.totalDays,
+					venue: events.venue,
+					releaseCount: sql<number>`(${releaseCountSubquery})`,
+				})
+				.from(events)
+				.leftJoin(eventSeries, eq(events.eventSeriesId, eventSeries.id))
+				.where(whereCondition)
+				.orderBy(orderByClause)
+				.limit(limit)
+				.offset(offset),
+			db.select({ count: count() }).from(events).where(whereCondition),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		const response = {
+			data,
+			total,
+			page,
+			limit,
+		};
+
+		// キャッシュに保存
+		setCache(cacheKey, response, CACHE_TTL.EVENTS_LIST);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.EVENTS_LIST });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/events");
+	}
+});
+
+/**
+ * GET /api/public/events/:id
+ * イベント詳細を取得（統計情報含む）
+ */
+eventsRouter.get("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+		const cacheKey = cacheKeys.eventDetail(id);
+
+		// キャッシュチェック
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.EVENT_DETAIL });
+			return c.json(cached);
+		}
+
+		// イベント基本情報を取得（JOINでシリーズ情報も一括取得）
+		const eventResult = await db
+			.select({
+				id: events.id,
+				name: events.name,
+				eventSeriesId: events.eventSeriesId,
+				eventSeriesName: eventSeries.name,
+				edition: events.edition,
+				startDate: events.startDate,
+				endDate: events.endDate,
+				totalDays: events.totalDays,
+				venue: events.venue,
+			})
+			.from(events)
+			.leftJoin(eventSeries, eq(events.eventSeriesId, eventSeries.id))
+			.where(eq(events.id, id))
+			.limit(1);
+
+		if (eventResult.length === 0) {
+			return c.json({ error: ERROR_MESSAGES.EVENT_NOT_FOUND }, 404);
+		}
+
+		const event = eventResult[0];
+
+		// 関連データを並列取得（N+1回避）
+		const [daysData, statsData] = await Promise.all([
+			// イベント日一覧
+			db
+				.select({
+					id: eventDays.id,
+					dayNumber: eventDays.dayNumber,
+					date: eventDays.date,
+				})
+				.from(eventDays)
+				.where(eq(eventDays.eventId, id))
+				.orderBy(asc(eventDays.dayNumber)),
+
+			// 統計情報（サブクエリで一括集計）
+			db
+				.select({
+					releaseCount: countDistinct(releases.id),
+					circleCount: countDistinct(releaseCircles.circleId),
+					trackCount: countDistinct(tracks.id),
+				})
+				.from(releases)
+				.leftJoin(releaseCircles, eq(releaseCircles.releaseId, releases.id))
+				.leftJoin(tracks, eq(tracks.releaseId, releases.id))
+				.where(eq(releases.eventId, id)),
+		]);
+
+		const stats = statsData[0] ?? {
+			releaseCount: 0,
+			circleCount: 0,
+			trackCount: 0,
+		};
+
+		const response = {
+			...event,
+			eventDays: daysData,
+			stats: {
+				releaseCount: stats.releaseCount,
+				circleCount: stats.circleCount,
+				trackCount: stats.trackCount,
+			},
+		};
+
+		// キャッシュに保存
+		setCache(cacheKey, response, CACHE_TTL.EVENT_DETAIL);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.EVENT_DETAIL });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/events/:id");
+	}
+});
+
+/**
+ * GET /api/public/events/:id/releases
+ * イベントのリリース一覧を取得（バッチフェッチでN+1回避）
+ */
+eventsRouter.get("/:id/releases", async (c) => {
+	try {
+		const eventId = c.req.param("id");
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+
+		const cacheKey = cacheKeys.eventReleases({ eventId, page, limit });
+
+		// キャッシュチェック
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.EVENT_RELEASES });
+			return c.json(cached);
+		}
+
+		// イベント存在チェック
+		const eventExists = await db
+			.select({ id: events.id })
+			.from(events)
+			.where(eq(events.id, eventId))
+			.limit(1);
+
+		if (eventExists.length === 0) {
+			return c.json({ error: ERROR_MESSAGES.EVENT_NOT_FOUND }, 404);
+		}
+
+		const offset = (page - 1) * limit;
+
+		// トラック数サブクエリ
+		const trackCountSubquery = db
+			.select({ count: count() })
+			.from(tracks)
+			.where(eq(tracks.releaseId, releases.id));
+
+		// Step 1: リリース一覧を取得
+		const [releasesData, totalResult] = await Promise.all([
+			db
+				.select({
+					id: releases.id,
+					name: releases.name,
+					nameJa: releases.nameJa,
+					releaseDate: releases.releaseDate,
+					releaseType: releases.releaseType,
+					trackCount: sql<number>`(${trackCountSubquery})`,
+				})
+				.from(releases)
+				.where(eq(releases.eventId, eventId))
+				.orderBy(asc(releases.name))
+				.limit(limit)
+				.offset(offset),
+			db
+				.select({ count: count() })
+				.from(releases)
+				.where(eq(releases.eventId, eventId)),
+		]);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		if (releasesData.length === 0) {
+			const response = { data: [], total, page, limit };
+			setCache(cacheKey, response, CACHE_TTL.EVENT_RELEASES);
+			setCacheHeaders(c, { maxAge: CACHE_TTL.EVENT_RELEASES });
+			return c.json(response);
+		}
+
+		// Step 2: バッチフェッチ用のIDリストを作成
+		const releaseIds = releasesData.map((r) => r.id);
+
+		// Step 3: サークル情報をバッチ取得（N+1回避）
+		const circlesData = await db
+			.select({
+				releaseId: releaseCircles.releaseId,
+				circleId: circles.id,
+				circleName: circles.name,
+				participationType: releaseCircles.participationType,
+			})
+			.from(releaseCircles)
+			.innerJoin(circles, eq(releaseCircles.circleId, circles.id))
+			.where(inArray(releaseCircles.releaseId, releaseIds));
+
+		// Step 4: メモリ上でマージ
+		const circlesByRelease = new Map<
+			string,
+			Array<{ id: string; name: string; participationType: string }>
+		>();
+		for (const c of circlesData) {
+			const key = c.releaseId;
+			const existing = circlesByRelease.get(key) ?? [];
+			if (!circlesByRelease.has(key)) {
+				circlesByRelease.set(key, existing);
+			}
+			existing.push({
+				id: c.circleId,
+				name: c.circleName,
+				participationType: c.participationType,
+			});
+		}
+
+		// 最終結果を構築
+		const data = releasesData.map((release) => ({
+			id: release.id,
+			name: release.name,
+			nameJa: release.nameJa,
+			releaseDate: release.releaseDate,
+			releaseType: release.releaseType,
+			trackCount: release.trackCount,
+			circles: circlesByRelease.get(release.id) ?? [],
+		}));
+
+		const response = { data, total, page, limit };
+
+		// キャッシュに保存
+		setCache(cacheKey, response, CACHE_TTL.EVENT_RELEASES);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.EVENT_RELEASES });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/events/:id/releases");
+	}
+});
+
+export { eventsRouter };

--- a/apps/server/src/routes/public/index.ts
+++ b/apps/server/src/routes/public/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { artistsRouter } from "./artists";
 import { categoriesRouter } from "./categories";
 import { circlesRouter } from "./circles";
+import { eventsRouter } from "./events";
 import { officialWorksRouter } from "./official-works";
 import { originalSongsRouter } from "./original-songs";
 
@@ -13,5 +14,6 @@ publicRouter.route("/official-works", officialWorksRouter);
 publicRouter.route("/original-songs", originalSongsRouter);
 publicRouter.route("/circles", circlesRouter);
 publicRouter.route("/artists", artistsRouter);
+publicRouter.route("/events", eventsRouter);
 
 export { publicRouter };

--- a/apps/server/src/utils/cache.ts
+++ b/apps/server/src/utils/cache.ts
@@ -28,6 +28,9 @@ export const CACHE_TTL = {
 	ARTISTS_LIST: 5 * 60, // 5分
 	ARTIST_DETAIL: 5 * 60, // 5分
 	ARTIST_TRACKS: 5 * 60, // 5分
+	EVENTS_LIST: 5 * 60, // 5分
+	EVENT_DETAIL: 5 * 60, // 5分
+	EVENT_RELEASES: 5 * 60, // 5分
 } as const;
 
 /**
@@ -203,4 +206,19 @@ export const cacheKeys = {
 		role?: string;
 	}) =>
 		`public:artists:${params.artistId}:tracks:page=${params.page}:limit=${params.limit}:aliasId=${params.aliasId || ""}:role=${params.role || ""}`,
+
+	eventsList: (params: {
+		page: number;
+		limit: number;
+		seriesId?: string;
+		search?: string;
+		sortBy?: string;
+		sortOrder?: string;
+	}) =>
+		`public:events:page=${params.page}:limit=${params.limit}:seriesId=${params.seriesId || ""}:search=${params.search || ""}:sortBy=${params.sortBy || ""}:sortOrder=${params.sortOrder || ""}`,
+
+	eventDetail: (eventId: string) => `public:events:${eventId}`,
+
+	eventReleases: (params: { eventId: string; page: number; limit: number }) =>
+		`public:events:${params.eventId}:releases:page=${params.page}:limit=${params.limit}`,
 };

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -291,6 +291,61 @@ export interface PublicArtistTrack {
 	originalSong: { id: string; name: string | null } | null;
 }
 
+/** イベント一覧項目 */
+export interface PublicEventItem {
+	id: string;
+	name: string;
+	eventSeriesId: string | null;
+	eventSeriesName: string | null;
+	edition: number | null;
+	startDate: string | null;
+	endDate: string | null;
+	totalDays: number | null;
+	venue: string | null;
+	releaseCount: number;
+}
+
+/** イベント日 */
+export interface PublicEventDay {
+	id: string;
+	dayNumber: number;
+	date: string;
+}
+
+/** イベント詳細 */
+export interface PublicEventDetail {
+	id: string;
+	name: string;
+	eventSeriesId: string | null;
+	eventSeriesName: string | null;
+	edition: number | null;
+	startDate: string | null;
+	endDate: string | null;
+	totalDays: number | null;
+	venue: string | null;
+	eventDays: PublicEventDay[];
+	stats: {
+		releaseCount: number;
+		circleCount: number;
+		trackCount: number;
+	};
+}
+
+/** イベントリリース */
+export interface PublicEventRelease {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	releaseDate: string | null;
+	releaseType: string | null;
+	trackCount: number;
+	circles: Array<{
+		id: string;
+		name: string;
+		participationType: string;
+	}>;
+}
+
 // =============================================================================
 // API関数
 // =============================================================================
@@ -484,6 +539,51 @@ export const publicApi = {
 			const query = sp.toString();
 			return publicFetch<PaginatedResponse<PublicArtistTrack>>(
 				`/api/public/artists/${id}/tracks${query ? `?${query}` : ""}`,
+			);
+		},
+	},
+
+	events: {
+		/** イベント一覧を取得 */
+		list: (params?: {
+			page?: number;
+			limit?: number;
+			seriesId?: string;
+			search?: string;
+			sortBy?: string;
+			sortOrder?: string;
+		}) => {
+			const sp = new URLSearchParams();
+			if (params?.page) sp.set("page", String(params.page));
+			if (params?.limit) sp.set("limit", String(params.limit));
+			if (params?.seriesId) sp.set("seriesId", params.seriesId);
+			if (params?.search) sp.set("search", params.search);
+			if (params?.sortBy) sp.set("sortBy", params.sortBy);
+			if (params?.sortOrder) sp.set("sortOrder", params.sortOrder);
+			const query = sp.toString();
+			return publicFetch<PaginatedResponse<PublicEventItem>>(
+				`/api/public/events${query ? `?${query}` : ""}`,
+			);
+		},
+
+		/** イベント詳細を取得 */
+		get: (id: string) =>
+			publicFetch<PublicEventDetail>(`/api/public/events/${id}`),
+
+		/** イベントのリリース一覧を取得 */
+		releases: (
+			id: string,
+			params?: {
+				page?: number;
+				limit?: number;
+			},
+		) => {
+			const sp = new URLSearchParams();
+			if (params?.page) sp.set("page", String(params.page));
+			if (params?.limit) sp.set("limit", String(params.limit));
+			const query = sp.toString();
+			return publicFetch<PaginatedResponse<PublicEventRelease>>(
+				`/api/public/events/${id}/releases${query ? `?${query}` : ""}`,
 			);
 		},
 	},


### PR DESCRIPTION
## 概要

イベント一覧・詳細ページを公開APIから取得できるように実装しました。

## 変更内容

### バックエンド
* `GET /api/public/events`: イベント一覧（ページネーション、検索、フィルタ対応）
* `GET /api/public/events/:id`: イベント詳細（統計情報含む）
* `GET /api/public/events/:id/releases`: イベントのリリース一覧

### フロントエンド
* イベント一覧ページ: シリーズ別・年別の切り替え表示を維持
* イベント詳細ページ: リリース一覧の遅延読み込み対応
* 共通Paginationコンポーネントを使用してUI統一

### パフォーマンス最適化
* N+1回避: JOINでイベントシリーズ情報を一括取得
* N+1回避: サブクエリでリリース数を取得
* N+1回避: バッチフェッチでサークル情報を取得
* キャッシュ設定: イベント用のTTLとキー生成関数を追加

## 影響範囲

* 公開API: `/api/public/events` エンドポイント追加
* フロントエンド: イベント一覧・詳細ページ