### PR TITLE
feat: 積み上げグラフの原曲表示順序をID順に変更

### DIFF
--- a/apps/web/src/components/public/work-stats-section.tsx
+++ b/apps/web/src/components/public/work-stats-section.tsx
@@ -176,19 +176,29 @@ function transformStackedDataForNivo(
 		);
 	}
 
-	// 全曲のユニークキーを収集
-	const songKeysSet = new Set<string>();
+	// 各ワーク内の曲をID順にソート
+	for (const work of sorted) {
+		work.songs.sort((a, b) => a.id.localeCompare(b.id));
+	}
+
+	// 全曲のユニークキーを収集（ID順でソート済み）
+	const songKeysMap = new Map<string, { id: string; name: string }>();
 	const colors: Record<string, string> = {};
 	for (const work of sorted) {
 		for (const song of work.songs) {
 			const key = song.name ?? "不明";
-			songKeysSet.add(key);
+			if (!songKeysMap.has(key)) {
+				songKeysMap.set(key, { id: song.id, name: key });
+			}
 			if (!colors[key]) {
 				colors[key] = getColorForItem(song.id);
 			}
 		}
 	}
-	const keys = Array.from(songKeysSet);
+	// ID順でキーをソート
+	const keys = Array.from(songKeysMap.values())
+		.sort((a, b) => a.id.localeCompare(b.id))
+		.map((item) => item.name);
 
 	// Nivo BarDatum形式に変換（totalTrackCountを含める）
 	const data: BarDatum[] = sorted.map((work) => {


### PR DESCRIPTION
## 概要

積み上げグラフ内の原曲の表示順序を、アレンジ数順から原曲ID順に変更する。

## 変更内容

* 各ワーク内の原曲（songs）を `song.id` でソートするロジックを追加
* 凡例のキー順序もID順に統一

## 影響範囲

* サークル/アーティスト/イベントの統計ページの積み上げグラフ表示

## 補足事項

これにより、同一ワーク内の原曲が一貫した順序（原曲ID順）で表示されるようになります。