### PR TITLE
feat: サークル・アーティスト・イベント詳細に統計タブを追加

### DIFF
--- a/apps/web/src/components/public/detail-tabs.tsx
+++ b/apps/web/src/components/public/detail-tabs.tsx
@@ -1,0 +1,59 @@
+import { BarChart3, Disc3, Music } from "lucide-react";
+import type { ReactNode } from "react";
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+interface TabConfig<T extends string> {
+	key: T;
+	label: string;
+	icon?: ReactNode;
+}
+
+interface DetailTabsProps<T extends string> {
+	tabs: TabConfig<T>[];
+	activeTab: T;
+	onTabChange: (tab: T) => void;
+}
+
+// =============================================================================
+// コンポーネント
+// =============================================================================
+
+/**
+ * 詳細ページ用タブコンポーネント
+ */
+export function DetailTabs<T extends string>({
+	tabs,
+	activeTab,
+	onTabChange,
+}: DetailTabsProps<T>) {
+	return (
+		<div role="tablist" className="tabs tabs-boxed w-fit">
+			{tabs.map((tab) => (
+				<button
+					key={tab.key}
+					type="button"
+					role="tab"
+					className={`tab gap-2 ${activeTab === tab.key ? "tab-active" : ""}`}
+					onClick={() => onTabChange(tab.key)}
+					aria-selected={activeTab === tab.key}
+				>
+					{tab.icon}
+					{tab.label}
+				</button>
+			))}
+		</div>
+	);
+}
+
+// =============================================================================
+// タブアイコン
+// =============================================================================
+
+export const TabIcons = {
+	releases: <Disc3 className="size-4" />,
+	tracks: <Music className="size-4" />,
+	stats: <BarChart3 className="size-4" />,
+} as const;

