### PR TITLE
feat: リリース詳細・トラック詳細の公開APIを実装し、詳細ページ間のリンクを追加

### DIFF
--- a/apps/server/src/routes/public/index.ts
+++ b/apps/server/src/routes/public/index.ts
@@ -5,6 +5,8 @@ import { circlesRouter } from "./circles";
 import { eventsRouter } from "./events";
 import { officialWorksRouter } from "./official-works";
 import { originalSongsRouter } from "./original-songs";
+import { releasesRouter } from "./releases";
+import { tracksRouter } from "./tracks";
 
 const publicRouter = new Hono();
 
@@ -15,5 +17,7 @@ publicRouter.route("/original-songs", originalSongsRouter);
 publicRouter.route("/circles", circlesRouter);
 publicRouter.route("/artists", artistsRouter);
 publicRouter.route("/events", eventsRouter);
+publicRouter.route("/releases", releasesRouter);
+publicRouter.route("/tracks", tracksRouter);
 
 export { publicRouter };

--- a/apps/server/src/routes/public/releases.ts
+++ b/apps/server/src/routes/public/releases.ts
@@ -1,0 +1,331 @@
+import {
+	asc,
+	circles,
+	creditRoles,
+	db,
+	discs,
+	eq,
+	events,
+	inArray,
+	officialSongs,
+	platforms,
+	releaseCircles,
+	releasePublications,
+	releases,
+	trackCreditRoles,
+	trackCredits,
+	trackOfficialSongs,
+	tracks,
+} from "@thac/db";
+import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../constants/error-messages";
+import { handleDbError } from "../../utils/api-error";
+import {
+	CACHE_TTL,
+	cacheKeys,
+	getCache,
+	setCache,
+	setCacheHeaders,
+} from "../../utils/cache";
+
+const releasesRouter = new Hono();
+
+/**
+ * GET /api/public/releases/:id
+ * リリース詳細を取得（サークル、ディスク、トラック、クレジット、原曲、配信リンク含む）
+ */
+releasesRouter.get("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+		const cacheKey = cacheKeys.releaseDetail(id);
+
+		// キャッシュチェック
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.RELEASE_DETAIL });
+			return c.json(cached);
+		}
+
+		// Step 1: リリース基本情報を取得（JOINでイベント情報も一括取得）
+		const releaseResult = await db
+			.select({
+				id: releases.id,
+				name: releases.name,
+				nameJa: releases.nameJa,
+				nameEn: releases.nameEn,
+				releaseDate: releases.releaseDate,
+				releaseYear: releases.releaseYear,
+				releaseMonth: releases.releaseMonth,
+				releaseDay: releases.releaseDay,
+				releaseType: releases.releaseType,
+				notes: releases.notes,
+				eventId: events.id,
+				eventName: events.name,
+			})
+			.from(releases)
+			.leftJoin(events, eq(releases.eventId, events.id))
+			.where(eq(releases.id, id))
+			.limit(1);
+
+		if (releaseResult.length === 0) {
+			return c.json({ error: ERROR_MESSAGES.RELEASE_NOT_FOUND }, 404);
+		}
+
+		// Non-null assertion is safe here because we checked length above
+		const release = releaseResult[0]!;
+
+		// Step 2: 関連データを並列取得（N+1回避）
+		const [circlesData, discsData, tracksData, publicationsData] =
+			await Promise.all([
+				// サークル一覧
+				db
+					.select({
+						circleId: circles.id,
+						circleName: circles.name,
+						participationType: releaseCircles.participationType,
+						position: releaseCircles.position,
+					})
+					.from(releaseCircles)
+					.innerJoin(circles, eq(releaseCircles.circleId, circles.id))
+					.where(eq(releaseCircles.releaseId, id))
+					.orderBy(asc(releaseCircles.position)),
+
+				// ディスク一覧
+				db
+					.select({
+						id: discs.id,
+						discNumber: discs.discNumber,
+						discName: discs.discName,
+					})
+					.from(discs)
+					.where(eq(discs.releaseId, id))
+					.orderBy(asc(discs.discNumber)),
+
+				// トラック一覧
+				db
+					.select({
+						id: tracks.id,
+						discId: tracks.discId,
+						trackNumber: tracks.trackNumber,
+						name: tracks.name,
+						nameJa: tracks.nameJa,
+						nameEn: tracks.nameEn,
+					})
+					.from(tracks)
+					.where(eq(tracks.releaseId, id))
+					.orderBy(asc(tracks.discId), asc(tracks.trackNumber)),
+
+				// 配信リンク
+				db
+					.select({
+						id: releasePublications.id,
+						platformCode: releasePublications.platformCode,
+						url: releasePublications.url,
+						platformName: platforms.name,
+						platformCategory: platforms.category,
+					})
+					.from(releasePublications)
+					.innerJoin(
+						platforms,
+						eq(releasePublications.platformCode, platforms.code),
+					)
+					.where(eq(releasePublications.releaseId, id)),
+			]);
+
+		// Step 3: トラックIDリストを作成してバッチフェッチ
+		const trackIds = tracksData.map((t) => t.id);
+
+		// 配信リンクを整形
+		const publications = publicationsData.map((pub) => ({
+			id: pub.id,
+			platformCode: pub.platformCode,
+			url: pub.url,
+			platform: {
+				code: pub.platformCode,
+				name: pub.platformName ?? pub.platformCode,
+				category: pub.platformCategory ?? "other",
+			},
+		}));
+
+		// トラックがない場合は空のレスポンスを返す
+		if (trackIds.length === 0) {
+			const response = {
+				id: release.id,
+				name: release.name,
+				nameJa: release.nameJa,
+				nameEn: release.nameEn,
+				releaseDate: release.releaseDate,
+				releaseYear: release.releaseYear,
+				releaseMonth: release.releaseMonth,
+				releaseDay: release.releaseDay,
+				releaseType: release.releaseType,
+				notes: release.notes,
+				event: release.eventId
+					? { id: release.eventId, name: release.eventName }
+					: null,
+				circles: circlesData,
+				discs: discsData,
+				tracks: [],
+				trackCount: 0,
+				artistCount: 0,
+				publications,
+			};
+
+			setCache(cacheKey, response, CACHE_TTL.RELEASE_DETAIL);
+			setCacheHeaders(c, { maxAge: CACHE_TTL.RELEASE_DETAIL });
+			return c.json(response);
+		}
+
+		// Step 4: クレジットと原曲をバッチ取得
+		const [creditsData, creditsRolesData, officialSongsData] =
+			await Promise.all([
+				// クレジット
+				db
+					.select({
+						trackId: trackCredits.trackId,
+						creditId: trackCredits.id,
+						artistId: trackCredits.artistId,
+						creditName: trackCredits.creditName,
+						creditPosition: trackCredits.creditPosition,
+					})
+					.from(trackCredits)
+					.where(inArray(trackCredits.trackId, trackIds))
+					.orderBy(asc(trackCredits.creditPosition)),
+
+				// クレジット役割
+				db
+					.select({
+						trackCreditId: trackCreditRoles.trackCreditId,
+						roleCode: trackCreditRoles.roleCode,
+						roleName: creditRoles.label,
+					})
+					.from(trackCreditRoles)
+					.innerJoin(
+						creditRoles,
+						eq(trackCreditRoles.roleCode, creditRoles.code),
+					)
+					.where(
+						inArray(
+							trackCreditRoles.trackCreditId,
+							db
+								.select({ id: trackCredits.id })
+								.from(trackCredits)
+								.where(inArray(trackCredits.trackId, trackIds)),
+						),
+					),
+
+				// 原曲
+				db
+					.select({
+						trackId: trackOfficialSongs.trackId,
+						officialSongId: trackOfficialSongs.officialSongId,
+						customSongName: trackOfficialSongs.customSongName,
+						songName: officialSongs.name,
+					})
+					.from(trackOfficialSongs)
+					.leftJoin(
+						officialSongs,
+						eq(trackOfficialSongs.officialSongId, officialSongs.id),
+					)
+					.where(inArray(trackOfficialSongs.trackId, trackIds)),
+			]);
+
+		// Step 5: メモリ上でマージ
+
+		// 役割をクレジットIDでグループ化
+		const rolesByCredit = new Map<
+			string,
+			Array<{ roleCode: string; roleName: string | null }>
+		>();
+		for (const role of creditsRolesData) {
+			const existing = rolesByCredit.get(role.trackCreditId) ?? [];
+			if (!rolesByCredit.has(role.trackCreditId)) {
+				rolesByCredit.set(role.trackCreditId, existing);
+			}
+			existing.push({ roleCode: role.roleCode, roleName: role.roleName });
+		}
+
+		// クレジットをトラックIDでグループ化
+		const creditsByTrack = new Map<
+			string,
+			Array<{
+				artistId: string;
+				creditName: string;
+				roles: Array<{ roleCode: string; roleName: string | null }>;
+			}>
+		>();
+		const artistIds = new Set<string>();
+		for (const credit of creditsData) {
+			artistIds.add(credit.artistId);
+			const existing = creditsByTrack.get(credit.trackId) ?? [];
+			if (!creditsByTrack.has(credit.trackId)) {
+				creditsByTrack.set(credit.trackId, existing);
+			}
+			existing.push({
+				artistId: credit.artistId,
+				creditName: credit.creditName,
+				roles: rolesByCredit.get(credit.creditId) ?? [],
+			});
+		}
+
+		// 原曲をトラックIDでグループ化
+		const officialSongsByTrack = new Map<
+			string,
+			Array<{ officialSongId: string | null; songName: string }>
+		>();
+		for (const os of officialSongsData) {
+			const existing = officialSongsByTrack.get(os.trackId) ?? [];
+			if (!officialSongsByTrack.has(os.trackId)) {
+				officialSongsByTrack.set(os.trackId, existing);
+			}
+			existing.push({
+				officialSongId: os.officialSongId,
+				songName: os.customSongName ?? os.songName ?? "",
+			});
+		}
+
+		// トラックデータを構築
+		const tracksWithDetails = tracksData.map((track) => ({
+			id: track.id,
+			discId: track.discId,
+			trackNumber: track.trackNumber,
+			name: track.name,
+			nameJa: track.nameJa,
+			nameEn: track.nameEn,
+			credits: creditsByTrack.get(track.id) ?? [],
+			officialSongs: officialSongsByTrack.get(track.id) ?? [],
+		}));
+
+		const response = {
+			id: release.id,
+			name: release.name,
+			nameJa: release.nameJa,
+			nameEn: release.nameEn,
+			releaseDate: release.releaseDate,
+			releaseYear: release.releaseYear,
+			releaseMonth: release.releaseMonth,
+			releaseDay: release.releaseDay,
+			releaseType: release.releaseType,
+			notes: release.notes,
+			event: release.eventId
+				? { id: release.eventId, name: release.eventName }
+				: null,
+			circles: circlesData,
+			discs: discsData,
+			tracks: tracksWithDetails,
+			trackCount: tracksData.length,
+			artistCount: artistIds.size,
+			publications,
+		};
+
+		// キャッシュに保存
+		setCache(cacheKey, response, CACHE_TTL.RELEASE_DETAIL);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.RELEASE_DETAIL });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/releases/:id");
+	}
+});
+
+export { releasesRouter };

