### PR TITLE
feat: 公開画面にTanStack Routerプリフェッチを導入

### DIFF
--- a/apps/web/src/components/public/hero-section.tsx
+++ b/apps/web/src/components/public/hero-section.tsx
@@ -26,6 +26,7 @@ function StatLink({ href, count, label, icon }: StatLinkProps) {
 	return (
 		<Link
 			to={href}
+			preload="render"
 			className="group flex items-center gap-2 transition-colors hover:text-primary"
 		>
 			{icon}
@@ -85,6 +86,7 @@ export function HeroSection({ stats }: HeroSectionProps) {
 				<div className="mx-auto max-w-2xl">
 					<Link
 						to="/search"
+						preload="render"
 						className="group flex w-full items-center gap-4 rounded-2xl border-2 border-primary/30 bg-base-100 px-6 py-5 shadow-xl transition-all duration-300 hover:border-primary hover:shadow-2xl"
 					>
 						<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary text-primary-content transition-transform group-hover:scale-110">

--- a/apps/web/src/components/public/navigation-section.tsx
+++ b/apps/web/src/components/public/navigation-section.tsx
@@ -80,6 +80,7 @@ export function NavigationSection() {
 						<Link
 							key={item.href}
 							to={item.href}
+							preload="render"
 							className="glass-card group relative overflow-hidden rounded-2xl p-6 transition-all duration-300 hover:shadow-xl hover:ring-2 hover:ring-primary/20"
 						>
 							{/* Gradient accent */}

--- a/apps/web/src/components/public/public-header.tsx
+++ b/apps/web/src/components/public/public-header.tsx
@@ -42,6 +42,7 @@ export function PublicHeader() {
 						<li key={to}>
 							<Link
 								to={to}
+								preload="render"
 								className={
 									isActive(to) ? "bg-base-200 font-semibold" : undefined
 								}
@@ -57,6 +58,7 @@ export function PublicHeader() {
 			<div className="navbar-end gap-1">
 				<Link
 					to="/search"
+					preload="render"
 					className="btn btn-ghost btn-circle"
 					aria-label="検索"
 				>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -38,7 +38,8 @@ export const getRouter = () => {
 	const router = createTanStackRouter({
 		routeTree,
 		scrollRestoration: true,
-		defaultPreload: false, // プリフェッチを無効化
+		defaultPreload: "intent", // ホバー・タッチ時にプリフェッチ
+		defaultPreloadStaleTime: 30_000, // 30秒間はキャッシュを使用
 		context: {
 			queryClient,
 		},


### PR DESCRIPTION
## 概要

公開画面でTanStack Routerのプリフェッチ機能を有効化し、ページ遷移を高速化。

## 変更内容

* `router.tsx`: `defaultPreload: "intent"` でホバー時自動プリフェッチを有効化
* `router.tsx`: `defaultPreloadStaleTime: 30_000` で30秒間キャッシュを保持
* `navigation-section.tsx`: ホームのメインナビに `preload="render"` を追加
* `hero-section.tsx`: 統計リンク・検索バーに `preload="render"` を追加
* `public-header.tsx`: ヘッダーナビ・検索ボタンに `preload="render"` を追加

## 影響範囲

* 公開画面全体のページ遷移動作
* プリフェッチによりネットワークリクエストが事前に発生（UX向上のトレードオフ）

## 補足事項

### プリフェッチの動作

| 設定 | 動作 |
|------|------|
| `defaultPreload: "intent"` | ホバー・タッチ時に自動プリフェッチ |
| `defaultPreloadStaleTime: 30_000` | 30秒間はキャッシュを使用（重複リクエスト防止） |
| `preload="render"` | ビューポート表示時に即座にプリフェッチ |

### 対象リンク

* **即座にプリフェッチ（render）**: ホームナビ、ヘッダーナビ、検索ボタン
* **ホバー時プリフェッチ（intent）**: その他全てのLink