--- a/apps/web/src/components/public/index.ts
+++ b/apps/web/src/components/public/index.ts
@@ -1,3 +1,4 @@
+export { DetailTabs, TabIcons } from "./detail-tabs";
 export {
 	MediaEmbed,
 	MediaEmbedList,
@@ -33,4 +34,5 @@ export {
 	TwoStageScriptFilter,
 } from "./script-filter";
 export { StatsCards } from "./stats-cards";
+export { StatsPlaceholder } from "./stats-placeholder";
 export { type ViewMode, ViewToggle } from "./view-toggle";

--- a/apps/web/src/components/public/stats-placeholder.tsx
+++ b/apps/web/src/components/public/stats-placeholder.tsx
@@ -1,0 +1,47 @@
+import { BarChart3 } from "lucide-react";
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+interface StatsPlaceholderProps {
+	entityType: "circle" | "artist" | "event";
+	entityName: string;
+}
+
+// =============================================================================
+// 定数
+// =============================================================================
+
+const ENTITY_LABELS = {
+	circle: "サークル",
+	artist: "アーティスト",
+	event: "イベント",
+} as const;
+
+// =============================================================================
+// コンポーネント
+// =============================================================================
+
+/**
+ * 統計タブのプレースホルダーコンポーネント
+ */
+export function StatsPlaceholder({
+	entityType,
+	entityName,
+}: StatsPlaceholderProps) {
+	return (
+		<div className="rounded-lg bg-base-100 p-8 text-center shadow-sm">
+			<div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-base-200">
+				<BarChart3 className="size-8 text-base-content/50" />
+			</div>
+			<h3 className="mb-2 font-bold text-lg">{entityName}の統計情報</h3>
+			<p className="text-base-content/70">
+				{ENTITY_LABELS[entityType]}の詳細な統計情報がここに表示されます
+			</p>
+			<p className="mt-4 text-base-content/50 text-sm">
+				この機能は今後実装予定です
+			</p>
+		</div>
+	);
+}

--- a/apps/web/src/lib/detail-tab-utils.ts
+++ b/apps/web/src/lib/detail-tab-utils.ts
@@ -1,0 +1,112 @@
+/**
+ * 詳細ページタブユーティリティ
+ *
+ * サークル詳細、アーティスト詳細、イベント詳細ページの
+ * タブ管理とURLパラメータバリデーションを提供。
+ */
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+/** サークル詳細のタブ */
+export type CircleDetailTab = "releases" | "tracks" | "stats";
+
+/** アーティスト詳細のタブ */
+export type ArtistDetailTab = "tracks" | "stats";
+
+/** イベント詳細のタブ */
+export type EventDetailTab = "releases" | "stats";
+
+// =============================================================================
+// 定数
+// =============================================================================
+
+/** サークル詳細タブの配列 */
+export const CIRCLE_DETAIL_TABS: readonly CircleDetailTab[] = [
+	"releases",
+	"tracks",
+	"stats",
+] as const;
+
+/** アーティスト詳細タブの配列 */
+export const ARTIST_DETAIL_TABS: readonly ArtistDetailTab[] = [
+	"tracks",
+	"stats",
+] as const;
+
+/** イベント詳細タブの配列 */
+export const EVENT_DETAIL_TABS: readonly EventDetailTab[] = [
+	"releases",
+	"stats",
+] as const;
+
+/** タブラベル */
+export const TAB_LABELS = {
+	releases: "リリース一覧",
+	tracks: "曲一覧",
+	stats: "統計",
+} as const;
+
+// =============================================================================
+// バリデーション関数
+// =============================================================================
+
+/**
+ * 有効なサークル詳細タブか判定
+ */
+export function isValidCircleDetailTab(
+	value: unknown,
+): value is CircleDetailTab {
+	return (
+		typeof value === "string" &&
+		CIRCLE_DETAIL_TABS.includes(value as CircleDetailTab)
+	);
+}
+
+/**
+ * 有効なアーティスト詳細タブか判定
+ */
+export function isValidArtistDetailTab(
+	value: unknown,
+): value is ArtistDetailTab {
+	return (
+		typeof value === "string" &&
+		ARTIST_DETAIL_TABS.includes(value as ArtistDetailTab)
+	);
+}
+
+/**
+ * 有効なイベント詳細タブか判定
+ */
+export function isValidEventDetailTab(value: unknown): value is EventDetailTab {
+	return (
+		typeof value === "string" &&
+		EVENT_DETAIL_TABS.includes(value as EventDetailTab)
+	);
+}
+
+// =============================================================================
+// URL パラメータ用ヘルパー
+// =============================================================================
+
+/**
+ * URLパラメータをパースしてサークル詳細タブを取得
+ */
+export function parseCircleDetailTab(value: unknown): CircleDetailTab {
+	return isValidCircleDetailTab(value) ? value : "releases";
+}
+
+/**
+ * URLパラメータをパースしてアーティスト詳細タブを取得
+ */
+export function parseArtistDetailTab(value: unknown): ArtistDetailTab {
+	return isValidArtistDetailTab(value) ? value : "tracks";
+}
+
+/**
+ * URLパラメータをパースしてイベント詳細タブを取得
+ */
+export function parseEventDetailTab(value: unknown): EventDetailTab {
+	return isValidEventDetailTab(value) ? value : "releases";
+}


### PR DESCRIPTION
## 概要

サークル詳細、アーティスト詳細、イベント詳細の画面に「統計」タブを追加し、URLパラメータでタブに直接アクセスできるようにする。

## 変更内容

* 詳細ページにタブ構造を導入し、URLパラメータ（`?tab=stats`）で直接アクセス可能に
* サークル詳細: リリース一覧 / 曲一覧 / 統計の3タブ
* アーティスト詳細: 曲一覧 / 統計の2タブ
* イベント詳細: リリース一覧 / 統計の2タブ
* 統計タブはプレースホルダーとして実装（内容は今後追加予定）
* 汎用タブコンポーネント（`DetailTabs`）を作成
* タブタイプとバリデーション関数のユーティリティ（`detail-tab-utils.ts`）を追加

## 影響範囲

* `/circles/:id` - タブ管理がuseStateからURLパラメータに変更
* `/artists/:id` - 新規タブ構造を追加
* `/events/:id` - 新規タブ構造を追加

## 補足事項

* 統計タブの具体的な内容（グラフ表示など）は今後実装予定
* 既存のURLはデフォルトタブにフォールバックするため後方互換性あり