### PR TITLE
feat: 管理画面にpublic画面へのリンクを追加

### DIFF
--- a/apps/web/src/components/admin-navbar.tsx
+++ b/apps/web/src/components/admin-navbar.tsx
@@ -1,5 +1,5 @@
-import { useNavigate } from "@tanstack/react-router";
-import { LogOut, Menu, PanelLeft } from "lucide-react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { ExternalLink, LogOut, Menu, PanelLeft } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
 import { ThemeSwitcher } from "./theme-switcher";
 
@@ -49,6 +49,14 @@ export function AdminNavbar({ user, onToggleSidebar }: AdminNavbarProps) {
 				>
 					<PanelLeft className="size-5" />
 				</button>
+				{/* Link to public site */}
+				<Link
+					to="/"
+					className="btn btn-ghost btn-circle"
+					aria-label="サイトを見る"
+				>
+					<ExternalLink className="size-5" />
+				</Link>
 			</div>
 
 			<div className="navbar-end gap-2">


### PR DESCRIPTION
## 概要

管理画面のナビバーからpublic画面（トップページ）へ移動できるリンクを追加

## 変更内容

* 管理画面のナビバー左側に `ExternalLink` アイコン付きのリンクを追加
* クリックするとトップページ（`/`）に遷移

## 影響範囲

* 管理画面のナビバー表示のみ