### PR TITLE
feat: タブスタイルをtabs-borderに変更

### DIFF
--- a/apps/web/src/components/public/detail-tabs.tsx
+++ b/apps/web/src/components/public/detail-tabs.tsx
@@ -30,7 +30,7 @@ export function DetailTabs<T extends string>({
 	onTabChange,
 }: DetailTabsProps<T>) {
 	return (
-		<div role="tablist" className="tabs tabs-boxed w-fit">
+		<div role="tablist" className="tabs tabs-border w-fit">
 			{tabs.map((tab) => (
 				<button
 					key={tab.key}

--- a/apps/web/src/components/public/work-stats-section.tsx
+++ b/apps/web/src/components/public/work-stats-section.tsx
@@ -808,7 +808,9 @@ export function WorkStatsSection({
 						</div>
 					</div>
 				) : (
-					<h3 className="mb-10 font-bold text-base-content text-lg">原作/原曲</h3>
+					<h3 className="mb-10 font-bold text-base-content text-lg">
+						原作/原曲
+					</h3>
 				)}
 
 				{/* コントロール行: 左=並び替え、中央=表示モード、右=向き */}


### PR DESCRIPTION
## 概要

詳細ページのタブコンポーネントのスタイルを`tabs-boxed`から`tabs-border`に変更

## 変更内容

* DetailTabsコンポーネントのタブスタイルを`tabs-border`に変更

## 影響範囲

以下のページのタブ表示が変更される：
* イベント詳細ページ（/events/:id）
* アーティスト詳細ページ（/artists/:id）
* サークル詳細ページ（/circles/:id）