### PR TITLE
fix: リリース詳細のアーティストリンクをartistAliasIdベースに変更

### DIFF
--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -379,7 +379,10 @@ export interface PublicReleaseDetail {
 		nameEn: string | null;
 		credits: Array<{
 			artistId: string;
+			artistAliasId: string | null;
 			creditName: string;
+			aliasName: string | null;
+			artistName: string | null;
 			roles: Array<{ roleCode: string; roleName: string | null }>;
 		}>;
 		officialSongs: Array<{

--- a/apps/web/src/routes/_public/releases_.$id.tsx
+++ b/apps/web/src/routes/_public/releases_.$id.tsx
@@ -303,27 +303,38 @@ function TrackTable({ tracks }: { tracks: PublicReleaseDetail["tracks"] }) {
 							</td>
 							<td className="hidden md:table-cell">
 								<div className="flex flex-wrap gap-1">
-									{track.credits.slice(0, 3).map((credit, idx) => (
-										<span key={credit.artistId}>
-											{idx > 0 && ", "}
-											<Link
-												to="/artists/$id"
-												params={{ id: credit.artistId }}
-												className="hover:text-primary"
-											>
-												{credit.creditName}
-											</Link>
-											{credit.roles.length > 0 && (
-												<span className="text-base-content/50 text-xs">
-													(
-													{credit.roles
-														.map((r) => r.roleName ?? r.roleCode)
-														.join("/")}
-													)
-												</span>
-											)}
-										</span>
-									))}
+									{track.credits.slice(0, 3).map((credit, idx) => {
+										// 表示名: creditName → aliasName → artistName の優先順
+										const displayName =
+											credit.creditName ||
+											credit.aliasName ||
+											credit.artistName ||
+											"Unknown";
+										// リンク先ID: artistAliasId があればそれを使用、なければ artistId__main__
+										const linkId =
+											credit.artistAliasId ?? `${credit.artistId}__main__`;
+										return (
+											<span key={credit.artistAliasId ?? credit.artistId}>
+												{idx > 0 && ", "}
+												<Link
+													to="/artists/$id"
+													params={{ id: linkId }}
+													className="hover:text-primary"
+												>
+													{displayName}
+												</Link>
+												{credit.roles.length > 0 && (
+													<span className="text-base-content/50 text-xs">
+														(
+														{credit.roles
+															.map((r) => r.roleName ?? r.roleCode)
+															.join("/")}
+														)
+													</span>
+												)}
+											</span>
+										);
+									})}
 									{track.credits.length > 3 && (
 										<span className="text-base-content/50 text-xs">
 											他{track.credits.length - 3}名


### PR DESCRIPTION
## 概要

リリース詳細ページのトラックテーブルで、アーティストの表示名とリンク先を修正。

## 問題の原因

アーティスト詳細APIは `artistAliasId` を期待しているが、リリース詳細ページのアーティストリンクは `artistId` を使用していたため、正しいアーティスト詳細ページに遷移できなかった。

## 変更内容

* サーバーAPI（releases.ts）で `artistAliases`, `artists` をLEFT JOINして追加データを返すように変更
  * 取得フィールド: `artistAliasId`, `aliasName`, `artistName`
* フロントエンド型（public-api.ts）に3フィールドを追加
* 表示ロジック（releases_.$id.tsx）を変更
  * 表示名の優先順位: `creditName` → `aliasName` → `artistName`
  * リンク先: `artistAliasId` があればそれを使用、なければ `{artistId}__main__`

## 影響範囲

* リリース詳細ページ（`/releases/:id`）のトラックテーブル
* アーティストリンクの遷移先