### PR TITLE
feat: 統計グラフセクションのUI改善

### DIFF
--- a/apps/web/src/components/public/work-stats-section.tsx
+++ b/apps/web/src/components/public/work-stats-section.tsx
@@ -788,7 +788,7 @@ export function WorkStatsSection({
 	return (
 		<div className="space-y-4">
 			{/* ヘッダー: タイトル + コントロール */}
-			<div className="space-y-3 rounded-lg border-2 border-base-content/20 bg-base-100 p-4 shadow-sm">
+			<div className="space-y-6 rounded-lg border-2 border-base-content/20 bg-base-100 p-6 shadow-sm">
 				{/* タイトル行 */}
 				{selectedWorkId ? (
 					<div className="flex items-center gap-3">
@@ -808,7 +808,7 @@ export function WorkStatsSection({
 						</div>
 					</div>
 				) : (
-					<h3 className="font-bold text-base-content text-lg">原作/原曲</h3>
+					<h3 className="mb-10 font-bold text-base-content text-lg">原作/原曲</h3>
 				)}
 
 				{/* コントロール行: 左=並び替え、中央=表示モード、右=向き */}


### PR DESCRIPTION
## 概要

統計グラフセクション（原作/原曲）のUIを改善し、より直感的で見やすいレイアウトにしました。

## 変更内容

* 「原作/原曲」タイトルを追加し、Box風コンテナでグループ化
* 「表示モード：」ラベルを削除してUIを簡潔化
* コントロール配置を変更（左:並び替え、中央:表示モード、右:向き切替）
* グラフをBox内に含めて一体感のあるデザインに
* 「単純」モードのアイコンをグラフの向きに応じて動的に変更
* 並び替えボタンのデフォルト状態を`btn-outline`に変更してクリック可能であることを明示
* Box内のパディングと要素間のスペースを調整

## 影響範囲

* `apps/web/src/components/public/work-stats-section.tsx`
  - サークル詳細、アーティスト詳細、イベント詳細ページの統計グラフ表示

## 補足事項

レイアウト変更のみで、機能面での変更はありません。