### PR TITLE
feat: トップページの統計情報を実データに変更

### DIFF
--- a/apps/server/src/routes/public/index.ts
+++ b/apps/server/src/routes/public/index.ts
@@ -6,6 +6,7 @@ import { eventsRouter } from "./events";
 import { officialWorksRouter } from "./official-works";
 import { originalSongsRouter } from "./original-songs";
 import { releasesRouter } from "./releases";
+import { statsRouter } from "./stats";
 import { tracksRouter } from "./tracks";
 
 const publicRouter = new Hono();
@@ -19,5 +20,6 @@ publicRouter.route("/artists", artistsRouter);
 publicRouter.route("/events", eventsRouter);
 publicRouter.route("/releases", releasesRouter);
 publicRouter.route("/tracks", tracksRouter);
+publicRouter.route("/stats", statsRouter);
 
 export { publicRouter };

--- a/apps/server/src/routes/public/stats.ts
+++ b/apps/server/src/routes/public/stats.ts
@@ -1,0 +1,85 @@
+import {
+	and,
+	artistAliases,
+	circles,
+	count,
+	countDistinct,
+	db,
+	eq,
+	events,
+	isNotNull,
+	ne,
+	officialSongs,
+	officialWorks,
+	trackOfficialSongs,
+} from "@thac/db";
+import { Hono } from "hono";
+import { handleDbError } from "../../utils/api-error";
+import {
+	CACHE_TTL,
+	cacheKeys,
+	getCache,
+	setCache,
+	setCacheHeaders,
+} from "../../utils/cache";
+
+const statsRouter = new Hono();
+
+/**
+ * GET /api/public/stats
+ * 公開統計情報を取得
+ */
+statsRouter.get("/", async (c) => {
+	try {
+		const cacheKey = cacheKeys.publicStats();
+
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.PUBLIC_STATS });
+			return c.json(cached);
+		}
+
+		const [eventsResult, circlesResult, artistsResult, tracksResult] =
+			await Promise.all([
+				db.select({ count: count() }).from(events),
+				db.select({ count: count() }).from(circles),
+				db.select({ count: count() }).from(artistAliases),
+				// 東方原曲に紐付くトラックのみをカウント
+				// - officialSongIdがNOT NULL
+				// - officialWorks.idが「0799」（その他）でない
+				db
+					.select({ count: countDistinct(trackOfficialSongs.trackId) })
+					.from(trackOfficialSongs)
+					.innerJoin(
+						officialSongs,
+						eq(trackOfficialSongs.officialSongId, officialSongs.id),
+					)
+					.innerJoin(
+						officialWorks,
+						eq(officialSongs.officialWorkId, officialWorks.id),
+					)
+					.where(
+						and(
+							isNotNull(trackOfficialSongs.officialSongId),
+							ne(officialWorks.id, "0799"),
+						),
+					),
+			]);
+
+		const response = {
+			events: eventsResult[0]?.count ?? 0,
+			circles: circlesResult[0]?.count ?? 0,
+			artists: artistsResult[0]?.count ?? 0,
+			tracks: tracksResult[0]?.count ?? 0,
+		};
+
+		setCache(cacheKey, response, CACHE_TTL.PUBLIC_STATS);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.PUBLIC_STATS });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/stats");
+	}
+});
+
+export { statsRouter };

--- a/apps/server/src/utils/cache.ts
+++ b/apps/server/src/utils/cache.ts
@@ -36,6 +36,7 @@ export const CACHE_TTL = {
 	EVENT_STATS: 5 * 60, // 5分
 	RELEASE_DETAIL: 5 * 60, // 5分
 	TRACK_DETAIL: 5 * 60, // 5分
+	PUBLIC_STATS: 5 * 60, // 5分
 } as const;
 
 /**
@@ -251,4 +252,6 @@ export const cacheKeys = {
 	releaseDetail: (releaseId: string) => `public:releases:${releaseId}`,
 
 	trackDetail: (trackId: string) => `public:tracks:${trackId}`,
+
+	publicStats: () => "public:stats",
 };

--- a/apps/web/src/components/public/hero-section.tsx
+++ b/apps/web/src/components/public/hero-section.tsx
@@ -1,15 +1,19 @@
 import { Link } from "@tanstack/react-router";
-import { Calendar, Disc3, Music, Search, Sparkles, Users } from "lucide-react";
+import { Calendar, Disc3, Search, Sparkles, Users } from "lucide-react";
+import type { PublicStats } from "@/lib/public-api";
 import { Badge } from "../ui/badge";
 
-// Mock data for demonstration
-const mockStats = {
-	originalSongs: 1234,
-	events: 567,
-	circles: 456,
-	artists: 890,
-	tracks: 12345,
+// フォールバック用のデフォルト値
+const defaultStats: PublicStats = {
+	events: 0,
+	circles: 0,
+	artists: 0,
+	tracks: 0,
 };
+
+interface HeroSectionProps {
+	stats: PublicStats | null;
+}
 
 interface StatLinkProps {
 	href: string;
@@ -35,7 +39,9 @@ function StatLink({ href, count, label, icon }: StatLinkProps) {
 	);
 }
 
-export function HeroSection() {
+export function HeroSection({ stats }: HeroSectionProps) {
+	const displayStats = stats ?? defaultStats;
+
 	return (
 		<section className="relative flex h-[calc(100vh-4rem)] flex-col justify-center overflow-hidden px-4 py-12">
 			{/* Gradient mesh background */}