--- a/apps/server/src/routes/public/tracks.ts
+++ b/apps/server/src/routes/public/tracks.ts
@@ -1,0 +1,327 @@
+import {
+	and,
+	asc,
+	creditRoles,
+	db,
+	discs,
+	eq,
+	events,
+	gt,
+	inArray,
+	lt,
+	officialSongs,
+	officialWorks,
+	platforms,
+	releases,
+	trackCreditRoles,
+	trackCredits,
+	trackDerivations,
+	trackOfficialSongs,
+	trackPublications,
+	tracks,
+} from "@thac/db";
+import { Hono } from "hono";
+import { ERROR_MESSAGES } from "../../constants/error-messages";
+import { handleDbError } from "../../utils/api-error";
+import {
+	CACHE_TTL,
+	cacheKeys,
+	getCache,
+	setCache,
+	setCacheHeaders,
+} from "../../utils/cache";
+
+const tracksRouter = new Hono();
+
+/**
+ * GET /api/public/tracks/:id
+ * トラック詳細を取得（リリース、クレジット、原曲、派生関係、前後トラック、配信リンク含む）
+ */
+tracksRouter.get("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+		const cacheKey = cacheKeys.trackDetail(id);
+
+		// キャッシュチェック
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.TRACK_DETAIL });
+			return c.json(cached);
+		}
+
+		// Step 1: トラック基本情報を取得（JOINでリリース・ディスク・イベント情報も一括取得）
+		const trackResult = await db
+			.select({
+				id: tracks.id,
+				name: tracks.name,
+				nameJa: tracks.nameJa,
+				nameEn: tracks.nameEn,
+				trackNumber: tracks.trackNumber,
+				releaseId: tracks.releaseId,
+				discId: tracks.discId,
+				releaseName: releases.name,
+				releaseDate: releases.releaseDate,
+				releaseType: releases.releaseType,
+				discNumber: discs.discNumber,
+				discName: discs.discName,
+				eventId: events.id,
+				eventName: events.name,
+			})
+			.from(tracks)
+			.leftJoin(releases, eq(tracks.releaseId, releases.id))
+			.leftJoin(discs, eq(tracks.discId, discs.id))
+			.leftJoin(events, eq(releases.eventId, events.id))
+			.where(eq(tracks.id, id))
+			.limit(1);
+
+		if (trackResult.length === 0) {
+			return c.json({ error: ERROR_MESSAGES.TRACK_NOT_FOUND }, 404);
+		}
+
+		// Non-null assertion is safe here because we checked length above
+		const track = trackResult[0]!;
+
+		// Step 2: 関連データを並列取得（N+1回避）
+		const [
+			creditsData,
+			officialSongsData,
+			parentTracksData,
+			publicationsData,
+			siblingTracksData,
+		] = await Promise.all([
+			// クレジット（役割含む）
+			db
+				.select({
+					creditId: trackCredits.id,
+					artistId: trackCredits.artistId,
+					creditName: trackCredits.creditName,
+					creditPosition: trackCredits.creditPosition,
+				})
+				.from(trackCredits)
+				.where(eq(trackCredits.trackId, id))
+				.orderBy(asc(trackCredits.creditPosition)),
+
+			// 原曲
+			db
+				.select({
+					officialSongId: trackOfficialSongs.officialSongId,
+					customSongName: trackOfficialSongs.customSongName,
+					partPosition: trackOfficialSongs.partPosition,
+					startSecond: trackOfficialSongs.startSecond,
+					endSecond: trackOfficialSongs.endSecond,
+					songName: officialSongs.name,
+					workId: officialSongs.officialWorkId,
+					workName: officialWorks.name,
+				})
+				.from(trackOfficialSongs)
+				.leftJoin(
+					officialSongs,
+					eq(trackOfficialSongs.officialSongId, officialSongs.id),
+				)
+				.leftJoin(
+					officialWorks,
+					eq(officialSongs.officialWorkId, officialWorks.id),
+				)
+				.where(eq(trackOfficialSongs.trackId, id))
+				.orderBy(asc(trackOfficialSongs.partPosition)),
+
+			// 派生元トラック
+			db
+				.select({
+					parentTrackId: trackDerivations.parentTrackId,
+					parentTrackName: tracks.name,
+					parentReleaseId: releases.id,
+					parentReleaseName: releases.name,
+				})
+				.from(trackDerivations)
+				.innerJoin(tracks, eq(trackDerivations.parentTrackId, tracks.id))
+				.leftJoin(releases, eq(tracks.releaseId, releases.id))
+				.where(eq(trackDerivations.childTrackId, id)),
+
+			// 配信リンク
+			db
+				.select({
+					id: trackPublications.id,
+					platformCode: trackPublications.platformCode,
+					url: trackPublications.url,
+					platformName: platforms.name,
+					platformCategory: platforms.category,
+				})
+				.from(trackPublications)
+				.innerJoin(
+					platforms,
+					eq(trackPublications.platformCode, platforms.code),
+				)
+				.where(eq(trackPublications.trackId, id)),
+
+			// 前後トラック（同じリリース内）
+			track.releaseId
+				? Promise.all([
+						// 前のトラック
+						db
+							.select({
+								id: tracks.id,
+								name: tracks.name,
+								trackNumber: tracks.trackNumber,
+							})
+							.from(tracks)
+							.where(
+								track.discId
+									? and(
+											eq(tracks.discId, track.discId),
+											lt(tracks.trackNumber, track.trackNumber),
+										)
+									: and(
+											eq(tracks.releaseId, track.releaseId!),
+											lt(tracks.trackNumber, track.trackNumber),
+										),
+							)
+							.orderBy(asc(tracks.trackNumber))
+							.limit(1),
+						// 次のトラック
+						db
+							.select({
+								id: tracks.id,
+								name: tracks.name,
+								trackNumber: tracks.trackNumber,
+							})
+							.from(tracks)
+							.where(
+								track.discId
+									? and(
+											eq(tracks.discId, track.discId),
+											gt(tracks.trackNumber, track.trackNumber),
+										)
+									: and(
+											eq(tracks.releaseId, track.releaseId!),
+											gt(tracks.trackNumber, track.trackNumber),
+										),
+							)
+							.orderBy(asc(tracks.trackNumber))
+							.limit(1),
+					])
+				: Promise.resolve([[], []]),
+		]);
+
+		// Step 3: クレジット役割をバッチ取得
+		const creditIds = creditsData.map((c) => c.creditId);
+		let rolesData: Array<{
+			trackCreditId: string;
+			roleCode: string;
+			roleName: string | null;
+		}> = [];
+
+		if (creditIds.length > 0) {
+			rolesData = await db
+				.select({
+					trackCreditId: trackCreditRoles.trackCreditId,
+					roleCode: trackCreditRoles.roleCode,
+					roleName: creditRoles.label,
+				})
+				.from(trackCreditRoles)
+				.innerJoin(creditRoles, eq(trackCreditRoles.roleCode, creditRoles.code))
+				.where(inArray(trackCreditRoles.trackCreditId, creditIds));
+		}
+
+		// Step 4: メモリ上でマージ
+
+		// 役割をクレジットIDでグループ化
+		const rolesByCredit = new Map<
+			string,
+			Array<{ roleCode: string; roleName: string | null }>
+		>();
+		for (const role of rolesData) {
+			const existing = rolesByCredit.get(role.trackCreditId) ?? [];
+			if (!rolesByCredit.has(role.trackCreditId)) {
+				rolesByCredit.set(role.trackCreditId, existing);
+			}
+			existing.push({ roleCode: role.roleCode, roleName: role.roleName });
+		}
+
+		// クレジットデータを構築
+		const credits = creditsData.map((credit) => ({
+			artistId: credit.artistId,
+			creditName: credit.creditName,
+			roles: rolesByCredit.get(credit.creditId) ?? [],
+		}));
+
+		// 原曲データを構築
+		const officialSongsResult = officialSongsData.map((os) => ({
+			officialSongId: os.officialSongId,
+			songName: os.customSongName ?? os.songName ?? "",
+			workName: os.workName ?? "",
+			partPosition: os.partPosition,
+			startSecond: os.startSecond,
+			endSecond: os.endSecond,
+		}));
+
+		// 派生元データを構築
+		const parentTracks = parentTracksData.map((pt) => ({
+			parentTrackId: pt.parentTrackId,
+			parentTrackName: pt.parentTrackName,
+			parentReleaseName: pt.parentReleaseName ?? "",
+		}));
+
+		// 前後トラックを取得
+		const [prevTracks, nextTracks] = siblingTracksData as [
+			Array<{ id: string; name: string; trackNumber: number }>,
+			Array<{ id: string; name: string; trackNumber: number }>,
+		];
+
+		// 配信リンクを整形
+		const publications = publicationsData.map((pub) => ({
+			id: pub.id,
+			platformCode: pub.platformCode,
+			url: pub.url,
+			platform: {
+				code: pub.platformCode,
+				name: pub.platformName ?? pub.platformCode,
+				category: pub.platformCategory ?? "other",
+			},
+		}));
+
+		const response = {
+			id: track.id,
+			name: track.name,
+			nameJa: track.nameJa,
+			nameEn: track.nameEn,
+			trackNumber: track.trackNumber,
+			credits,
+			officialSongs: officialSongsResult,
+			release: track.releaseId
+				? {
+						id: track.releaseId,
+						name: track.releaseName ?? "",
+						releaseDate: track.releaseDate,
+						releaseType: track.releaseType,
+					}
+				: null,
+			disc: track.discId
+				? {
+						id: track.discId,
+						discNumber: track.discNumber ?? 1,
+						discName: track.discName,
+					}
+				: null,
+			event: track.eventId
+				? { id: track.eventId, name: track.eventName ?? "" }
+				: null,
+			parentTracks,
+			siblingTracks: {
+				prev: prevTracks.length > 0 ? prevTracks[0] : null,
+				next: nextTracks.length > 0 ? nextTracks[0] : null,
+			},
+			publications,
+		};
+
+		// キャッシュに保存
+		setCache(cacheKey, response, CACHE_TTL.TRACK_DETAIL);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.TRACK_DETAIL });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/tracks/:id");
+	}
+});
+
+export { tracksRouter };

