### PR TITLE
feat: 公開画面全体にpreload属性を設定

### DIFF
--- a/apps/web/src/components/public/entity-card.tsx
+++ b/apps/web/src/components/public/entity-card.tsx
@@ -25,7 +25,7 @@ export function EntityCard({
 	image,
 }: EntityCardProps) {
 	return (
-		<Link to={href} className="block">
+		<Link to={href} preload="intent" className="block">
 			<Card className="transition-shadow hover:shadow-md">
 				{image && (
 					<figure className="aspect-square bg-base-200">

--- a/apps/web/src/components/public/public-footer.tsx
+++ b/apps/web/src/components/public/public-footer.tsx
@@ -6,11 +6,11 @@ export function PublicFooter() {
 			<div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-between sm:gap-8">
 				<div className="font-semibold">東方編曲録</div>
 				<nav className="flex gap-4">
-					<Link to="/about" className="link link-hover">
+					<Link to="/about" preload="render" className="link link-hover">
 						About
 					</Link>
 					<span className="text-base-content/30">|</span>
-					<Link to="/privacy" className="link link-hover">
+					<Link to="/privacy" preload="render" className="link link-hover">
 						Privacy
 					</Link>
 					<span className="text-base-content/30">|</span>

--- a/apps/web/src/components/public/public-header.tsx
+++ b/apps/web/src/components/public/public-header.tsx
@@ -30,7 +30,11 @@ export function PublicHeader() {
 				>
 					<Menu className="size-5" />
 				</button>
-				<Link to="/" className="btn btn-ghost font-bold text-lg">
+				<Link
+					to="/"
+					preload="render"
+					className="btn btn-ghost font-bold text-lg"
+				>
 					東方編曲録
 				</Link>
 			</div>
@@ -95,7 +99,11 @@ export function PublicHeader() {
 						</div>
 						<ul className="menu p-4">
 							<li>
-								<Link to="/" onClick={() => setIsDrawerOpen(false)}>
+								<Link
+									to="/"
+									preload="render"
+									onClick={() => setIsDrawerOpen(false)}
+								>
 									ホーム
 								</Link>
 							</li>
@@ -103,6 +111,7 @@ export function PublicHeader() {
 								<li key={to}>
 									<Link
 										to={to}
+										preload="render"
 										className={isActive(to) ? "active" : undefined}
 										onClick={() => setIsDrawerOpen(false)}
 									>
@@ -111,7 +120,11 @@ export function PublicHeader() {
 								</li>
 							))}
 							<li className="mt-4 border-base-300 border-t pt-4">
-								<Link to="/about" onClick={() => setIsDrawerOpen(false)}>
+								<Link
+									to="/about"
+									preload="render"
+									onClick={() => setIsDrawerOpen(false)}
+								>
 									About
 								</Link>
 							</li>

--- a/apps/web/src/components/public/recent-releases.tsx
+++ b/apps/web/src/components/public/recent-releases.tsx
@@ -165,6 +165,7 @@ export function RecentReleases() {
 					</div>
 					<Link
 						to="/stats"
+						preload="render"
 						className="group flex items-center gap-1 text-primary text-sm transition-colors hover:text-primary/80"
 					>
 						すべて見る

--- a/apps/web/src/components/public/stats-cards.tsx
+++ b/apps/web/src/components/public/stats-cards.tsx
@@ -47,7 +47,7 @@ function StatCard({ icon: Icon, count, label, href, trend }: StatCardProps) {
 
 	if (href) {
 		return (
-			<Link to={href} className="block">
+			<Link to={href} preload="render" className="block">
 				{content}
 			</Link>
 		);
@@ -72,6 +72,7 @@ export function StatsCards() {
 				<h2 className="font-bold text-xl">データ統計</h2>
 				<Link
 					to="/stats"
+					preload="render"
 					className="group flex items-center gap-1 text-primary text-sm transition-colors hover:text-primary/80"
 				>
 					詳細を見る

--- a/apps/web/src/routes/_public/about.tsx
+++ b/apps/web/src/routes/_public/about.tsx
@@ -112,7 +112,7 @@ function AboutPage() {
 
 			{/* フッターリンク */}
 			<div className="text-center">
-				<Link to="/" className="btn btn-primary">
+				<Link to="/" preload="render" className="btn btn-primary">
 					トップページへ戻る
 				</Link>
 			</div>

--- a/apps/web/src/routes/_public/artists.tsx
+++ b/apps/web/src/routes/_public/artists.tsx
@@ -363,6 +363,7 @@ function ArtistsPage() {
 							key={artist.id}
 							to="/artists/$id"
 							params={{ id: artist.id }}
+							preload="intent"
 							className="card bg-base-100 shadow-sm transition-shadow hover:shadow-md"
 						>
 							<div className="card-body p-4">
@@ -419,6 +420,7 @@ function ArtistsPage() {
 										<Link
 											to="/artists/$id"
 											params={{ id: artist.id }}
+											preload="intent"
 											className="flex items-center gap-3 hover:text-primary"
 										>
 											<div className="flex size-8 items-center justify-center rounded-full bg-accent/10">

--- a/apps/web/src/routes/_public/artists_.$id.tsx
+++ b/apps/web/src/routes/_public/artists_.$id.tsx
@@ -167,7 +167,7 @@ function ArtistDetailPage() {
 					<p className="mt-2 text-base-content/70">
 						指定されたIDのアーティストは存在しません
 					</p>
-					<Link to="/artists" className="btn btn-primary mt-4">
+					<Link to="/artists" preload="intent" className="btn btn-primary mt-4">
 						アーティスト一覧に戻る
 					</Link>
 				</div>
@@ -234,6 +234,7 @@ function ArtistDetailPage() {
 									key={alias.id}
 									to="/artists/$id"
 									params={{ id: alias.id }}
+									preload="intent"
 									className="badge badge-ghost hover:badge-primary transition-colors"
 								>
 									{alias.name}
@@ -335,6 +336,7 @@ function ArtistDetailPage() {
 												<Link
 													to="/tracks/$id"
 													params={{ id: credit.track.id }}
+													preload="intent"
 													className="font-medium hover:text-primary"
 												>
 													{credit.track.name}
@@ -356,6 +358,7 @@ function ArtistDetailPage() {
 												<Link
 													to="/releases/$id"
 													params={{ id: credit.release.id }}
+													preload="intent"
 													className="text-base-content/70 text-sm hover:text-primary"
 												>
 													{credit.release.name}
@@ -366,6 +369,7 @@ function ArtistDetailPage() {
 															key={circle.id}
 															to="/circles/$id"
 															params={{ id: circle.id }}
+															preload="intent"
 															className="text-base-content/50 text-xs hover:text-primary"
 														>
 															{circle.name}
@@ -378,6 +382,7 @@ function ArtistDetailPage() {
 													<Link
 														to="/original-songs/$id"
 														params={{ id: credit.originalSong.id }}
+														preload="intent"
 														className="text-base-content/70 text-sm hover:text-primary"
 													>
 														{credit.originalSong.name}

--- a/apps/web/src/routes/_public/circles.tsx
+++ b/apps/web/src/routes/_public/circles.tsx
@@ -273,6 +273,7 @@ function CirclesPage() {
 							key={circle.id}
 							to="/circles/$id"
 							params={{ id: circle.id }}
+							preload="intent"
 							className="card bg-base-100 shadow-sm transition-shadow hover:shadow-md"
 						>
 							<div className="card-body p-4">
@@ -323,6 +324,7 @@ function CirclesPage() {
 										<Link
 											to="/circles/$id"
 											params={{ id: circle.id }}
+											preload="intent"
 											className="flex items-center gap-3 hover:text-primary"
 										>
 											<div className="flex size-8 items-center justify-center rounded-full bg-primary/10">

--- a/apps/web/src/routes/_public/circles_.$id.tsx
+++ b/apps/web/src/routes/_public/circles_.$id.tsx
@@ -230,7 +230,7 @@ function CircleDetailPage() {
 					<p className="mt-2 text-base-content/70">
 						指定されたIDのサークルは存在しません
 					</p>
-					<Link to="/circles" className="btn btn-primary mt-4">
+					<Link to="/circles" preload="intent" className="btn btn-primary mt-4">
 						サークル一覧に戻る
 					</Link>
 				</div>
@@ -346,6 +346,7 @@ function CircleDetailPage() {
 										<Link
 											to="/releases/$id"
 											params={{ id: release.id }}
+											preload="intent"
 											className="card-title text-base hover:text-primary"
 										>
 											{release.name}
@@ -355,6 +356,7 @@ function CircleDetailPage() {
 												<Link
 													to="/events/$id"
 													params={{ id: release.event.id }}
+													preload="intent"
 													className="badge badge-outline badge-sm hover:badge-primary"
 												>
 													{release.event.name}
@@ -406,6 +408,7 @@ function CircleDetailPage() {
 												<Link
 													to="/releases/$id"
 													params={{ id: release.id }}
+													preload="intent"
 													className="font-medium hover:text-primary"
 												>
 													{release.name}
@@ -416,6 +419,7 @@ function CircleDetailPage() {
 													<Link
 														to="/events/$id"
 														params={{ id: release.event.id }}
+														preload="intent"
 														className="hover:text-primary"
 													>
 														{release.event.name}
@@ -503,6 +507,7 @@ function CircleDetailPage() {
 												<Link
 													to="/tracks/$id"
 													params={{ id: track.id }}
+													preload="intent"
 													className="font-medium hover:text-primary"
 												>
 													{track.name}
@@ -513,6 +518,7 @@ function CircleDetailPage() {
 													<Link
 														to="/releases/$id"
 														params={{ id: track.releaseId }}
+														preload="intent"
 														className="hover:text-primary"
 													>
 														{track.releaseName || "-"}
@@ -528,6 +534,7 @@ function CircleDetailPage() {
 															key={artist.id}
 															to="/artists/$id"
 															params={{ id: artist.id }}
+															preload="intent"
 															className="inline-flex items-center gap-1 hover:text-primary"
 														>
 															<Users className="size-3" />
@@ -548,6 +555,7 @@ function CircleDetailPage() {
 													<Link
 														to="/original-songs/$id"
 														params={{ id: track.originalSong.id }}
+														preload="intent"
 														className="text-base-content/70 hover:text-primary"
 													>
 														{track.originalSong.name}

--- a/apps/web/src/routes/_public/events.tsx
+++ b/apps/web/src/routes/_public/events.tsx
@@ -296,6 +296,7 @@ function EventsPage() {
 												key={event.id}
 												to="/events/$id"
 												params={{ id: event.id }}
+												preload="intent"
 												className="flex items-center justify-between border-base-200 border-b px-4 py-3 pl-12 last:border-b-0 hover:bg-base-200/30"
 											>
 												<div className="flex items-center gap-4">
@@ -377,6 +378,7 @@ function EventsPage() {
 																<Link
 																	to="/events/$id"
 																	params={{ id: event.id }}
+																	preload="intent"
 																	className="font-medium hover:text-primary"
 																>
 																	{event.name}

--- a/apps/web/src/routes/_public/events_.$id.tsx
+++ b/apps/web/src/routes/_public/events_.$id.tsx
@@ -168,7 +168,7 @@ function EventDetailPage() {
 					<p className="mt-2 text-base-content/70">
 						指定されたIDのイベントは存在しません
 					</p>
-					<Link to="/events" className="btn btn-primary mt-4">
+					<Link to="/events" preload="intent" className="btn btn-primary mt-4">
 						イベント一覧に戻る
 					</Link>
 				</div>
@@ -298,6 +298,7 @@ function EventDetailPage() {
 										<Link
 											to="/releases/$id"
 											params={{ id: release.id }}
+											preload="intent"
 											className="card-title text-base hover:text-primary"
 										>
 											{release.name}
@@ -308,6 +309,7 @@ function EventDetailPage() {
 													key={circle.id}
 													to="/circles/$id"
 													params={{ id: circle.id }}
+													preload="intent"
 													className="badge badge-outline badge-sm hover:badge-primary"
 												>
 													{circle.name}
@@ -355,6 +357,7 @@ function EventDetailPage() {
 												<Link
 													to="/releases/$id"
 													params={{ id: release.id }}
+													preload="intent"
 													className="font-medium hover:text-primary"
 												>
 													{release.name}
@@ -367,6 +370,7 @@ function EventDetailPage() {
 														<Link
 															to="/circles/$id"
 															params={{ id: circle.id }}
+															preload="intent"
 															className="hover:text-primary"
 														>
 															{circle.name}

--- a/apps/web/src/routes/_public/official-works.tsx
+++ b/apps/web/src/routes/_public/official-works.tsx
@@ -265,6 +265,7 @@ function WorksGridView({ works }: WorksViewProps) {
 						key={work.id}
 						to="/official-works/$id"
 						params={{ id: work.id }}
+						preload="intent"
 						className="card bg-base-100 shadow-sm transition-shadow hover:shadow-md"
 					>
 						<div className="card-body p-4">
@@ -324,6 +325,7 @@ function WorksListView({ works }: WorksViewProps) {
 									<Link
 										to="/official-works/$id"
 										params={{ id: work.id }}
+										preload="intent"
 										className="hover:text-primary"
 									>
 										<div className="font-medium">{work.nameJa}</div>

--- a/apps/web/src/routes/_public/official-works_.$id.tsx
+++ b/apps/web/src/routes/_public/official-works_.$id.tsx
@@ -113,7 +113,11 @@ function OfficialWorkDetailPage() {
 					<p className="mt-2 text-base-content/70">
 						指定されたIDの作品は存在しません
 					</p>
-					<Link to="/official-works" className="btn btn-primary mt-4">
+					<Link
+						to="/official-works"
+						preload="intent"
+						className="btn btn-primary mt-4"
+					>
 						作品一覧に戻る
 					</Link>
 				</div>
@@ -179,6 +183,7 @@ function OfficialWorkDetailPage() {
 						<Link
 							to="/original-songs"
 							search={{ type: work.categoryCode }}
+							preload="intent"
 							className="btn btn-outline btn-sm gap-1"
 						>
 							<Music className="size-4" />
@@ -242,6 +247,7 @@ function OfficialWorkDetailPage() {
 												<Link
 													to="/original-songs/$id"
 													params={{ id: song.id }}
+													preload="intent"
 													className="hover:text-primary"
 												>
 													<div className="font-medium">{song.nameJa}</div>

--- a/apps/web/src/routes/_public/original-songs.tsx
+++ b/apps/web/src/routes/_public/original-songs.tsx
@@ -210,7 +210,11 @@ function OriginalSongsPage() {
 						東方Project公式楽曲 · {works.length}作品 · {totalSongCount}曲
 					</p>
 				</div>
-				<Link to="/official-works" className="btn btn-outline btn-sm gap-1">
+				<Link
+					to="/official-works"
+					preload="intent"
+					className="btn btn-outline btn-sm gap-1"
+				>
 					<Music className="size-4" />
 					公式作品一覧
 					<ChevronRight className="size-4" />
@@ -357,6 +361,7 @@ function WorkAccordion({
 									<Link
 										to="/original-songs/$id"
 										params={{ id: song.id }}
+										preload="intent"
 										className="hover:text-primary"
 									>
 										<div className="font-medium">{song.nameJa}</div>

--- a/apps/web/src/routes/_public/original-songs_.$id.tsx
+++ b/apps/web/src/routes/_public/original-songs_.$id.tsx
@@ -76,7 +76,11 @@ function OriginalSongDetailPage() {
 					<p className="mt-2 text-base-content/70">
 						指定されたIDの曲は存在しません
 					</p>
-					<Link to="/original-songs" className="btn btn-primary mt-4">
+					<Link
+						to="/original-songs"
+						preload="intent"
+						className="btn btn-primary mt-4"
+					>
 						原曲一覧に戻る
 					</Link>
 				</div>
@@ -121,6 +125,7 @@ function OriginalSongDetailPage() {
 								<Link
 									to="/official-works/$id"
 									params={{ id: work.id }}
+									preload="intent"
 									className="flex items-center gap-1 hover:text-primary"
 								>
 									<Disc3 className="size-4" />
@@ -193,6 +198,7 @@ function OriginalSongDetailPage() {
 					<Link
 						to="/original-songs/$id"
 						params={{ id: song.prevSong.id }}
+						preload="intent"
 						className="btn btn-ghost btn-sm gap-1"
 					>
 						<ChevronLeft className="size-4" />
@@ -206,6 +212,7 @@ function OriginalSongDetailPage() {
 					<Link
 						to="/original-songs/$id"
 						params={{ id: song.nextSong.id }}
+						preload="intent"
 						className="btn btn-ghost btn-sm gap-1"
 					>
 						<span className="hidden sm:inline">{song.nextSong.name}</span>
@@ -238,6 +245,7 @@ function OriginalSongDetailPage() {
 											<Link
 												to="/tracks/$id"
 												params={{ id: track.trackId }}
+												preload="intent"
 												className="font-medium hover:text-primary"
 											>
 												{track.trackName}
@@ -246,6 +254,7 @@ function OriginalSongDetailPage() {
 												<Link
 													to="/releases/$id"
 													params={{ id: track.release.id }}
+													preload="intent"
 													className="block text-base-content/60 text-sm hover:text-primary"
 												>
 													{track.release.name}
@@ -259,6 +268,7 @@ function OriginalSongDetailPage() {
 													<Link
 														to="/circles/$id"
 														params={{ id: circle.id }}
+														preload="intent"
 														className="hover:text-primary"
 													>
 														{circle.name}
@@ -273,6 +283,7 @@ function OriginalSongDetailPage() {
 														key={artist.id}
 														to="/artists/$id"
 														params={{ id: artist.id }}
+														preload="intent"
 														className="inline-flex items-center gap-1 hover:text-primary"
 													>
 														<Users className="size-3" />

--- a/apps/web/src/routes/_public/privacy.tsx
+++ b/apps/web/src/routes/_public/privacy.tsx
@@ -129,7 +129,7 @@ function PrivacyPage() {
 				<div className="space-y-4 text-base-content/80">
 					<p>
 						本プライバシーポリシーに関するお問い合わせは、
-						<Link to="/about" className="link link-primary">
+						<Link to="/about" preload="render" className="link link-primary">
 							Aboutページ
 						</Link>
 						に記載の連絡先までお願いいたします。
@@ -146,7 +146,7 @@ function PrivacyPage() {
 
 			{/* フッターリンク */}
 			<div className="text-center">
-				<Link to="/" className="btn btn-primary">
+				<Link to="/" preload="render" className="btn btn-primary">
 					トップページへ戻る
 				</Link>
 			</div>

--- a/apps/web/src/routes/_public/releases_.$id.tsx
+++ b/apps/web/src/routes/_public/releases_.$id.tsx
@@ -143,6 +143,7 @@ function ReleaseDetailPage() {
 								<Link
 									to="/events/$id"
 									params={{ id: release.event.id }}
+									preload="intent"
 									className="flex items-center gap-1 hover:text-primary"
 								>
 									<Calendar className="size-4" />
@@ -255,6 +256,7 @@ function CircleBadge({
 		<Link
 			to="/circles/$id"
 			params={{ id: circle.circleId }}
+			preload="intent"
 			className="inline-flex items-center gap-1 hover:opacity-80"
 		>
 			<span className="font-medium hover:text-primary">
@@ -296,6 +298,7 @@ function TrackTable({ tracks }: { tracks: PublicReleaseDetail["tracks"] }) {
 								<Link
 									to="/tracks/$id"
 									params={{ id: track.id }}
+									preload="intent"
 									className="font-medium hover:text-primary"
 								>
 									{track.name}
@@ -319,6 +322,7 @@ function TrackTable({ tracks }: { tracks: PublicReleaseDetail["tracks"] }) {
 												<Link
 													to="/artists/$id"
 													params={{ id: linkId }}
+													preload="intent"
 													className="hover:text-primary"
 												>
 													{displayName}
@@ -352,6 +356,7 @@ function TrackTable({ tracks }: { tracks: PublicReleaseDetail["tracks"] }) {
 													<Link
 														to="/original-songs/$id"
 														params={{ id: os.officialSongId }}
+														preload="intent"
 														className="hover:text-primary"
 													>
 														{os.songName}

--- a/apps/web/src/routes/_public/search.tsx
+++ b/apps/web/src/routes/_public/search.tsx
@@ -518,6 +518,7 @@ function SearchPage() {
 								<Link
 									key={`${result.type}-${result.id}`}
 									to={getResultHref(result)}
+									preload="intent"
 								>
 									<Card className="group flex items-start gap-4 rounded-xl p-4 transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10">
 										<div
@@ -601,6 +602,7 @@ function SearchPage() {
 						<div className="grid gap-3 sm:grid-cols-3">
 							<Link
 								to="/circles"
+								preload="intent"
 								className="group flex items-center gap-3 rounded-xl bg-primary/5 p-4 transition-all hover:bg-primary/10 hover:shadow-md"
 							>
 								<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
@@ -613,6 +615,7 @@ function SearchPage() {
 							</Link>
 							<Link
 								to="/artists"
+								preload="intent"
 								className="group flex items-center gap-3 rounded-xl bg-accent/5 p-4 transition-all hover:bg-accent/10 hover:shadow-md"
 							>
 								<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent/10 text-accent">
@@ -625,6 +628,7 @@ function SearchPage() {
 							</Link>
 							<Link
 								to="/original-songs"
+								preload="intent"
 								className="group flex items-center gap-3 rounded-xl bg-secondary/5 p-4 transition-all hover:bg-secondary/10 hover:shadow-md"
 							>
 								<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-secondary/10 text-secondary">

--- a/apps/web/src/routes/_public/stats.tsx
+++ b/apps/web/src/routes/_public/stats.tsx
@@ -141,7 +141,7 @@ function StatCard({
 
 	if (href) {
 		return (
-			<Link to={href} className="block">
+			<Link to={href} preload="intent" className="block">
 				{content}
 			</Link>
 		);
@@ -175,6 +175,7 @@ function RankingItem({ rank, name, count, unit, href }: RankingItemProps) {
 	return (
 		<Link
 			to={href}
+			preload="intent"
 			className="group flex items-center gap-3 rounded-xl p-3 transition-all duration-300 hover:bg-base-content/5"
 		>
 			<span
@@ -267,6 +268,7 @@ function StatsPage() {
 						</div>
 						<Link
 							to="/original-songs"
+							preload="intent"
 							className="group flex items-center gap-1 text-primary text-sm transition-colors hover:text-primary/80"
 						>
 							すべて見る
@@ -298,6 +300,7 @@ function StatsPage() {
 						</div>
 						<Link
 							to="/circles"
+							preload="intent"
 							className="group flex items-center gap-1 text-primary text-sm transition-colors hover:text-primary/80"
 						>
 							すべて見る
@@ -329,6 +332,7 @@ function StatsPage() {
 						</div>
 						<Link
 							to="/artists"
+							preload="intent"
 							className="group flex items-center gap-1 text-primary text-sm transition-colors hover:text-primary/80"
 						>
 							すべて見る

--- a/apps/web/src/routes/_public/tracks_.$id.tsx
+++ b/apps/web/src/routes/_public/tracks_.$id.tsx
@@ -130,6 +130,7 @@ function TrackDetailPage() {
 							<Link
 								to="/releases/$id"
 								params={{ id: track.release.id }}
+								preload="intent"
 								className="flex items-center gap-1 hover:text-primary"
 							>
 								<Disc3 className="size-4" />
@@ -147,6 +148,7 @@ function TrackDetailPage() {
 							<Link
 								to="/events/$id"
 								params={{ id: track.event.id }}
+								preload="intent"
 								className="flex items-center gap-1 hover:text-primary"
 							>
 								{track.event.name}
@@ -177,6 +179,7 @@ function TrackDetailPage() {
 													<Link
 														to="/artists/$id"
 														params={{ id: credit.artistId }}
+														preload="intent"
 														className="hover:text-primary"
 													>
 														{credit.creditName}
@@ -220,6 +223,7 @@ function TrackDetailPage() {
 												<Link
 													to="/original-songs/$id"
 													params={{ id: os.officialSongId }}
+													preload="intent"
 													className="font-medium hover:text-primary"
 												>
 													{os.songName}
@@ -279,6 +283,7 @@ function TrackDetailPage() {
 									<Link
 										to="/tracks/$id"
 										params={{ id: derivation.parentTrackId }}
+										preload="intent"
 										className="font-medium hover:text-primary"
 									>
 										{derivation.parentTrackName}
@@ -299,6 +304,7 @@ function TrackDetailPage() {
 					<Link
 						to="/tracks/$id"
 						params={{ id: track.siblingTracks.prev.id }}
+						preload="intent"
 						className="btn btn-ghost btn-sm gap-1"
 					>
 						<ChevronLeft className="size-4" />
@@ -314,6 +320,7 @@ function TrackDetailPage() {
 					<Link
 						to="/tracks/$id"
 						params={{ id: track.siblingTracks.next.id }}
+						preload="intent"
 						className="btn btn-ghost btn-sm gap-1"
 					>
 						<span className="hidden sm:inline">


### PR DESCRIPTION
## 概要

公開画面のすべてのLinkコンポーネントにpreload属性を明示的に設定し、プリフェッチの意図を明確化

## 変更内容

* ナビゲーション・UI要素に`preload="render"`（画面表示時プリフェッチ）を設定
* 一覧・詳細画面のリンクに`preload="intent"`（ホバー時プリフェッチ）を設定

### 共通コンポーネント（preload="render"）
* `public-header.tsx` - ロゴ、モバイルメニュー、Aboutリンク
* `public-footer.tsx` - About/Privacyリンク
* `stats-cards.tsx` - 統計カード、詳細リンク
* `recent-releases.tsx` - 「すべて見る」リンク
* `entity-card.tsx` - カードリンク（intent）

### 一覧画面（preload="intent"）
* `artists.tsx`, `circles.tsx`, `events.tsx`
* `original-songs.tsx`, `official-works.tsx`
* `search.tsx`, `stats.tsx`

### 詳細画面（preload="intent"）
* `artists_.$id.tsx`, `circles_.$id.tsx`, `events_.$id.tsx`
* `original-songs_.$id.tsx`, `official-works_.$id.tsx`
* `releases_.$id.tsx`, `tracks_.$id.tsx`

### その他（preload="render"）
* `about.tsx`, `privacy.tsx` - ホームへ戻るリンク

## 影響範囲

* 公開画面全体のナビゲーションパフォーマンス向上
* ルーターの`defaultPreload: "intent"`設定と組み合わせて動作

## 補足事項

| 用途 | 設定 | 理由 |
|------|------|------|
| ナビゲーション系 | `preload="render"` | 確実にクリックされる導線、画面表示時にプリフェッチ |
| 一覧・詳細のリンク | `preload="intent"` | 項目数が多いため、ホバー時にプリフェッチ |