@@ -96,20 +102,8 @@ export function HeroSection() {
 				{/* Stats with links */}
 				<div className="mt-12 flex flex-wrap items-center justify-center gap-4 text-base-content/50 text-sm md:gap-6">
 					<StatLink
-						href="/original-songs"
-						count={mockStats.originalSongs}
-						label="原曲"
-						icon={
-							<Music
-								className="h-4 w-4 text-primary group-hover:text-primary"
-								aria-hidden="true"
-							/>
-						}
-					/>
-					<div className="h-4 w-px bg-base-content/20" aria-hidden="true" />
-					<StatLink
 						href="/events"
-						count={mockStats.events}
+						count={displayStats.events}
 						label="イベント"
 						icon={
 							<Calendar
@@ -121,7 +115,7 @@ export function HeroSection() {
 					<div className="h-4 w-px bg-base-content/20" aria-hidden="true" />
 					<StatLink
 						href="/circles"
-						count={mockStats.circles}
+						count={displayStats.circles}
 						label="サークル"
 						icon={
 							<Users
@@ -133,7 +127,7 @@ export function HeroSection() {
 					<div className="h-4 w-px bg-base-content/20" aria-hidden="true" />
 					<StatLink
 						href="/artists"
-						count={mockStats.artists}
+						count={displayStats.artists}
 						label="アーティスト"
 						icon={
 							<Users
@@ -145,7 +139,7 @@ export function HeroSection() {
 					<div className="h-4 w-px bg-base-content/20" aria-hidden="true" />
 					<StatLink
 						href="/stats"
-						count={mockStats.tracks}
+						count={displayStats.tracks}
 						label="トラック"
 						icon={
 							<Disc3

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -33,6 +33,14 @@ async function publicFetch<T>(endpoint: string): Promise<T> {
 // 型定義
 // =============================================================================
 
+/** 公開統計情報 */
+export interface PublicStats {
+	events: number;
+	circles: number;
+	artists: number;
+	tracks: number;
+}
+
 /** カテゴリ */
 export interface PublicCategory {
 	code: string;
@@ -505,6 +513,9 @@ export interface PublicTrackDetail {
 // =============================================================================
 
 export const publicApi = {
+	/** サイト全体の統計情報を取得 */
+	stats: () => publicFetch<PublicStats>("/api/public/stats"),
+
 	/** カテゴリマスタ一覧を取得 */
 	categories: () =>
 		publicFetch<{ data: PublicCategory[] }>(

--- a/apps/web/src/routes/_public/index.tsx
+++ b/apps/web/src/routes/_public/index.tsx
@@ -4,19 +4,29 @@ import {
 	HeroSection,
 	NavigationSection,
 } from "@/components/public";
+import { type PublicStats, publicApi } from "@/lib/public-api";
 
 export const Route = createFileRoute("/_public/")({
 	head: () => ({
 		meta: [{ title: "東方編曲録　〜 Arrangement Chronicle" }],
 	}),
+	loader: async (): Promise<{ stats: PublicStats | null }> => {
+		try {
+			const stats = await publicApi.stats();
+			return { stats };
+		} catch {
+			return { stats: null };
+		}
+	},
 	component: HomePage,
 });
 
 function HomePage() {
+	const { stats } = Route.useLoaderData();
 	return (
 		<div className="scrollbar-hide -mx-4 -my-6 h-[calc(100vh-4rem)] snap-y snap-mandatory overflow-y-auto">
 			<div className="snap-start">
-				<HeroSection />
+				<HeroSection stats={stats} />
 			</div>
 			<div className="snap-start">
 				<FeaturesSection />

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -88,10 +88,12 @@ export {
 	eq,
 	gt,
 	inArray,
+	isNotNull,
 	isNull,
 	like,
 	lt,
 	max,
+	ne,
 	or,
 	sql,
 } from "drizzle-orm";


### PR DESCRIPTION
## 概要

トップページのHeroSectionに表示されている統計情報（イベント、サークル、アーティスト、トラック）をハードコードではなく、実際のデータベースから取得するように変更。

## 変更内容

* 公開stats APIエンドポイントを追加 (`GET /api/public/stats`)
* イベント数、サークル数、アーティスト名義数、トラック数を取得
* トラック数は東方原曲に紐付くもののみをカウント（作品ID `0799` を除外）
* HeroSectionをprops経由でデータを受け取る形式に変更
* 原曲の統計表示をUIから削除
* `@thac/db`に`isNotNull`、`ne`オペレータのエクスポートを追加

## 影響範囲

* トップページ（公開画面）の統計表示
* 公開API（新規エンドポイント追加）