### PR TITLE
fix: N+1クエリ問題を修正

### DIFF
--- a/apps/server/src/routes/admin/artists/index.ts
+++ b/apps/server/src/routes/admin/artists/index.ts
@@ -7,6 +7,7 @@ import {
 	db,
 	desc,
 	eq,
+	inArray,
 	insertArtistSchema,
 	like,
 	or,
@@ -328,36 +329,25 @@ artistsRouter.delete("/batch", async (c) => {
 			return c.json({ error: ERROR_MESSAGES.MAXIMUM_BATCH_ITEMS }, 400);
 		}
 
-		const deleted: string[] = [];
-		const failed: Array<{ id: string; error: string }> = [];
+		// 一括で存在確認（N+1回避）
+		const existingRecords = await db
+			.select({ id: artists.id })
+			.from(artists)
+			.where(inArray(artists.id, ids));
 
-		for (const id of ids) {
-			try {
-				// 存在チェック
-				const existing = await db
-					.select()
-					.from(artists)
-					.where(eq(artists.id, id))
-					.limit(1);
+		const existingIdSet = new Set(existingRecords.map((r) => r.id));
 
-				if (existing.length === 0) {
-					failed.push({
-						id,
-						error: ERROR_MESSAGES.ARTIST_NOT_FOUND,
-					});
-					continue;
-				}
+		// 存在しないIDをfailedに追加
+		const failed: Array<{ id: string; error: string }> = ids
+			.filter((id) => !existingIdSet.has(id))
+			.map((id) => ({ id, error: ERROR_MESSAGES.ARTIST_NOT_FOUND }));
 
-				// 削除（関連別名義はCASCADE削除）
-				await db.delete(artists).where(eq(artists.id, id));
-				deleted.push(id);
-			} catch (e) {
-				failed.push({
-					id,
-					error: e instanceof Error ? e.message : "Unknown error",
-				});
-			}
+		// 存在するIDを一括削除（関連別名義はCASCADE削除）
+		const idsToDelete = Array.from(existingIdSet);
+		if (idsToDelete.length > 0) {
+			await db.delete(artists).where(inArray(artists.id, idsToDelete));
 		}
+		const deleted = idsToDelete;
 
 		return c.json({
 			success: failed.length === 0,

--- a/apps/server/src/routes/admin/circles/index.ts
+++ b/apps/server/src/routes/admin/circles/index.ts
@@ -7,6 +7,7 @@ import {
 	db,
 	desc,
 	eq,
+	inArray,
 	insertCircleLinkSchema,
 	insertCircleSchema,
 	like,
@@ -628,36 +629,25 @@ circlesRouter.delete("/batch", async (c) => {
 			return c.json({ error: ERROR_MESSAGES.MAXIMUM_BATCH_ITEMS }, 400);
 		}
 
-		const deleted: string[] = [];
-		const failed: Array<{ id: string; error: string }> = [];
+		// 一括で存在確認（N+1回避）
+		const existingRecords = await db
+			.select({ id: circles.id })
+			.from(circles)
+			.where(inArray(circles.id, ids));
 
-		for (const id of ids) {
-			try {
-				// 存在チェック
-				const existing = await db
-					.select()
-					.from(circles)
-					.where(eq(circles.id, id))
-					.limit(1);
+		const existingIdSet = new Set(existingRecords.map((r) => r.id));
 
-				if (existing.length === 0) {
-					failed.push({
-						id,
-						error: ERROR_MESSAGES.CIRCLE_NOT_FOUND,
-					});
-					continue;
-				}
+		// 存在しないIDをfailedに追加
+		const failed: Array<{ id: string; error: string }> = ids
+			.filter((id) => !existingIdSet.has(id))
+			.map((id) => ({ id, error: ERROR_MESSAGES.CIRCLE_NOT_FOUND }));
 
-				// 削除（関連リンクはCASCADE削除）
-				await db.delete(circles).where(eq(circles.id, id));
-				deleted.push(id);
-			} catch (e) {
-				failed.push({
-					id,
-					error: e instanceof Error ? e.message : "Unknown error",
-				});
-			}
+		// 存在するIDを一括削除（関連リンクはCASCADE削除）
+		const idsToDelete = Array.from(existingIdSet);
+		if (idsToDelete.length > 0) {
+			await db.delete(circles).where(inArray(circles.id, idsToDelete));
 		}
+		const deleted = idsToDelete;
 
 		return c.json({
 			success: failed.length === 0,

--- a/apps/server/src/routes/admin/releases/releases.ts
+++ b/apps/server/src/routes/admin/releases/releases.ts
@@ -8,6 +8,7 @@ import {
 	eq,
 	eventDays,
 	events,
+	inArray,
 	insertReleaseSchema,
 	like,
 	releases,
@@ -515,36 +516,25 @@ releasesRouter.delete("/batch", async (c) => {
 			return c.json({ error: ERROR_MESSAGES.MAXIMUM_BATCH_ITEMS }, 400);
 		}
 
-		const deleted: string[] = [];
-		const failed: Array<{ id: string; error: string }> = [];
+		// 一括で存在確認（N+1回避）
+		const existingRecords = await db
+			.select({ id: releases.id })
+			.from(releases)
+			.where(inArray(releases.id, ids));
 
-		for (const id of ids) {
-			try {
-				// 存在チェック
-				const existing = await db
-					.select()
-					.from(releases)
-					.where(eq(releases.id, id))
-					.limit(1);
+		const existingIdSet = new Set(existingRecords.map((r) => r.id));
 
-				if (existing.length === 0) {
-					failed.push({
-						id,
-						error: ERROR_MESSAGES.RELEASE_NOT_FOUND,
-					});
-					continue;
-				}
+		// 存在しないIDをfailedに追加
+		const failed: Array<{ id: string; error: string }> = ids
+			.filter((id) => !existingIdSet.has(id))
+			.map((id) => ({ id, error: ERROR_MESSAGES.RELEASE_NOT_FOUND }));
 
-				// 削除（ディスク・トラックはCASCADE削除）
-				await db.delete(releases).where(eq(releases.id, id));
-				deleted.push(id);
-			} catch (e) {
-				failed.push({
-					id,
-					error: e instanceof Error ? e.message : "Unknown error",
-				});
-			}
+		// 存在するIDを一括削除（ディスク・トラックはCASCADE削除）
+		const idsToDelete = Array.from(existingIdSet);
+		if (idsToDelete.length > 0) {
+			await db.delete(releases).where(inArray(releases.id, idsToDelete));
 		}
+		const deleted = idsToDelete;
 
 		return c.json({
 			success: failed.length === 0,


### PR DESCRIPTION
## 概要

Admin APIのバッチ削除操作と公開APIのリスト取得で発生していたN+1クエリ問題を修正。

## 問題の原因

### バッチ削除API（CRITICAL）
ループ内で各IDに対して個別にSELECT（存在確認）とDELETEを実行していたため、N件の削除で2N回のクエリが発生していた。

### 公開API（MODERATE）
相関サブクエリを使用してカウントを取得していたため、結果セットの各行に対してサブクエリが実行されていた。

## 変更内容

### バッチ削除APIの最適化
* `apps/server/src/routes/admin/artists/index.ts` - inArray()による一括処理に変更
* `apps/server/src/routes/admin/artist-aliases/index.ts` - 同上
* `apps/server/src/routes/admin/circles/index.ts` - 同上
* `apps/server/src/routes/admin/releases/releases.ts` - 同上

### 公開APIの最適化
* `apps/server/src/routes/public/circles.ts` - releaseCount, trackCountをLEFT JOIN + GROUP BYに変更
* `apps/server/src/routes/public/official-works.ts` - songCount, totalArrangeCountをLEFT JOIN + GROUP BYに変更
* `apps/server/src/routes/public/original-songs.ts` - arrangeCountをLEFT JOIN + GROUP BYに変更

## 影響範囲

* Admin API: バッチ削除エンドポイント（artists, artist-aliases, circles, releases）
* Public API: 一覧取得エンドポイント（circles, official-works, original-songs）

## 補足事項

* APIのレスポンス形式に変更なし
* 既存のキャッシュ戦略はそのまま維持