--- a/apps/server/src/utils/cache.ts
+++ b/apps/server/src/utils/cache.ts
@@ -31,6 +31,8 @@ export const CACHE_TTL = {
 	EVENTS_LIST: 5 * 60, // 5分
 	EVENT_DETAIL: 5 * 60, // 5分
 	EVENT_RELEASES: 5 * 60, // 5分
+	RELEASE_DETAIL: 5 * 60, // 5分
+	TRACK_DETAIL: 5 * 60, // 5分
 } as const;
 
 /**
@@ -221,4 +223,8 @@ export const cacheKeys = {
 
 	eventReleases: (params: { eventId: string; page: number; limit: number }) =>
 		`public:events:${params.eventId}:releases:page=${params.page}:limit=${params.limit}`,
+
+	releaseDetail: (releaseId: string) => `public:releases:${releaseId}`,
+
+	trackDetail: (trackId: string) => `public:tracks:${trackId}`,
 };

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -346,6 +346,114 @@ export interface PublicEventRelease {
 	}>;
 }
 
+/** リリース詳細 */
+export interface PublicReleaseDetail {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+	releaseDate: string | null;
+	releaseYear: number | null;
+	releaseMonth: number | null;
+	releaseDay: number | null;
+	releaseType: string | null;
+	notes: string | null;
+	event: { id: string; name: string | null } | null;
+	circles: Array<{
+		circleId: string;
+		circleName: string;
+		participationType: string;
+		position: number | null;
+	}>;
+	discs: Array<{
+		id: string;
+		discNumber: number;
+		discName: string | null;
+	}>;
+	tracks: Array<{
+		id: string;
+		discId: string | null;
+		trackNumber: number;
+		name: string;
+		nameJa: string | null;
+		nameEn: string | null;
+		credits: Array<{
+			artistId: string;
+			creditName: string;
+			roles: Array<{ roleCode: string; roleName: string | null }>;
+		}>;
+		officialSongs: Array<{
+			officialSongId: string | null;
+			songName: string;
+		}>;
+	}>;
+	trackCount: number;
+	artistCount: number;
+	publications: Array<{
+		id: string;
+		platformCode: string;
+		url: string;
+		platform: {
+			code: string;
+			name: string;
+			category: "streaming" | "video" | "download" | "shop" | "other";
+		};
+	}>;
+}
+
+/** トラック詳細 */
+export interface PublicTrackDetail {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+	trackNumber: number;
+	credits: Array<{
+		artistId: string;
+		creditName: string;
+		roles: Array<{ roleCode: string; roleName: string | null }>;
+	}>;
+	officialSongs: Array<{
+		officialSongId: string | null;
+		songName: string;
+		workName: string;
+		partPosition: number | null;
+		startSecond: number | null;
+		endSecond: number | null;
+	}>;
+	release: {
+		id: string;
+		name: string;
+		releaseDate: string | null;
+		releaseType: string | null;
+	} | null;
+	disc: {
+		id: string;
+		discNumber: number;
+		discName: string | null;
+	} | null;
+	event: { id: string; name: string } | null;
+	parentTracks: Array<{
+		parentTrackId: string;
+		parentTrackName: string;
+		parentReleaseName: string;
+	}>;
+	siblingTracks: {
+		prev: { id: string; name: string; trackNumber: number } | null;
+		next: { id: string; name: string; trackNumber: number } | null;
+	};
+	publications: Array<{
+		id: string;
+		platformCode: string;
+		url: string;
+		platform: {
+			code: string;
+			name: string;
+			category: "streaming" | "video" | "download" | "shop" | "other";
+		};
+	}>;
+}
+
 // =============================================================================
 // API関数
 // =============================================================================
