### PR TITLE
refactor: daisyUIコンポーネントに統一

### DIFF
--- a/apps/web/src/components/admin-header.tsx
+++ b/apps/web/src/components/admin-header.tsx
@@ -36,16 +36,16 @@ export default function AdminHeader({ user }: AdminHeaderProps) {
 	};
 
 	return (
-		<div className="bg-slate-800">
+		<div className="bg-neutral text-neutral-content">
 			<div className="flex flex-row items-center justify-between px-4 py-2">
 				<div className="flex items-center gap-6">
-					<span className="font-bold text-lg text-white">管理者</span>
+					<span className="font-bold text-lg">管理者</span>
 					<nav className="flex gap-4">
 						{navLinks.map(({ to, label }) => (
 							<Link
 								key={to}
 								to={to}
-								className="text-slate-300 hover:text-white [&.active]:font-semibold [&.active]:text-white"
+								className="text-neutral-content/70 hover:text-neutral-content [&.active]:font-semibold [&.active]:text-neutral-content"
 							>
 								{label}
 							</Link>
@@ -53,7 +53,9 @@ export default function AdminHeader({ user }: AdminHeaderProps) {
 					</nav>
 				</div>
 				<div className="flex items-center gap-4">
-					<span className="text-slate-300">{user?.name || user?.email}</span>
+					<span className="text-neutral-content/70">
+						{user?.name || user?.email}
+					</span>
 					<Button variant="outline" size="sm" onClick={handleLogout}>
 						ログアウト
 					</Button>

--- a/apps/web/src/components/admin/official-links-card.tsx
+++ b/apps/web/src/components/admin/official-links-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import {
 	Table,
 	TableBody,
@@ -169,7 +170,7 @@ export function OfficialLinksCard({
 
 	if (isLoading) {
 		return (
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<Card className="card-bordered">
 				<div className="flex items-center justify-between border-base-300 border-b p-4">
 					<h3 className="flex items-center gap-2 font-semibold text-lg">
 						<ExternalLink className="h-5 w-5" />
@@ -182,13 +183,13 @@ export function OfficialLinksCard({
 						<div className="h-8 rounded bg-base-300" />
 					</div>
 				</div>
-			</div>
+			</Card>
 		);
 	}
 
 	return (
 		<>
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<Card className="card-bordered">
 				<div className="flex items-center justify-between border-base-300 border-b p-4">
 					<h3 className="flex items-center gap-2 font-semibold text-lg">
 						<ExternalLink className="h-5 w-5" />
@@ -220,18 +221,18 @@ export function OfficialLinksCard({
 									<TableRow key={link.id}>
 										<TableCell>
 											<div className="flex gap-1">
-												<button
-													type="button"
-													className="btn btn-xs btn-ghost"
+												<Button
+													variant="ghost"
+													size="xs"
 													disabled={index === 0 || reorderMutation.isPending}
 													onClick={() => handleMoveUp(index)}
 													title="上へ移動"
 												>
 													<ArrowUp className="h-3 w-3" />
-												</button>
-												<button
-													type="button"
-													className="btn btn-xs btn-ghost"
+												</Button>
+												<Button
+													variant="ghost"
+													size="xs"
 													disabled={
 														index === sortedLinks.length - 1 ||
 														reorderMutation.isPending
@@ -240,7 +241,7 @@ export function OfficialLinksCard({
 													title="下へ移動"
 												>
 													<ArrowDown className="h-3 w-3" />
-												</button>
+												</Button>
 											</div>
 										</TableCell>
 										<TableCell className="font-medium">
@@ -261,23 +262,24 @@ export function OfficialLinksCard({
 										</TableCell>
 										<TableCell>
 											<div className="flex gap-1">
-												<button
-													type="button"
-													className="btn btn-xs btn-ghost"
+												<Button
+													variant="ghost"
+													size="xs"
 													onClick={() => openEditDialog(link)}
 													title="編集"
 												>
 													<Pencil className="h-3 w-3" />
-												</button>
-												<button
-													type="button"
-													className="btn btn-xs btn-ghost text-error"
+												</Button>
+												<Button
+													variant="ghost"
+													size="xs"
 													onClick={() => handleDelete(link.id)}
 													disabled={isDeleting === link.id}
 													title="削除"
+													className="text-error"
 												>
 													<Trash2 className="h-3 w-3" />
-												</button>
+												</Button>
 											</div>
 										</TableCell>
 									</TableRow>
@@ -286,7 +288,7 @@ export function OfficialLinksCard({
 						</Table>
 					</div>
 				)}
-			</div>
+			</Card>
 
 			<OfficialLinkDialog
 				open={dialogOpen}

--- a/apps/web/src/components/public/empty-state.tsx
+++ b/apps/web/src/components/public/empty-state.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import { AlertCircle, Inbox, Search, SearchX } from "lucide-react";
+import { Card } from "../ui/card";
 
 export type EmptyStateType = "filter" | "empty" | "error" | "search";
 
@@ -50,13 +51,13 @@ export function EmptyState({
 	const displayDescription = description ?? config.description;
 
 	return (
-		<div className="rounded-lg bg-base-100 p-8 text-center shadow-sm">
+		<Card className="p-8 text-center">
 			<Icon className="mx-auto size-12 text-base-content/30" />
 			<h3 className="mt-4 font-medium text-base-content/70 text-lg">
 				{displayTitle}
 			</h3>
 			<p className="mt-2 text-base-content/50 text-sm">{displayDescription}</p>
 			{action && <div className="mt-4">{action}</div>}
-		</div>
+		</Card>
 	);
 }

--- a/apps/web/src/components/public/entity-card.tsx
+++ b/apps/web/src/components/public/entity-card.tsx
@@ -1,6 +1,8 @@
 import { Link } from "@tanstack/react-router";
+import { Badge, type BadgeVariant } from "../ui/badge";
+import { Card } from "../ui/card";
 
-export interface Badge {
+export interface BadgeInfo {
 	label: string;
 	variant: "primary" | "secondary" | "accent" | "ghost";
 }
@@ -9,17 +11,10 @@ interface EntityCardProps {
 	href: string;
 	title: string;
 	subtitle?: string;
-	badges?: Badge[];
+	badges?: BadgeInfo[];
 	meta?: string;
 	image?: string;
 }
-
-const badgeVariantClass: Record<Badge["variant"], string> = {
-	primary: "badge-primary",
-	secondary: "badge-secondary",
-	accent: "badge-accent",
-	ghost: "badge-ghost",
-};
 
 export function EntityCard({
 	href,
@@ -30,32 +25,34 @@ export function EntityCard({
 	image,
 }: EntityCardProps) {
 	return (
-		<Link
-			to={href}
-			className="card bg-base-100 shadow-sm transition-shadow hover:shadow-md"
-		>
-			{image && (
-				<figure className="aspect-square bg-base-200">
-					<img src={image} alt={title} className="size-full object-cover" />
-				</figure>
-			)}
-			<div className="card-body p-4">
-				<h3 className="card-title text-base">{title}</h3>
-				{subtitle && <p className="text-base-content/70 text-sm">{subtitle}</p>}
-				{badges && badges.length > 0 && (
-					<div className="flex flex-wrap gap-1">
-						{badges.map((badge) => (
-							<span
-								key={badge.label}
-								className={`badge badge-sm ${badgeVariantClass[badge.variant]}`}
-							>
-								{badge.label}
-							</span>
-						))}
-					</div>
+		<Link to={href} className="block">
+			<Card className="transition-shadow hover:shadow-md">
+				{image && (
+					<figure className="aspect-square bg-base-200">
+						<img src={image} alt={title} className="size-full object-cover" />
+					</figure>
 				)}
-				{meta && <p className="text-base-content/50 text-sm">{meta}</p>}
-			</div>
+				<div className="card-body p-4">
+					<h3 className="card-title text-base">{title}</h3>
+					{subtitle && (
+						<p className="text-base-content/70 text-sm">{subtitle}</p>
+					)}
+					{badges && badges.length > 0 && (
+						<div className="flex flex-wrap gap-1">
+							{badges.map((badge) => (
+								<Badge
+									key={badge.label}
+									variant={badge.variant as BadgeVariant}
+									className="badge-sm"
+								>
+									{badge.label}
+								</Badge>
+							))}
+						</div>
+					)}
+					{meta && <p className="text-base-content/50 text-sm">{meta}</p>}
+				</div>
+			</Card>
 		</Link>
 	);
 }

--- a/apps/web/src/components/public/features-section.tsx
+++ b/apps/web/src/components/public/features-section.tsx
@@ -1,4 +1,5 @@
 import { Database, Music, Search, Users } from "lucide-react";
+import { Card } from "../ui/card";
 
 const features = [
 	{
@@ -52,16 +53,16 @@ export function FeaturesSection() {
 
 				<div className="grid gap-8 md:grid-cols-2">
 					{features.map((feature) => (
-						<div
+						<Card
 							key={feature.title}
-							className="glass-card group rounded-2xl p-8 transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
+							className="group rounded-2xl p-8 transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
 						>
 							<div className="mb-4 flex h-14 w-14 items-center justify-center rounded-xl bg-primary/10 text-primary transition-transform duration-300 group-hover:scale-110">
 								<feature.icon className="h-7 w-7" aria-hidden="true" />
 							</div>
 							<h3 className="mb-2 font-bold text-xl">{feature.title}</h3>
 							<p className="text-base-content/60">{feature.description}</p>
-						</div>
+						</Card>
 					))}
 				</div>
 			</div>

--- a/apps/web/src/components/public/hero-section.tsx
+++ b/apps/web/src/components/public/hero-section.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { Calendar, Disc3, Music, Search, Sparkles, Users } from "lucide-react";
+import { Badge } from "../ui/badge";
 
 // Mock data for demonstration
 const mockStats = {
@@ -49,10 +50,13 @@ export function HeroSection() {
 
 			<div className="relative mx-auto max-w-4xl text-center">
 				{/* Badge */}
-				<div className="mb-6 inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-primary text-sm">
+				<Badge
+					variant="primary"
+					className="mb-6 inline-flex items-center gap-2 bg-primary/10 px-4 py-2 text-primary"
+				>
 					<Sparkles className="h-4 w-4" aria-hidden="true" />
 					<span>東方アレンジ楽曲データベース</span>
-				</div>
+				</Badge>
 
 				{/* Main title with gradient */}
 				<h1 className="mb-4 font-bold text-5xl tracking-tight md:text-6xl lg:text-7xl">

--- a/apps/web/src/components/public/index.ts
+++ b/apps/web/src/components/public/index.ts
@@ -7,7 +7,7 @@ export {
 	YouTubeEmbed,
 } from "./embeds";
 export { EmptyState, type EmptyStateType } from "./empty-state";
-export { type Badge, EntityCard } from "./entity-card";
+export { type BadgeInfo, EntityCard } from "./entity-card";
 export { ExternalLink } from "./external-link";
 export { FeaturesSection } from "./features-section";
 export { HeroSection } from "./hero-section";

--- a/apps/web/src/components/public/recent-releases.tsx
+++ b/apps/web/src/components/public/recent-releases.tsx
@@ -7,6 +7,9 @@ import {
 	Sparkles,
 } from "lucide-react";
 import { useRef, useState } from "react";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Card } from "../ui/card";
 
 interface Release {
 	id: string;
@@ -62,7 +65,7 @@ const mockReleases: Release[] = [
 function ReleaseCard({ release }: { release: Release }) {
 	return (
 		<div className="min-w-[180px] flex-shrink-0 snap-start sm:min-w-[200px]">
-			<div className="glass-card group h-full overflow-hidden rounded-2xl transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10">
+			<Card className="group h-full overflow-hidden rounded-2xl transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10">
 				{/* Album art placeholder */}
 				<div className="relative aspect-square overflow-hidden bg-gradient-to-br from-primary/20 via-secondary/10 to-accent/20">
 					<div className="flex h-full items-center justify-center">
@@ -73,10 +76,13 @@ function ReleaseCard({ release }: { release: Release }) {
 					</div>
 					{release.isNew && (
 						<div className="absolute top-2 right-2">
-							<div className="flex items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-primary-content text-xs shadow-lg">
+							<Badge
+								variant="primary"
+								className="flex items-center gap-1 bg-primary px-2 py-0.5 text-primary-content shadow-lg"
+							>
 								<Sparkles className="h-3 w-3" aria-hidden="true" />
 								NEW
-							</div>
+							</Badge>
 						</div>
 					)}
 					{/* Overlay on hover */}
@@ -98,7 +104,7 @@ function ReleaseCard({ release }: { release: Release }) {
 						<span>{release.eventName}</span>
 					</div>
 				</div>
-			</div>
+			</Card>
 		</div>
 	);
 }
@@ -129,31 +135,33 @@ export function RecentReleases() {
 			<div className="mb-6 flex items-center justify-between">
 				<div className="flex items-center gap-3">
 					<h2 className="font-bold text-xl">最近のリリース</h2>
-					<div className="rounded-full bg-primary/10 px-2.5 py-0.5 text-primary text-xs">
+					<Badge variant="primary" className="bg-primary/10 text-primary">
 						{mockReleases.length}件
-					</div>
+					</Badge>
 				</div>
 				<div className="flex items-center gap-2">
 					{/* Desktop scroll buttons */}
 					<div className="hidden items-center gap-1 md:flex">
-						<button
-							type="button"
+						<Button
+							variant="ghost"
+							size="icon"
 							onClick={() => scroll("left")}
 							disabled={!canScrollLeft}
-							className="flex h-8 w-8 items-center justify-center rounded-full bg-base-200 text-base-content/60 transition-all hover:bg-base-300 hover:text-base-content disabled:cursor-not-allowed disabled:opacity-30"
 							aria-label="前へ"
+							className="h-8 w-8 rounded-full"
 						>
 							<ChevronLeft className="h-4 w-4" />
-						</button>
-						<button
-							type="button"
+						</Button>
+						<Button
+							variant="ghost"
+							size="icon"
 							onClick={() => scroll("right")}
 							disabled={!canScrollRight}
-							className="flex h-8 w-8 items-center justify-center rounded-full bg-base-200 text-base-content/60 transition-all hover:bg-base-300 hover:text-base-content disabled:cursor-not-allowed disabled:opacity-30"
 							aria-label="次へ"
+							className="h-8 w-8 rounded-full"
 						>
 							<ChevronRight className="h-4 w-4" />
-						</button>
+						</Button>
 					</div>
 					<Link
 						to="/stats"

--- a/apps/web/src/components/public/stats-cards.tsx
+++ b/apps/web/src/components/public/stats-cards.tsx
@@ -8,6 +8,8 @@ import {
 	Users,
 } from "lucide-react";
 import { formatNumber } from "../../lib/format";
+import { Badge } from "../ui/badge";
+import { Card } from "../ui/card";
 
 interface StatCardProps {
 	icon: LucideIcon;
@@ -19,16 +21,19 @@ interface StatCardProps {
 
 function StatCard({ icon: Icon, count, label, href, trend }: StatCardProps) {
 	const content = (
-		<div className="glass-card group flex flex-col gap-3 rounded-2xl p-5 transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10">
+		<Card className="group flex flex-col gap-3 rounded-2xl p-5 transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10">
 			<div className="flex items-center justify-between">
 				<div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10 text-primary transition-transform duration-300 group-hover:scale-110">
 					<Icon className="h-5 w-5" aria-hidden="true" />
 				</div>
 				{trend !== undefined && (
-					<div className="flex items-center gap-1 rounded-full bg-success/10 px-2 py-1 text-success text-xs">
+					<Badge
+						variant="success"
+						className="flex items-center gap-1 bg-success/10 text-success"
+					>
 						<TrendingUp className="h-3 w-3" aria-hidden="true" />
 						<span>+{trend}%</span>
-					</div>
+					</Badge>
 				)}
 			</div>
 			<div>
@@ -37,7 +42,7 @@ function StatCard({ icon: Icon, count, label, href, trend }: StatCardProps) {
 				</div>
 				<div className="mt-1 text-base-content/60 text-sm">{label}</div>
 			</div>
-		</div>
+		</Card>
 	);
 
 	if (href) {

--- a/apps/web/src/components/public/view-toggle.tsx
+++ b/apps/web/src/components/public/view-toggle.tsx
@@ -1,4 +1,5 @@
 import { LayoutGrid, List } from "lucide-react";
+import { Button } from "../ui/button";
 
 export type ViewMode = "grid" | "list";
 
@@ -10,24 +11,24 @@ interface ViewToggleProps {
 export function ViewToggle({ value, onChange }: ViewToggleProps) {
 	return (
 		<div className="flex gap-1 rounded-lg bg-base-200 p-1">
-			<button
-				type="button"
-				className={`btn btn-sm ${value === "grid" ? "btn-primary" : "btn-ghost"}`}
+			<Button
+				size="sm"
+				variant={value === "grid" ? "primary" : "ghost"}
 				onClick={() => onChange("grid")}
 				aria-label="グリッド表示"
 				aria-pressed={value === "grid"}
 			>
 				<LayoutGrid className="size-4" />
-			</button>
-			<button
-				type="button"
-				className={`btn btn-sm ${value === "list" ? "btn-primary" : "btn-ghost"}`}
+			</Button>
+			<Button
+				size="sm"
+				variant={value === "list" ? "primary" : "ghost"}
 				onClick={() => onChange("list")}
 				aria-label="リスト表示"
 				aria-pressed={value === "list"}
 			>
 				<List className="size-4" />
-			</button>
+			</Button>
 		</div>
 	);
 }

--- a/apps/web/src/components/public/work-stats-section.tsx
+++ b/apps/web/src/components/public/work-stats-section.tsx
@@ -27,6 +27,8 @@ import {
 	type WorkStat,
 	type WorkStatsResponse,
 } from "@/lib/public-api";
+import { Button } from "../ui/button";
+import { Card } from "../ui/card";
 import { WorkStatsSkeleton } from "./work-stats-skeleton";
 
 // SSR対応: @nivo/barを動的インポート
@@ -764,24 +766,24 @@ export function WorkStatsSection({
 	// エラー表示
 	if (error) {
 		return (
-			<div className="rounded-lg bg-base-100 p-8 text-center shadow-sm">
+			<Card className="p-8 text-center">
 				<div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-error/10">
 					<BarChart3 className="size-8 text-error" />
 				</div>
 				<p className="text-error">{error}</p>
-			</div>
+			</Card>
 		);
 	}
 
 	// データなし
 	if (!chartData || chartData.data.length === 0) {
 		return (
-			<div className="rounded-lg bg-base-100 p-8 text-center shadow-sm">
+			<Card className="p-8 text-center">
 				<div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-base-200">
 					<BarChart3 className="size-8 text-base-content/50" />
 				</div>
 				<p className="text-base-content/70">統計データがありません</p>
-			</div>
+			</Card>
 		);
 	}
 
@@ -794,18 +796,14 @@ export function WorkStatsSection({
 	return (
 		<div className="space-y-4">
 			{/* ヘッダー: タイトル + コントロール */}
-			<div className="space-y-6 rounded-lg border-2 border-base-content/20 bg-base-100 p-6 shadow-sm">
+			<Card className="space-y-6 border-2 border-base-content/20 p-6">
 				{/* タイトル行 */}
 				{selectedWorkId ? (
 					<div className="flex items-center gap-3">
-						<button
-							type="button"
-							className="btn btn-ghost btn-sm gap-1"
-							onClick={handleBack}
-						>
+						<Button variant="ghost" size="sm" onClick={handleBack}>
 							<ArrowLeft className="size-4" />
 							戻る
-						</button>
+						</Button>
 						<div>
 							<span className="font-medium text-primary">
 								{selectedWorkName}
@@ -817,10 +815,11 @@ export function WorkStatsSection({
 					<div className="mb-10 flex items-center justify-between">
 						<h3 className="font-bold text-base-content text-lg">原作/原曲</h3>
 						{/* モバイル: 並び替えボタンをタイトル行に配置 */}
-						<button
-							type="button"
-							className={`btn btn-sm gap-1 md:hidden ${sortOrder === "id" ? "btn-outline" : "btn-secondary"}`}
+						<Button
+							variant={sortOrder === "id" ? "outline" : "secondary"}
+							size="sm"
 							onClick={cycleSortOrder}
+							className="md:hidden"
 						>
 							{sortOrder === "id" && (
 								<>
@@ -840,16 +839,16 @@ export function WorkStatsSection({
 									トラック数 ↑
 								</>
 							)}
-						</button>
+						</Button>
 					</div>
 				)}
 
 				{/* コントロール行: 左=並び替え、中央=表示モード、右=向き - デスクトップのみ */}
 				<div className="hidden items-center justify-between md:flex">
 					{/* 左: 並び替えボタン */}
-					<button
-						type="button"
-						className={`btn btn-sm gap-1 ${sortOrder === "id" ? "btn-outline" : "btn-secondary"}`}
+					<Button
+						variant={sortOrder === "id" ? "outline" : "secondary"}
+						size="sm"
 						onClick={cycleSortOrder}
 					>
 						{sortOrder === "id" && (
@@ -870,26 +869,28 @@ export function WorkStatsSection({
 								トラック数 ↑
 							</>
 						)}
-					</button>
+					</Button>
 
 					{/* 中央: 表示モード切替 - デスクトップのみ、ドリルダウン時は非表示 */}
 					{!selectedWorkId ? (
 						<div className="hidden items-center gap-2 md:flex">
 							<div className="join">
-								<button
-									type="button"
-									className={`btn join-item btn-sm gap-1 ${isStacked ? "btn-primary" : "btn-ghost"}`}
+								<Button
+									variant={isStacked ? "primary" : "ghost"}
+									size="sm"
 									onClick={() => !isStacked && handleModeToggle()}
 									disabled={isUpdating}
+									className="join-item"
 								>
 									<Layers className="size-4" />
 									積み上げ
-								</button>
-								<button
-									type="button"
-									className={`btn join-item btn-sm gap-1 ${!isStacked ? "btn-primary" : "btn-ghost"}`}
+								</Button>
+								<Button
+									variant={!isStacked ? "primary" : "ghost"}
+									size="sm"
 									onClick={() => isStacked && handleModeToggle()}
 									disabled={isUpdating}
+									className="join-item"
 								>
 									{effectiveOrientation === "horizontal" ? (
 										<BarChartHorizontal className="size-4" />
@@ -897,7 +898,7 @@ export function WorkStatsSection({
 										<BarChart3 className="size-4" />
 									)}
 									単純
-								</button>
+								</Button>
 							</div>
 							{isUpdating && (
 								<Loader2 className="size-4 animate-spin text-primary" />
@@ -909,30 +910,28 @@ export function WorkStatsSection({
 
 					{/* 右: 向き切り替えボタン - デスクトップのみ */}
 					<div className="join hidden md:flex">
-						<button
-							type="button"
-							className={`btn btn-sm btn-square join-item ${
-								effectiveOrientation === "vertical"
-									? "btn-primary"
-									: "btn-ghost"
-							}`}
+						<Button
+							variant={
+								effectiveOrientation === "vertical" ? "primary" : "ghost"
+							}
+							size="icon"
 							onClick={() => handleOrientationChange("vertical")}
 							title="縦グラフ"
+							className="join-item"
 						>
 							<BarChart3 className="size-4" />
-						</button>
-						<button
-							type="button"
-							className={`btn btn-sm btn-square join-item ${
-								effectiveOrientation === "horizontal"
-									? "btn-primary"
-									: "btn-ghost"
-							}`}
+						</Button>
+						<Button
+							variant={
+								effectiveOrientation === "horizontal" ? "primary" : "ghost"
+							}
+							size="icon"
 							onClick={() => handleOrientationChange("horizontal")}
 							title="横グラフ"
+							className="join-item"
 						>
 							<BarChartHorizontal className="size-4" />
-						</button>
+						</Button>
 					</div>
 				</div>
 
@@ -1035,7 +1034,7 @@ export function WorkStatsSection({
 						/>
 					</Suspense>
 				</div>
-			</div>
+			</Card>
 		</div>
 	);
 }

--- a/apps/web/src/components/search/FilterSection.tsx
+++ b/apps/web/src/components/search/FilterSection.tsx
@@ -1,5 +1,7 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface FilterSectionProps {
@@ -62,21 +64,22 @@ export function FilterSection({
 
 					{/* 選択数バッジ */}
 					{selectedCount > 0 && (
-						<span className="badge badge-primary badge-sm">
+						<Badge variant="primary" className="badge-sm">
 							{selectedCount}
-						</span>
+						</Badge>
 					)}
 				</div>
 
 				{/* クリアボタン */}
 				{selectedCount > 0 && onClear && (
-					<button
-						type="button"
+					<Button
+						variant="ghost"
+						size="xs"
 						onClick={handleClear}
-						className="rounded px-2 py-1 text-base-content/60 text-xs transition-colors hover:bg-base-300 hover:text-base-content"
+						className="text-base-content/60"
 					>
 						クリア
-					</button>
+					</Button>
 				)}
 			</button>
 

--- a/apps/web/src/components/sign-in-form.tsx
+++ b/apps/web/src/components/sign-in-form.tsx
@@ -93,7 +93,7 @@ export default function SignInForm({
 									onChange={(e) => field.handleChange(e.target.value)}
 								/>
 								{field.state.meta.errors.map((error) => (
-									<p key={error?.message} className="text-red-500">
+									<p key={error?.message} className="text-error text-sm">
 										{error?.message}
 									</p>
 								))}
@@ -116,7 +116,7 @@ export default function SignInForm({
 									onChange={(e) => field.handleChange(e.target.value)}
 								/>
 								{field.state.meta.errors.map((error) => (
-									<p key={error?.message} className="text-red-500">
+									<p key={error?.message} className="text-error text-sm">
 										{error?.message}
 									</p>
 								))}
@@ -142,7 +142,7 @@ export default function SignInForm({
 				<Button
 					variant="link"
 					onClick={onSwitchToSignUp}
-					className="text-indigo-600 hover:text-indigo-800"
+					className="text-primary hover:text-primary/80"
 				>
 					Need an account? Sign Up
 				</Button>

--- a/apps/web/src/components/sign-up-form.tsx
+++ b/apps/web/src/components/sign-up-form.tsx
@@ -95,7 +95,7 @@ export default function SignUpForm({
 									onChange={(e) => field.handleChange(e.target.value)}
 								/>
 								{field.state.meta.errors.map((error) => (
-									<p key={error?.message} className="text-red-500">
+									<p key={error?.message} className="text-error text-sm">
 										{error?.message}
 									</p>
 								))}
@@ -118,7 +118,7 @@ export default function SignUpForm({
 									onChange={(e) => field.handleChange(e.target.value)}
 								/>
 								{field.state.meta.errors.map((error) => (
-									<p key={error?.message} className="text-red-500">
+									<p key={error?.message} className="text-error text-sm">
 										{error?.message}
 									</p>
 								))}
@@ -141,7 +141,7 @@ export default function SignUpForm({
 									onChange={(e) => field.handleChange(e.target.value)}
 								/>
 								{field.state.meta.errors.map((error) => (
-									<p key={error?.message} className="text-red-500">
+									<p key={error?.message} className="text-error text-sm">
 										{error?.message}
 									</p>
 								))}
@@ -167,7 +167,7 @@ export default function SignUpForm({
 				<Button
 					variant="link"
 					onClick={onSwitchToSignIn}
-					className="text-indigo-600 hover:text-indigo-800"
+					className="text-primary hover:text-primary/80"
 				>
 					Already have an account? Sign In
 				</Button>

--- a/apps/web/src/routes/_public/search.tsx
+++ b/apps/web/src/routes/_public/search.tsx
@@ -20,6 +20,9 @@ import {
 	FilterChips,
 	useFilterChips,
 } from "@/components/search";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { createPageHead } from "@/lib/head";
 
 type SearchCategory = "all" | "artist" | "circle" | "track";
@@ -369,7 +372,7 @@ function SearchPage() {
 			<PublicBreadcrumb items={[{ label: "検索" }]} />
 
 			{/* Hero search section */}
-			<div className="glass-card relative overflow-hidden rounded-2xl p-6 md:p-8">
+			<Card className="relative overflow-hidden rounded-2xl p-6 md:p-8">
 				<div className="gradient-mesh absolute inset-0" />
 				<div className="relative">
 					<div className="mb-6 text-center">
@@ -408,24 +411,21 @@ function SearchPage() {
 							</div>
 
 							{/* Advanced search button */}
-							<button
+							<Button
 								type="button"
+								variant={activeFilterCount > 0 ? "primary" : "outline"}
 								onClick={openAdvancedSearch}
-								className={`flex items-center gap-2 rounded-xl border-2 px-4 py-2 font-medium transition-all ${
-									activeFilterCount > 0
-										? "border-primary bg-primary text-primary-content"
-										: "border-base-300 bg-base-100 text-base-content hover:border-primary hover:bg-primary/10"
-								}`}
+								className="gap-2 rounded-xl px-4 py-2"
 								aria-label="詳細検索を開く"
 							>
 								<SlidersHorizontal className="h-5 w-5" />
 								<span className="hidden sm:inline">詳細検索</span>
 								{activeFilterCount > 0 && (
-									<span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary-content text-primary text-xs">
+									<Badge className="flex h-5 w-5 items-center justify-center rounded-full bg-primary-content text-primary">
 										{activeFilterCount}
-									</span>
+									</Badge>
 								)}
-							</button>
+							</Button>
 						</div>
 					</form>
 
@@ -462,7 +462,7 @@ function SearchPage() {
 						</div>
 					)}
 				</div>
-			</div>
+			</Card>
 
 			{/* Advanced search modal */}
 			<AdvancedSearchModal
@@ -486,7 +486,7 @@ function SearchPage() {
 								className={`flex items-center gap-2 rounded-full px-4 py-2 text-sm transition-all ${
 									isActive
 										? "bg-primary text-primary-content shadow-md"
-										: "glass-card hover:ring-2 hover:ring-primary/20"
+										: "bg-base-100 shadow-sm hover:ring-2 hover:ring-primary/20"
 								}`}
 								aria-pressed={isActive}
 							>
@@ -521,36 +521,37 @@ function SearchPage() {
 								<Link
 									key={`${result.type}-${result.id}`}
 									to={getResultHref(result)}
-									className="glass-card group flex items-start gap-4 rounded-xl p-4 transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
 								>
-									<div
-										className={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl transition-transform duration-300 group-hover:scale-110 ${getResultIconColor(result.type)}`}
-									>
-										{getResultIcon(result.type)}
-									</div>
-									<div className="min-w-0 flex-1">
-										<div className="mb-1 flex items-center gap-2">
-											<span
-												className={`rounded-full bg-base-content/5 px-2 py-0.5 text-xs ${categoryConfig[result.type].color}`}
-											>
-												{categoryConfig[result.type].label}
-											</span>
+									<Card className="group flex items-start gap-4 rounded-xl p-4 transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10">
+										<div
+											className={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl transition-transform duration-300 group-hover:scale-110 ${getResultIconColor(result.type)}`}
+										>
+											{getResultIcon(result.type)}
 										</div>
-										<h3 className="font-semibold transition-colors group-hover:text-primary">
-											{highlightMatch(result.title, query)}
-										</h3>
-										<p className="mt-0.5 text-base-content/60 text-sm">
-											{highlightMatch(result.subtitle, query)}
-										</p>
-									</div>
-									<div className="hidden text-base-content/30 transition-all group-hover:translate-x-1 group-hover:text-primary sm:block">
-										→
-									</div>
+										<div className="min-w-0 flex-1">
+											<div className="mb-1 flex items-center gap-2">
+												<span
+													className={`rounded-full bg-base-content/5 px-2 py-0.5 text-xs ${categoryConfig[result.type].color}`}
+												>
+													{categoryConfig[result.type].label}
+												</span>
+											</div>
+											<h3 className="font-semibold transition-colors group-hover:text-primary">
+												{highlightMatch(result.title, query)}
+											</h3>
+											<p className="mt-0.5 text-base-content/60 text-sm">
+												{highlightMatch(result.subtitle, query)}
+											</p>
+										</div>
+										<div className="hidden text-base-content/30 transition-all group-hover:translate-x-1 group-hover:text-primary sm:block">
+											→
+										</div>
+									</Card>
 								</Link>
 							))}
 						</div>
 					) : (
-						<div className="glass-card rounded-2xl p-12 text-center">
+						<Card className="rounded-2xl p-12 text-center">
 							<div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-base-content/5">
 								<Search
 									className="h-8 w-8 text-base-content/30"
@@ -563,14 +564,14 @@ function SearchPage() {
 							<p className="mt-2 text-base-content/50 text-sm">
 								別のキーワードで検索してみてください
 							</p>
-						</div>
+						</Card>
 					)}
 				</div>
 			) : (
 				/* Search history */
 				<div className="space-y-6">
 					{searchHistory.length > 0 && (
-						<div className="glass-card rounded-2xl p-6">
+						<Card className="rounded-2xl p-6">
 							<h2 className="mb-4 flex items-center gap-2 font-semibold">
 								<Clock className="h-4 w-4 text-primary" aria-hidden="true" />
 								最近の検索
@@ -591,11 +592,11 @@ function SearchPage() {
 									</button>
 								))}
 							</div>
-						</div>
+						</Card>
 					)}
 
 					{/* Browse categories */}
-					<div className="glass-card rounded-2xl p-6">
+					<Card className="rounded-2xl p-6">
 						<h2 className="mb-4 flex items-center gap-2 font-semibold">
 							<Sparkles className="h-4 w-4 text-primary" aria-hidden="true" />
 							カテゴリから探す
@@ -638,7 +639,7 @@ function SearchPage() {
 								</div>
 							</Link>
 						</div>
-					</div>
+					</Card>
 				</div>
 			)}
 		</div>


### PR DESCRIPTION
## 概要

UIコンポーネントをdaisyUIのラッパーコンポーネントに統一し、コードベース全体の一貫性を向上

## 変更内容

### エラーテキスト・リンクのセマンティックカラー化
* `text-red-500` → `text-error`（エラーメッセージ）
* `text-indigo-600` → `text-primary`（リンク）

### 管理画面のテーマ対応
* `bg-slate-800` → `bg-neutral`
* `text-white` → `text-neutral-content`
* `text-slate-300` → `text-neutral-content/70`

### Cardコンポーネントへの置き換え
* `glass-card`カスタムクラス → `Card`コンポーネント
* 生のdiv要素 → `Card`/`CardContent`コンポーネント

### Button/Badgeコンポーネントへの置き換え
* 生の`btn`クラス → `Button`コンポーネント
* 生の`badge`クラス → `Badge`コンポーネント

## 影響範囲

* 認証フォーム（sign-in-form, sign-up-form）
* 管理画面（admin-header, official-links-card）
* Publicコンポーネント（stats-cards, entity-card, empty-state, hero-section, features-section, recent-releases, work-stats-section, view-toggle）
* 検索機能（search.tsx, FilterSection）

## 補足事項

* 見た目の変更は最小限（既存のスタイルを維持）
* `BadgeInfo`型への名前変更（daisyUIのBadgeコンポーネントとの競合回避）