@@ -586,5 +694,17 @@ export const publicApi = {
 				`/api/public/events/${id}/releases${query ? `?${query}` : ""}`,
 			);
 		},
+	},
+
+	releases: {
+		/** リリース詳細を取得 */
+		get: (id: string) =>
+			publicFetch<PublicReleaseDetail>(`/api/public/releases/${id}`),
+	},
+
+	tracks: {
+		/** トラック詳細を取得 */
+		get: (id: string) =>
+			publicFetch<PublicTrackDetail>(`/api/public/tracks/${id}`),
 	},
 };

--- a/apps/web/src/routes/_public/artists_.$id.tsx
+++ b/apps/web/src/routes/_public/artists_.$id.tsx
@@ -256,7 +256,13 @@ function ArtistDetailPage() {
 								{tracks.map((credit) => (
 									<tr key={credit.id} className="hover:bg-base-200/50">
 										<td>
-											<div className="font-medium">{credit.track.name}</div>
+											<Link
+												to="/tracks/$id"
+												params={{ id: credit.track.id }}
+												className="font-medium hover:text-primary"
+											>
+												{credit.track.name}
+											</Link>
 										</td>
 										<td className="hidden md:table-cell">
 											<div className="flex flex-wrap gap-1">
@@ -271,9 +277,13 @@ function ArtistDetailPage() {
 											</div>
 										</td>
 										<td className="hidden sm:table-cell">
-											<div className="text-base-content/70 text-sm">
+											<Link
+												to="/releases/$id"
+												params={{ id: credit.release.id }}
+												className="text-base-content/70 text-sm hover:text-primary"
+											>
 												{credit.release.name}
-											</div>
+											</Link>
 											<div className="flex gap-1">
 												{credit.circles.map((circle) => (
 													<Link

--- a/apps/web/src/routes/_public/circles_.$id.tsx
+++ b/apps/web/src/routes/_public/circles_.$id.tsx
@@ -450,10 +450,26 @@ function CircleDetailPage() {
 									{tracks.map((track) => (
 										<tr key={track.id} className="hover:bg-base-200/50">
 											<td>
-												<div className="font-medium">{track.name}</div>
+												<Link
+													to="/tracks/$id"
+													params={{ id: track.id }}
+													className="font-medium hover:text-primary"
+												>
+													{track.name}
+												</Link>
 											</td>
 											<td className="text-base-content/70">
-												{track.releaseName || "-"}
+												{track.releaseId ? (
+													<Link
+														to="/releases/$id"
+														params={{ id: track.releaseId }}
+														className="hover:text-primary"
+													>
+														{track.releaseName || "-"}
+													</Link>
+												) : (
+													track.releaseName || "-"
+												)}
 											</td>
 											<td className="hidden md:table-cell">
 												<div className="flex flex-wrap gap-1">

--- a/apps/web/src/routes/_public/original-songs_.$id.tsx
+++ b/apps/web/src/routes/_public/original-songs_.$id.tsx
@@ -235,11 +235,21 @@ function OriginalSongDetailPage() {
 								{tracks.map((track) => (
 									<tr key={track.trackId} className="hover:bg-base-200/50">
 										<td>
-											<div className="font-medium">{track.trackName}</div>
+											<Link
+												to="/tracks/$id"
+												params={{ id: track.trackId }}
+												className="font-medium hover:text-primary"
+											>
+												{track.trackName}
+											</Link>
 											{track.release && (
-												<div className="text-base-content/60 text-sm">
+												<Link
+													to="/releases/$id"
+													params={{ id: track.release.id }}
+													className="block text-base-content/60 text-sm hover:text-primary"
+												>
 													{track.release.name}
-												</div>
+												</Link>
 											)}
 										</td>
 										<td>


### PR DESCRIPTION
## 概要

リリース詳細・トラック詳細の公開APIエンドポイントを実装し、他の詳細ページからリリース・トラックへのリンクを追加しました。

## 変更内容

### バックエンド
* `GET /api/public/releases/:id` - リリース詳細API（サークル、ディスク、トラック、クレジット、原曲、配信リンク含む）
* `GET /api/public/tracks/:id` - トラック詳細API（リリース、クレジット、原曲、派生関係、前後トラック、配信リンク含む）
* キャッシュ設定（TTL: 5分）を追加

### フロントエンド
* リリース詳細ページ・トラック詳細ページをモックデータから公開APIに移行
* 型定義（`PublicReleaseDetail`, `PublicTrackDetail`）を追加
* APIクライアントメソッド（`publicApi.releases.get()`, `publicApi.tracks.get()`）を追加

### 詳細ページ間リンク追加
* **アーティスト詳細**: トラック名→トラック詳細、リリース名→リリース詳細へのリンクを追加
* **原曲詳細**: アレンジトラック名→トラック詳細、リリース名→リリース詳細へのリンクを追加
* **サークル詳細**: トラック名→トラック詳細、リリース名→リリース詳細へのリンクを追加

## 影響範囲

* 公開サイトのリリース詳細ページ（`/releases/:id`）
* 公開サイトのトラック詳細ページ（`/tracks/:id`）
* 公開サイトのアーティスト詳細ページ（`/artists/:id`）
* 公開サイトの原曲詳細ページ（`/original-songs/:id`）
* 公開サイトのサークル詳細ページ（`/circles/:id`）

## 補足事項

* N+1クエリ回避のため、バッチフェッチと`Map`によるインメモリマージを使用
* 配信リンクは`PublicationWithPlatform`型に準拠（`id`, `platformCode`, `url`, `platform`オブジェクト含む）