### PR TITLE
feat: Optimistic updates実装

### DIFF
--- a/apps/web/src/components/admin/artist-alias-edit-dialog.tsx
+++ b/apps/web/src/components/admin/artist-alias-edit-dialog.tsx
@@ -211,9 +211,9 @@ export function ArtistAliasEditDialog({
 			updateMutation.mutate(
 				{
 					id: alias.id,
+					artistId: form.artistId,
 					data: {
 						name: form.name,
-						artistId: form.artistId,
 						aliasTypeCode: form.aliasTypeCode,
 						initialScript: form.initialScript,
 						nameInitial: form.nameInitial,

--- a/apps/web/src/components/admin/release-edit-dialog.tsx
+++ b/apps/web/src/components/admin/release-edit-dialog.tsx
@@ -23,6 +23,7 @@ import {
 	type ReleaseType,
 } from "@/lib/api-client";
 import { releaseMutations } from "@/lib/mutation-options";
+import { getErrorMessage } from "@/lib/utils";
 import { ConflictDialog } from "./conflict-dialog";
 
 // 作品タイプのオプション
@@ -208,11 +209,11 @@ export function ReleaseEditDialog({
 						<DialogTitle>リリースの編集</DialogTitle>
 					</DialogHeader>
 					<div className="grid gap-4 py-4">
-						{mutationError && !isConflictError(mutationError) && (
+						{mutationError && !isConflictError(mutationError) ? (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{mutationError.message}
+								{getErrorMessage(mutationError)}
 							</div>
-						)}
+						) : null}
 						<div className="grid gap-4">
 							<div className="grid gap-2">
 								<Label htmlFor="release-name">

--- a/apps/web/src/lib/mutation-options.test.ts
+++ b/apps/web/src/lib/mutation-options.test.ts
@@ -328,11 +328,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates artistAliases and artistAlias queries", () => {
+		test("update.onSettled invalidates artistAliases and artistAlias queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = artistAliasMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { id: "alias-123", data: {} });
+			callCallback(config, "onSettled", { id: "alias-123", data: {} });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["artistAliases"],
@@ -342,13 +342,13 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates artist queries when artistId is provided", () => {
+		test("update.onSettled invalidates artist queries when artistId is provided", () => {
 			const queryClient = createMockQueryClient();
 			const config = artistAliasMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", {
+			callCallback(config, "onSettled", {
 				id: "alias-123",
-				data: { artistId: "artist-456" },
+				artistId: "artist-456",
 			});
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -359,9 +359,6 @@ describe("mutation-options", () => {
 			});
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["artist", "artist-456"],
-			});
-			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
-				queryKey: ["artist", "artist-456", "full"],
 			});
 		});
 
@@ -397,11 +394,11 @@ describe("mutation-options", () => {
 			expect(config).toHaveProperty("onSuccess");
 		});
 
-		test("update.onSuccess invalidates circles and specific circle queries", () => {
+		test("update.onSettled invalidates circles and specific circle queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = circleMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { id: "circle-id" });
+			callCallback(config, "onSettled", { id: "circle-id" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["circles"],
@@ -443,11 +440,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates eventSeries and specific event-series queries", () => {
+		test("update.onSettled invalidates eventSeries and specific event-series queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = eventSeriesMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { id: "series-123" });
+			callCallback(config, "onSettled", { id: "series-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(2);
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -490,11 +487,11 @@ describe("mutation-options", () => {
 			expect(config).toHaveProperty("onSuccess");
 		});
 
-		test("update.onSuccess invalidates releases and specific release queries", () => {
+		test("update.onSettled invalidates releases and specific release queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = releaseMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { id: "release-id" });
+			callCallback(config, "onSettled", { id: "release-id" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["releases"],
@@ -563,11 +560,11 @@ describe("mutation-options", () => {
 			expect(config).toHaveProperty("onSuccess");
 		});
 
-		test("update.onSuccess invalidates platforms and specific platform queries", () => {
+		test("update.onSettled invalidates platforms and specific platform queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = platformMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { code: "spotify" });
+			callCallback(config, "onSettled", { code: "spotify" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["platforms"],
@@ -598,11 +595,11 @@ describe("mutation-options", () => {
 			expect(config).toHaveProperty("onSuccess");
 		});
 
-		test("update.onSuccess invalidates aliasTypes and specific aliasType queries", () => {
+		test("update.onSettled invalidates aliasTypes and specific aliasType queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = aliasTypeMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { code: "vocal" });
+			callCallback(config, "onSettled", { code: "vocal" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["aliasTypes"],
@@ -633,11 +630,11 @@ describe("mutation-options", () => {
 			expect(config).toHaveProperty("onSuccess");
 		});
 
-		test("update.onSuccess invalidates creditRoles and specific creditRole queries", () => {
+		test("update.onSettled invalidates creditRoles and specific creditRole queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = creditRoleMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { code: "composer" });
+			callCallback(config, "onSettled", { code: "composer" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["creditRoles"],
@@ -668,11 +665,11 @@ describe("mutation-options", () => {
 			expect(config).toHaveProperty("onSuccess");
 		});
 
-		test("update.onSuccess invalidates officialWorkCategories and specific category queries", () => {
+		test("update.onSettled invalidates officialWorkCategories and specific category queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = officialWorkCategoryMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { code: "game" });
+			callCallback(config, "onSettled", { code: "game" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["officialWorkCategories"],
@@ -719,17 +716,14 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates circle queries", () => {
+		test("update.onSettled invalidates circle queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = circleLinkMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { circleId: "circle-123" });
+			callCallback(config, "onSettled", { circleId: "circle-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["circle", "circle-123"],
-			});
-			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
-				queryKey: ["circle", "circle-123", "full"],
 			});
 		});
 
@@ -768,11 +762,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates events and specific event queries", () => {
+		test("update.onSettled invalidates events and specific event queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = eventMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { id: "event-123" });
+			callCallback(config, "onSettled", { id: "event-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["events"],
@@ -814,11 +808,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates event query", () => {
+		test("update.onSettled invalidates event query", () => {
 			const queryClient = createMockQueryClient();
 			const config = eventDayMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { eventId: "event-123" });
+			callCallback(config, "onSettled", { eventId: "event-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["event", "event-123"],
@@ -860,17 +854,14 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates release queries", () => {
+		test("update.onSettled invalidates release queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = discMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { releaseId: "release-123" });
+			callCallback(config, "onSettled", { releaseId: "release-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["release", "release-123"],
-			});
-			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
-				queryKey: ["release", "release-123", "full"],
 			});
 		});
 
@@ -909,11 +900,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates officialWorks and specific work queries", () => {
+		test("update.onSettled invalidates officialWorks and specific work queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = officialWorkMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { id: "work-123" });
+			callCallback(config, "onSettled", { id: "work-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["officialWorks"],
@@ -955,11 +946,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates officialSongs and specific song queries", () => {
+		test("update.onSettled invalidates officialSongs and specific song queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = officialSongMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { id: "song-123" });
+			callCallback(config, "onSettled", { id: "song-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["officialSongs"],
@@ -1004,11 +995,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates release queries", () => {
+		test("update.onSettled invalidates release queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = releaseCircleMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { releaseId: "release-123" });
+			callCallback(config, "onSettled", { releaseId: "release-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["release", "release-123"],
@@ -1056,11 +1047,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates release queries", () => {
+		test("update.onSettled invalidates release queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = releasePublicationMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { releaseId: "release-123" });
+			callCallback(config, "onSettled", { releaseId: "release-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["release", "release-123"],
@@ -1108,11 +1099,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates release queries", () => {
+		test("update.onSettled invalidates release queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = releaseJanCodeMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { releaseId: "release-123" });
+			callCallback(config, "onSettled", { releaseId: "release-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["release", "release-123"],
@@ -1166,11 +1157,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates track and release queries", () => {
+		test("update.onSettled invalidates track and release queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = trackCreditMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", {
+			callCallback(config, "onSettled", {
 				trackId: "track-123",
 				releaseId: "release-123",
 			});
@@ -1230,11 +1221,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates track-official-songs and track queries", () => {
+		test("update.onSettled invalidates track-official-songs and track queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = trackOfficialSongMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { trackId: "track-123" });
+			callCallback(config, "onSettled", { trackId: "track-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["track-official-songs", "track-123"],
@@ -1334,11 +1325,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates track-publications and track queries", () => {
+		test("update.onSettled invalidates track-publications and track queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = trackPublicationMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { trackId: "track-123" });
+			callCallback(config, "onSettled", { trackId: "track-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["track-publications", "track-123"],
@@ -1386,11 +1377,11 @@ describe("mutation-options", () => {
 			});
 		});
 
-		test("update.onSuccess invalidates track-isrcs and track queries", () => {
+		test("update.onSettled invalidates track-isrcs and track queries", () => {
 			const queryClient = createMockQueryClient();
 			const config = trackIsrcMutations.update(queryClient as never);
 
-			callCallback(config, "onSuccess", { trackId: "track-123" });
+			callCallback(config, "onSettled", { trackId: "track-123" });
 
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
 				queryKey: ["track-isrcs", "track-123"],

--- a/apps/web/src/lib/mutation-options.ts
+++ b/apps/web/src/lib/mutation-options.ts
@@ -26,7 +26,9 @@ import {
 	artistAliasesApi,
 	artistsApi,
 	type Circle,
+	type CircleFullResponse,
 	type CircleLink,
+	type CircleWithLinks,
 	type CreditRole,
 	circleLinksApi,
 	circlesApi,
@@ -36,6 +38,8 @@ import {
 	type Event,
 	type EventDay,
 	type EventSeries,
+	type EventSeriesWithEvents,
+	type EventWithDays,
 	eventDaysApi,
 	eventSeriesApi,
 	eventsApi,
@@ -52,8 +56,11 @@ import {
 	platformsApi,
 	type Release,
 	type ReleaseCircle,
+	type ReleaseFullResponse,
 	type ReleaseJanCode,
 	type ReleasePublication,
+	type ReleaseWithCounts,
+	type ReleaseWithDiscs,
 	releaseCirclesApi,
 	releaseJanCodesApi,
 	releasePublicationsApi,
@@ -61,9 +68,12 @@ import {
 	type Track,
 	type TrackCredit,
 	type TrackDerivation,
+	type TrackDetail,
 	type TrackIsrc,
+	type TrackListItem,
 	type TrackOfficialSong,
 	type TrackPublication,
+	type TrackWithCreditCount,
 	trackCreditsApi,
 	trackDerivationsApi,
 	trackIsrcsApi,
@@ -245,25 +255,174 @@ export const artistAliasMutations = {
 		},
 	}),
 	update: (queryClient: QueryClient) => ({
-		mutationFn: ({ id, data }: { id: string; data: UpdateArtistAliasData }) =>
-			artistAliasesApi.update(id, data),
-		onSuccess: (
-			_data: ArtistAlias,
-			variables: { id: string; data: UpdateArtistAliasData },
+		mutationFn: ({
+			id,
+			artistId: _artistId,
+			data,
+		}: {
+			id: string;
+			artistId: string;
+			data: UpdateArtistAliasData;
+		}) => artistAliasesApi.update(id, data),
+
+		onMutate: async (variables: {
+			id: string;
+			artistId: string;
+			data: UpdateArtistAliasData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["artistAliases"] });
+			await queryClient.cancelQueries({
+				queryKey: ["artistAlias", variables.id],
+			});
+			await queryClient.cancelQueries({
+				queryKey: ["artist", variables.artistId],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousAliases = queryClient.getQueriesData<
+				PaginatedResponse<ArtistAlias>
+			>({ queryKey: ["artistAliases"] });
+			const previousDetail = queryClient.getQueryData<ArtistAlias>([
+				"artistAlias",
+				variables.id,
+			]);
+			const previousArtist = queryClient.getQueryData<ArtistWithAliases>([
+				"artist",
+				variables.artistId,
+			]);
+			const previousArtistFull = queryClient.getQueryData<ArtistFullResponse>([
+				"artist",
+				variables.artistId,
+				"full",
+			]);
+
+			// 3. 楽観的更新
+			// リストデータ
+			for (const [key, data] of previousAliases) {
+				if (
+					data &&
+					typeof data === "object" &&
+					"data" in data &&
+					Array.isArray(data.data)
+				) {
+					queryClient.setQueryData(key, {
+						...data,
+						data: data.data.map((a: ArtistAlias) =>
+							a.id === variables.id ? { ...a, ...variables.data } : a,
+						),
+					});
+				}
+			}
+
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<ArtistAlias>(
+					["artistAlias", variables.id],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// 親アーティストの詳細データ
+			if (previousArtist) {
+				queryClient.setQueryData<ArtistWithAliases>(
+					["artist", variables.artistId],
+					(old) =>
+						old
+							? {
+									...old,
+									aliases: old.aliases.map((a) =>
+										a.id === variables.id ? { ...a, ...variables.data } : a,
+									),
+								}
+							: old,
+				);
+			}
+
+			// 親アーティストの統合データ
+			if (previousArtistFull) {
+				queryClient.setQueryData<ArtistFullResponse>(
+					["artist", variables.artistId, "full"],
+					(old) =>
+						old
+							? {
+									...old,
+									artist: {
+										...old.artist,
+										aliases: old.artist.aliases.map((a) =>
+											a.id === variables.id ? { ...a, ...variables.data } : a,
+										),
+									},
+								}
+							: old,
+				);
+			}
+
+			return {
+				previousAliases,
+				previousDetail,
+				previousArtist,
+				previousArtistFull,
+			};
+		},
+
+		onError: (
+			err: unknown,
+			variables: { id: string; artistId: string },
+			context:
+				| {
+						previousAliases: [
+							readonly unknown[],
+							PaginatedResponse<ArtistAlias> | undefined,
+						][];
+						previousDetail: ArtistAlias | undefined;
+						previousArtist: ArtistWithAliases | undefined;
+						previousArtistFull: ArtistFullResponse | undefined;
+				  }
+				| undefined,
 		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousAliases) {
+				for (const [key, data] of context.previousAliases) {
+					queryClient.setQueryData(key, data);
+				}
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["artistAlias", variables.id],
+					context.previousDetail,
+				);
+			}
+			if (context?.previousArtist) {
+				queryClient.setQueryData(
+					["artist", variables.artistId],
+					context.previousArtist,
+				);
+			}
+			if (context?.previousArtistFull) {
+				queryClient.setQueryData(
+					["artist", variables.artistId, "full"],
+					context.previousArtistFull,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: ArtistAlias | undefined,
+			_error: unknown,
+			variables: { id: string; artistId: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["artistAliases"] });
 			queryClient.invalidateQueries({
 				queryKey: ["artistAlias", variables.id],
 			});
-			// artistIdがある場合、アーティスト詳細も無効化
-			if (variables.data.artistId) {
-				queryClient.invalidateQueries({
-					queryKey: ["artist", variables.data.artistId],
-				});
-				queryClient.invalidateQueries({
-					queryKey: ["artist", variables.data.artistId, "full"],
-				});
-			}
+			queryClient.invalidateQueries({
+				queryKey: ["artist", variables.artistId],
+			});
 		},
 	}),
 	delete: (queryClient: QueryClient) => ({
@@ -300,12 +459,111 @@ export const circleMutations = {
 	update: (queryClient: QueryClient) => ({
 		mutationFn: ({ id, data }: { id: string; data: UpdateCircleData }) =>
 			circlesApi.update(id, data),
-		onSuccess: (_data: Circle, variables: { id: string }) => {
+
+		onMutate: async (variables: { id: string; data: UpdateCircleData }) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["circles"] });
+			await queryClient.cancelQueries({ queryKey: ["circle", variables.id] });
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousCircles = queryClient.getQueriesData<
+				PaginatedResponse<Circle>
+			>({ queryKey: ["circles"] });
+			const previousDetail = queryClient.getQueryData<CircleWithLinks>([
+				"circle",
+				variables.id,
+			]);
+			const previousFull = queryClient.getQueryData<CircleFullResponse>([
+				"circle",
+				variables.id,
+				"full",
+			]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<CircleWithLinks>(
+					["circle", variables.id],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// 統合データ
+			if (previousFull) {
+				queryClient.setQueryData<CircleFullResponse>(
+					["circle", variables.id, "full"],
+					(old) =>
+						old
+							? { ...old, circle: { ...old.circle, ...variables.data } }
+							: old,
+				);
+			}
+
+			// リストデータ
+			for (const [key, data] of previousCircles) {
+				if (
+					data &&
+					typeof data === "object" &&
+					"data" in data &&
+					Array.isArray(data.data)
+				) {
+					queryClient.setQueryData(key, {
+						...data,
+						data: data.data.map((c: Circle) =>
+							c.id === variables.id ? { ...c, ...variables.data } : c,
+						),
+					});
+				}
+			}
+
+			return { previousCircles, previousDetail, previousFull };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { id: string },
+			context:
+				| {
+						previousCircles: [
+							readonly unknown[],
+							PaginatedResponse<Circle> | undefined,
+						][];
+						previousDetail: CircleWithLinks | undefined;
+						previousFull: CircleFullResponse | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousCircles) {
+				for (const [key, data] of context.previousCircles) {
+					queryClient.setQueryData(key, data);
+				}
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["circle", variables.id],
+					context.previousDetail,
+				);
+			}
+			if (context?.previousFull) {
+				queryClient.setQueryData(
+					["circle", variables.id, "full"],
+					context.previousFull,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: Circle | undefined,
+			_error: unknown,
+			variables: { id: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["circles"] });
 			queryClient.invalidateQueries({ queryKey: ["circle", variables.id] });
-			queryClient.invalidateQueries({
-				queryKey: ["circle", variables.id, "full"],
-			});
 		},
 	}),
 	delete: (queryClient: QueryClient) => ({
@@ -363,12 +621,105 @@ export const circleLinkMutations = {
 			linkId: string;
 			data: UpdateCircleLinkData;
 		}) => circleLinksApi.update(circleId, linkId, data),
-		onSuccess: (_data: CircleLink, variables: { circleId: string }) => {
-			queryClient.invalidateQueries({
+
+		onMutate: async (variables: {
+			circleId: string;
+			linkId: string;
+			data: UpdateCircleLinkData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({
 				queryKey: ["circle", variables.circleId],
 			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousCircle = queryClient.getQueryData<CircleWithLinks>([
+				"circle",
+				variables.circleId,
+			]);
+			const previousCircleFull = queryClient.getQueryData<CircleFullResponse>([
+				"circle",
+				variables.circleId,
+				"full",
+			]);
+
+			// 3. 楽観的更新
+			// サークル詳細データ
+			if (previousCircle) {
+				queryClient.setQueryData<CircleWithLinks>(
+					["circle", variables.circleId],
+					(old) =>
+						old
+							? {
+									...old,
+									links: old.links.map((l) =>
+										l.id === variables.linkId ? { ...l, ...variables.data } : l,
+									),
+								}
+							: old,
+				);
+			}
+
+			// サークル統合データ
+			if (previousCircleFull) {
+				queryClient.setQueryData<CircleFullResponse>(
+					["circle", variables.circleId, "full"],
+					(old) =>
+						old
+							? {
+									...old,
+									circle: {
+										...old.circle,
+										links: old.circle.links.map((l) =>
+											l.id === variables.linkId
+												? { ...l, ...variables.data }
+												: l,
+										),
+									},
+								}
+							: old,
+				);
+			}
+
+			return { previousCircle, previousCircleFull };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { circleId: string; linkId: string },
+			context:
+				| {
+						previousCircle: CircleWithLinks | undefined;
+						previousCircleFull: CircleFullResponse | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousCircle) {
+				queryClient.setQueryData(
+					["circle", variables.circleId],
+					context.previousCircle,
+				);
+			}
+			if (context?.previousCircleFull) {
+				queryClient.setQueryData(
+					["circle", variables.circleId, "full"],
+					context.previousCircleFull,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: CircleLink | undefined,
+			_error: unknown,
+			variables: { circleId: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({
-				queryKey: ["circle", variables.circleId, "full"],
+				queryKey: ["circle", variables.circleId],
 			});
 		},
 	}),
@@ -408,7 +759,80 @@ export const eventSeriesMutations = {
 	update: (queryClient: QueryClient) => ({
 		mutationFn: ({ id, data }: { id: string; data: UpdateEventSeriesData }) =>
 			eventSeriesApi.update(id, data),
-		onSuccess: (_data: EventSeries, variables: { id: string }) => {
+
+		onMutate: async (variables: {
+			id: string;
+			data: UpdateEventSeriesData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["eventSeries"] });
+			await queryClient.cancelQueries({
+				queryKey: ["eventSeries", variables.id],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousEventSeries = queryClient.getQueryData<EventSeries[]>([
+				"eventSeries",
+			]);
+			const previousDetail = queryClient.getQueryData<EventSeriesWithEvents>([
+				"eventSeries",
+				variables.id,
+			]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<EventSeriesWithEvents>(
+					["eventSeries", variables.id],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// リストデータ
+			if (previousEventSeries) {
+				queryClient.setQueryData<EventSeries[]>(["eventSeries"], (old) =>
+					old
+						? old.map((es) =>
+								es.id === variables.id ? { ...es, ...variables.data } : es,
+							)
+						: old,
+				);
+			}
+
+			return { previousEventSeries, previousDetail };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { id: string },
+			context:
+				| {
+						previousEventSeries: EventSeries[] | undefined;
+						previousDetail: EventSeriesWithEvents | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousEventSeries) {
+				queryClient.setQueryData(["eventSeries"], context.previousEventSeries);
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["eventSeries", variables.id],
+					context.previousDetail,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: EventSeries | undefined,
+			_error: unknown,
+			variables: { id: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["eventSeries"] });
 			queryClient.invalidateQueries({
 				queryKey: ["eventSeries", variables.id],
@@ -449,7 +873,86 @@ export const eventMutations = {
 	update: (queryClient: QueryClient) => ({
 		mutationFn: ({ id, data }: { id: string; data: UpdateEventData }) =>
 			eventsApi.update(id, data),
-		onSuccess: (_data: Event, variables: { id: string }) => {
+
+		onMutate: async (variables: { id: string; data: UpdateEventData }) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["events"] });
+			await queryClient.cancelQueries({ queryKey: ["event", variables.id] });
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousEvents = queryClient.getQueriesData<
+				PaginatedResponse<Event>
+			>({ queryKey: ["events"] });
+			const previousDetail = queryClient.getQueryData<EventWithDays>([
+				"event",
+				variables.id,
+			]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<EventWithDays>(
+					["event", variables.id],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// リストデータ
+			for (const [key, data] of previousEvents) {
+				if (
+					data &&
+					typeof data === "object" &&
+					"data" in data &&
+					Array.isArray(data.data)
+				) {
+					queryClient.setQueryData(key, {
+						...data,
+						data: data.data.map((e: Event) =>
+							e.id === variables.id ? { ...e, ...variables.data } : e,
+						),
+					});
+				}
+			}
+
+			return { previousEvents, previousDetail };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { id: string },
+			context:
+				| {
+						previousEvents: [
+							readonly unknown[],
+							PaginatedResponse<Event> | undefined,
+						][];
+						previousDetail: EventWithDays | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousEvents) {
+				for (const [key, data] of context.previousEvents) {
+					queryClient.setQueryData(key, data);
+				}
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["event", variables.id],
+					context.previousDetail,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: Event | undefined,
+			_error: unknown,
+			variables: { id: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["events"] });
 			queryClient.invalidateQueries({ queryKey: ["event", variables.id] });
 		},
@@ -492,8 +995,69 @@ export const eventDayMutations = {
 			dayId: string;
 			data: UpdateEventDayData;
 		}) => eventDaysApi.update(eventId, dayId, data),
-		onSuccess: (_data: EventDay, variables: { eventId: string }) => {
-			queryClient.invalidateQueries({ queryKey: ["event", variables.eventId] });
+
+		onMutate: async (variables: {
+			eventId: string;
+			dayId: string;
+			data: UpdateEventDayData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({
+				queryKey: ["event", variables.eventId],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousEvent = queryClient.getQueryData<EventWithDays>([
+				"event",
+				variables.eventId,
+			]);
+
+			// 3. 楽観的更新
+			// イベント詳細データ（eventDaysはevent内に含まれる）
+			if (previousEvent) {
+				queryClient.setQueryData<EventWithDays>(
+					["event", variables.eventId],
+					(old) =>
+						old
+							? {
+									...old,
+									days: old.days.map((d) =>
+										d.id === variables.dayId ? { ...d, ...variables.data } : d,
+									),
+								}
+							: old,
+				);
+			}
+
+			return { previousEvent };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { eventId: string; dayId: string },
+			context: { previousEvent: EventWithDays | undefined } | undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousEvent) {
+				queryClient.setQueryData(
+					["event", variables.eventId],
+					context.previousEvent,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: EventDay | undefined,
+			_error: unknown,
+			variables: { eventId: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
+			queryClient.invalidateQueries({
+				queryKey: ["event", variables.eventId],
+			});
 		},
 	}),
 	delete: (queryClient: QueryClient) => ({
@@ -527,12 +1091,111 @@ export const releaseMutations = {
 	update: (queryClient: QueryClient) => ({
 		mutationFn: ({ id, data }: { id: string; data: UpdateReleaseData }) =>
 			releasesApi.update(id, data),
-		onSuccess: (_data: Release, variables: { id: string }) => {
+
+		onMutate: async (variables: { id: string; data: UpdateReleaseData }) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["releases"] });
+			await queryClient.cancelQueries({ queryKey: ["release", variables.id] });
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousReleases = queryClient.getQueriesData<
+				PaginatedResponse<ReleaseWithCounts>
+			>({ queryKey: ["releases"] });
+			const previousDetail = queryClient.getQueryData<ReleaseWithDiscs>([
+				"release",
+				variables.id,
+			]);
+			const previousFull = queryClient.getQueryData<ReleaseFullResponse>([
+				"release",
+				variables.id,
+				"full",
+			]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<ReleaseWithDiscs>(
+					["release", variables.id],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// 統合データ
+			if (previousFull) {
+				queryClient.setQueryData<ReleaseFullResponse>(
+					["release", variables.id, "full"],
+					(old) =>
+						old
+							? { ...old, release: { ...old.release, ...variables.data } }
+							: old,
+				);
+			}
+
+			// リストデータ
+			for (const [key, data] of previousReleases) {
+				if (
+					data &&
+					typeof data === "object" &&
+					"data" in data &&
+					Array.isArray(data.data)
+				) {
+					queryClient.setQueryData(key, {
+						...data,
+						data: data.data.map((r: ReleaseWithCounts) =>
+							r.id === variables.id ? { ...r, ...variables.data } : r,
+						),
+					});
+				}
+			}
+
+			return { previousReleases, previousDetail, previousFull };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { id: string },
+			context:
+				| {
+						previousReleases: [
+							readonly unknown[],
+							PaginatedResponse<ReleaseWithCounts> | undefined,
+						][];
+						previousDetail: ReleaseWithDiscs | undefined;
+						previousFull: ReleaseFullResponse | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousReleases) {
+				for (const [key, data] of context.previousReleases) {
+					queryClient.setQueryData(key, data);
+				}
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["release", variables.id],
+					context.previousDetail,
+				);
+			}
+			if (context?.previousFull) {
+				queryClient.setQueryData(
+					["release", variables.id, "full"],
+					context.previousFull,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: Release | undefined,
+			_error: unknown,
+			variables: { id: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["releases"] });
 			queryClient.invalidateQueries({ queryKey: ["release", variables.id] });
-			queryClient.invalidateQueries({
-				queryKey: ["release", variables.id, "full"],
-			});
 		},
 	}),
 	delete: (queryClient: QueryClient) => ({
@@ -584,12 +1247,103 @@ export const discMutations = {
 			discId: string;
 			data: UpdateDiscData;
 		}) => discsApi.update(releaseId, discId, data),
-		onSuccess: (_data: Disc, variables: { releaseId: string }) => {
-			queryClient.invalidateQueries({
+
+		onMutate: async (variables: {
+			releaseId: string;
+			discId: string;
+			data: UpdateDiscData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({
 				queryKey: ["release", variables.releaseId],
 			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousRelease = queryClient.getQueryData<ReleaseWithDiscs>([
+				"release",
+				variables.releaseId,
+			]);
+			const previousReleaseFull = queryClient.getQueryData<ReleaseFullResponse>(
+				["release", variables.releaseId, "full"],
+			);
+
+			// 3. 楽観的更新
+			// リリース詳細データ
+			if (previousRelease) {
+				queryClient.setQueryData<ReleaseWithDiscs>(
+					["release", variables.releaseId],
+					(old) =>
+						old
+							? {
+									...old,
+									discs: old.discs.map((d) =>
+										d.id === variables.discId ? { ...d, ...variables.data } : d,
+									),
+								}
+							: old,
+				);
+			}
+
+			// リリース統合データ
+			if (previousReleaseFull) {
+				queryClient.setQueryData<ReleaseFullResponse>(
+					["release", variables.releaseId, "full"],
+					(old) =>
+						old
+							? {
+									...old,
+									release: {
+										...old.release,
+										discs: old.release.discs.map((d) =>
+											d.id === variables.discId
+												? { ...d, ...variables.data }
+												: d,
+										),
+									},
+								}
+							: old,
+				);
+			}
+
+			return { previousRelease, previousReleaseFull };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { releaseId: string; discId: string },
+			context:
+				| {
+						previousRelease: ReleaseWithDiscs | undefined;
+						previousReleaseFull: ReleaseFullResponse | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousRelease) {
+				queryClient.setQueryData(
+					["release", variables.releaseId],
+					context.previousRelease,
+				);
+			}
+			if (context?.previousReleaseFull) {
+				queryClient.setQueryData(
+					["release", variables.releaseId, "full"],
+					context.previousReleaseFull,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: Disc | undefined,
+			_error: unknown,
+			variables: { releaseId: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({
-				queryKey: ["release", variables.releaseId, "full"],
+				queryKey: ["release", variables.releaseId],
 			});
 		},
 	}),
@@ -656,10 +1410,151 @@ export const trackMutations = {
 			trackId: string;
 			data: UpdateTrackData;
 		}) => tracksApi.update(releaseId, trackId, data),
-		onSuccess: (
-			_data: Track,
+
+		onMutate: async (variables: {
+			releaseId: string;
+			trackId: string;
+			data: UpdateTrackData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["tracks"] });
+			await queryClient.cancelQueries({
+				queryKey: ["track", variables.trackId],
+			});
+			await queryClient.cancelQueries({
+				queryKey: ["release", variables.releaseId],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousTracks = queryClient.getQueriesData<
+				PaginatedResponse<TrackListItem>
+			>({ queryKey: ["tracks"] });
+			const previousDetail = queryClient.getQueryData<TrackDetail>([
+				"track",
+				variables.trackId,
+			]);
+			const previousReleaseFull = queryClient.getQueryData<ReleaseFullResponse>(
+				["release", variables.releaseId, "full"],
+			);
+			const previousReleaseTracks = queryClient.getQueryData<
+				TrackWithCreditCount[]
+			>(["release", variables.releaseId, "tracks"]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<TrackDetail>(
+					["track", variables.trackId],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// リストデータ
+			for (const [key, data] of previousTracks) {
+				if (
+					data &&
+					typeof data === "object" &&
+					"data" in data &&
+					Array.isArray(data.data)
+				) {
+					queryClient.setQueryData(key, {
+						...data,
+						data: data.data.map((t: TrackListItem) =>
+							t.id === variables.trackId ? { ...t, ...variables.data } : t,
+						),
+					});
+				}
+			}
+
+			// リリースのトラック一覧
+			if (previousReleaseTracks) {
+				queryClient.setQueryData<TrackWithCreditCount[]>(
+					["release", variables.releaseId, "tracks"],
+					(old) =>
+						old
+							? old.map((t) =>
+									t.id === variables.trackId ? { ...t, ...variables.data } : t,
+								)
+							: old,
+				);
+			}
+
+			// 親リリースの統合データ（トラック一覧を更新）
+			if (previousReleaseFull) {
+				queryClient.setQueryData<ReleaseFullResponse>(
+					["release", variables.releaseId, "full"],
+					(old) =>
+						old
+							? {
+									...old,
+									tracks: old.tracks.map((t) =>
+										t.id === variables.trackId
+											? { ...t, ...variables.data }
+											: t,
+									),
+								}
+							: old,
+				);
+			}
+
+			return {
+				previousTracks,
+				previousDetail,
+				previousReleaseFull,
+				previousReleaseTracks,
+			};
+		},
+
+		onError: (
+			err: unknown,
+			variables: { releaseId: string; trackId: string },
+			context:
+				| {
+						previousTracks: [
+							readonly unknown[],
+							PaginatedResponse<TrackListItem> | undefined,
+						][];
+						previousDetail: TrackDetail | undefined;
+						previousReleaseFull: ReleaseFullResponse | undefined;
+						previousReleaseTracks: TrackWithCreditCount[] | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousTracks) {
+				for (const [key, data] of context.previousTracks) {
+					queryClient.setQueryData(key, data);
+				}
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["track", variables.trackId],
+					context.previousDetail,
+				);
+			}
+			if (context?.previousReleaseFull) {
+				queryClient.setQueryData(
+					["release", variables.releaseId, "full"],
+					context.previousReleaseFull,
+				);
+			}
+			if (context?.previousReleaseTracks) {
+				queryClient.setQueryData(
+					["release", variables.releaseId, "tracks"],
+					context.previousReleaseTracks,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: Track | undefined,
+			_error: unknown,
 			variables: { releaseId: string; trackId: string },
 		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["tracks"] });
 			queryClient.invalidateQueries({ queryKey: ["track", variables.trackId] });
 			queryClient.invalidateQueries({
@@ -750,7 +1645,91 @@ export const officialWorkMutations = {
 	update: (queryClient: QueryClient) => ({
 		mutationFn: ({ id, data }: { id: string; data: UpdateOfficialWorkData }) =>
 			officialWorksApi.update(id, data),
-		onSuccess: (_data: OfficialWork, variables: { id: string }) => {
+
+		onMutate: async (variables: {
+			id: string;
+			data: UpdateOfficialWorkData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["officialWorks"] });
+			await queryClient.cancelQueries({
+				queryKey: ["officialWork", variables.id],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousOfficialWorks = queryClient.getQueriesData<
+				PaginatedResponse<OfficialWork>
+			>({ queryKey: ["officialWorks"] });
+			const previousDetail = queryClient.getQueryData<OfficialWork>([
+				"officialWork",
+				variables.id,
+			]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<OfficialWork>(
+					["officialWork", variables.id],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// リストデータ
+			for (const [key, data] of previousOfficialWorks) {
+				if (
+					data &&
+					typeof data === "object" &&
+					"data" in data &&
+					Array.isArray(data.data)
+				) {
+					queryClient.setQueryData(key, {
+						...data,
+						data: data.data.map((ow: OfficialWork) =>
+							ow.id === variables.id ? { ...ow, ...variables.data } : ow,
+						),
+					});
+				}
+			}
+
+			return { previousOfficialWorks, previousDetail };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { id: string },
+			context:
+				| {
+						previousOfficialWorks: [
+							readonly unknown[],
+							PaginatedResponse<OfficialWork> | undefined,
+						][];
+						previousDetail: OfficialWork | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousOfficialWorks) {
+				for (const [key, data] of context.previousOfficialWorks) {
+					queryClient.setQueryData(key, data);
+				}
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["officialWork", variables.id],
+					context.previousDetail,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: OfficialWork | undefined,
+			_error: unknown,
+			variables: { id: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["officialWorks"] });
 			queryClient.invalidateQueries({
 				queryKey: ["officialWork", variables.id],
@@ -785,7 +1764,91 @@ export const officialSongMutations = {
 	update: (queryClient: QueryClient) => ({
 		mutationFn: ({ id, data }: { id: string; data: UpdateOfficialSongData }) =>
 			officialSongsApi.update(id, data),
-		onSuccess: (_data: OfficialSong, variables: { id: string }) => {
+
+		onMutate: async (variables: {
+			id: string;
+			data: UpdateOfficialSongData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["officialSongs"] });
+			await queryClient.cancelQueries({
+				queryKey: ["officialSong", variables.id],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousOfficialSongs = queryClient.getQueriesData<
+				PaginatedResponse<OfficialSong>
+			>({ queryKey: ["officialSongs"] });
+			const previousDetail = queryClient.getQueryData<OfficialSong>([
+				"officialSong",
+				variables.id,
+			]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<OfficialSong>(
+					["officialSong", variables.id],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// リストデータ
+			for (const [key, data] of previousOfficialSongs) {
+				if (
+					data &&
+					typeof data === "object" &&
+					"data" in data &&
+					Array.isArray(data.data)
+				) {
+					queryClient.setQueryData(key, {
+						...data,
+						data: data.data.map((os: OfficialSong) =>
+							os.id === variables.id ? { ...os, ...variables.data } : os,
+						),
+					});
+				}
+			}
+
+			return { previousOfficialSongs, previousDetail };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { id: string },
+			context:
+				| {
+						previousOfficialSongs: [
+							readonly unknown[],
+							PaginatedResponse<OfficialSong> | undefined,
+						][];
+						previousDetail: OfficialSong | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousOfficialSongs) {
+				for (const [key, data] of context.previousOfficialSongs) {
+					queryClient.setQueryData(key, data);
+				}
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["officialSong", variables.id],
+					context.previousDetail,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: OfficialSong | undefined,
+			_error: unknown,
+			variables: { id: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["officialSongs"] });
 			queryClient.invalidateQueries({
 				queryKey: ["officialSong", variables.id],
@@ -819,7 +1882,77 @@ export const platformMutations = {
 	update: (queryClient: QueryClient) => ({
 		mutationFn: ({ code, data }: { code: string; data: UpdatePlatformData }) =>
 			platformsApi.update(code, data),
-		onSuccess: (_data: Platform, variables: { code: string }) => {
+
+		onMutate: async (variables: { code: string; data: UpdatePlatformData }) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["platforms"] });
+			await queryClient.cancelQueries({
+				queryKey: ["platform", variables.code],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousPlatforms = queryClient.getQueryData<Platform[]>([
+				"platforms",
+			]);
+			const previousDetail = queryClient.getQueryData<Platform>([
+				"platform",
+				variables.code,
+			]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<Platform>(
+					["platform", variables.code],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// リストデータ
+			if (previousPlatforms) {
+				queryClient.setQueryData<Platform[]>(["platforms"], (old) =>
+					old
+						? old.map((p) =>
+								p.code === variables.code ? { ...p, ...variables.data } : p,
+							)
+						: old,
+				);
+			}
+
+			return { previousPlatforms, previousDetail };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { code: string },
+			context:
+				| {
+						previousPlatforms: Platform[] | undefined;
+						previousDetail: Platform | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousPlatforms) {
+				queryClient.setQueryData(["platforms"], context.previousPlatforms);
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["platform", variables.code],
+					context.previousDetail,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: Platform | undefined,
+			_error: unknown,
+			variables: { code: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["platforms"] });
 			queryClient.invalidateQueries({ queryKey: ["platform", variables.code] });
 		},
@@ -863,7 +1996,80 @@ export const aliasTypeMutations = {
 	update: (queryClient: QueryClient) => ({
 		mutationFn: ({ code, data }: { code: string; data: UpdateAliasTypeData }) =>
 			aliasTypesApi.update(code, data),
-		onSuccess: (_data: AliasType, variables: { code: string }) => {
+
+		onMutate: async (variables: {
+			code: string;
+			data: UpdateAliasTypeData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["aliasTypes"] });
+			await queryClient.cancelQueries({
+				queryKey: ["aliasType", variables.code],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousAliasTypes = queryClient.getQueryData<AliasType[]>([
+				"aliasTypes",
+			]);
+			const previousDetail = queryClient.getQueryData<AliasType>([
+				"aliasType",
+				variables.code,
+			]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<AliasType>(
+					["aliasType", variables.code],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// リストデータ
+			if (previousAliasTypes) {
+				queryClient.setQueryData<AliasType[]>(["aliasTypes"], (old) =>
+					old
+						? old.map((a) =>
+								a.code === variables.code ? { ...a, ...variables.data } : a,
+							)
+						: old,
+				);
+			}
+
+			return { previousAliasTypes, previousDetail };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { code: string },
+			context:
+				| {
+						previousAliasTypes: AliasType[] | undefined;
+						previousDetail: AliasType | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousAliasTypes) {
+				queryClient.setQueryData(["aliasTypes"], context.previousAliasTypes);
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["aliasType", variables.code],
+					context.previousDetail,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: AliasType | undefined,
+			_error: unknown,
+			variables: { code: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["aliasTypes"] });
 			queryClient.invalidateQueries({
 				queryKey: ["aliasType", variables.code],
@@ -914,7 +2120,80 @@ export const creditRoleMutations = {
 			code: string;
 			data: UpdateCreditRoleData;
 		}) => creditRolesApi.update(code, data),
-		onSuccess: (_data: CreditRole, variables: { code: string }) => {
+
+		onMutate: async (variables: {
+			code: string;
+			data: UpdateCreditRoleData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["creditRoles"] });
+			await queryClient.cancelQueries({
+				queryKey: ["creditRole", variables.code],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousCreditRoles = queryClient.getQueryData<CreditRole[]>([
+				"creditRoles",
+			]);
+			const previousDetail = queryClient.getQueryData<CreditRole>([
+				"creditRole",
+				variables.code,
+			]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<CreditRole>(
+					["creditRole", variables.code],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// リストデータ
+			if (previousCreditRoles) {
+				queryClient.setQueryData<CreditRole[]>(["creditRoles"], (old) =>
+					old
+						? old.map((c) =>
+								c.code === variables.code ? { ...c, ...variables.data } : c,
+							)
+						: old,
+				);
+			}
+
+			return { previousCreditRoles, previousDetail };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { code: string },
+			context:
+				| {
+						previousCreditRoles: CreditRole[] | undefined;
+						previousDetail: CreditRole | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousCreditRoles) {
+				queryClient.setQueryData(["creditRoles"], context.previousCreditRoles);
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["creditRole", variables.code],
+					context.previousDetail,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: CreditRole | undefined,
+			_error: unknown,
+			variables: { code: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["creditRoles"] });
 			queryClient.invalidateQueries({
 				queryKey: ["creditRole", variables.code],
@@ -964,7 +2243,85 @@ export const officialWorkCategoryMutations = {
 			code: string;
 			data: UpdateOfficialWorkCategoryData;
 		}) => officialWorkCategoriesApi.update(code, data),
-		onSuccess: (_data: OfficialWorkCategory, variables: { code: string }) => {
+
+		onMutate: async (variables: {
+			code: string;
+			data: UpdateOfficialWorkCategoryData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({ queryKey: ["officialWorkCategories"] });
+			await queryClient.cancelQueries({
+				queryKey: ["officialWorkCategory", variables.code],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousCategories = queryClient.getQueryData<
+				OfficialWorkCategory[]
+			>(["officialWorkCategories"]);
+			const previousDetail = queryClient.getQueryData<OfficialWorkCategory>([
+				"officialWorkCategory",
+				variables.code,
+			]);
+
+			// 3. 楽観的更新
+			// 詳細データ
+			if (previousDetail) {
+				queryClient.setQueryData<OfficialWorkCategory>(
+					["officialWorkCategory", variables.code],
+					(old) => (old ? { ...old, ...variables.data } : old),
+				);
+			}
+
+			// リストデータ
+			if (previousCategories) {
+				queryClient.setQueryData<OfficialWorkCategory[]>(
+					["officialWorkCategories"],
+					(old) =>
+						old
+							? old.map((c) =>
+									c.code === variables.code ? { ...c, ...variables.data } : c,
+								)
+							: old,
+				);
+			}
+
+			return { previousCategories, previousDetail };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { code: string },
+			context:
+				| {
+						previousCategories: OfficialWorkCategory[] | undefined;
+						previousDetail: OfficialWorkCategory | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousCategories) {
+				queryClient.setQueryData(
+					["officialWorkCategories"],
+					context.previousCategories,
+				);
+			}
+			if (context?.previousDetail) {
+				queryClient.setQueryData(
+					["officialWorkCategory", variables.code],
+					context.previousDetail,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: OfficialWorkCategory | undefined,
+			_error: unknown,
+			variables: { code: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["officialWorkCategories"] });
 			queryClient.invalidateQueries({
 				queryKey: ["officialWorkCategory", variables.code],
@@ -1029,12 +2386,81 @@ export const releaseCircleMutations = {
 			data: UpdateReleaseCircleData;
 		}) =>
 			releaseCirclesApi.update(releaseId, circleId, participationType, data),
-		onSuccess: (_data: ReleaseCircle, variables: { releaseId: string }) => {
+
+		onMutate: async (variables: {
+			releaseId: string;
+			circleId: string;
+			participationType: ParticipationType;
+			data: UpdateReleaseCircleData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({
+				queryKey: ["release", variables.releaseId, "full"],
+			});
+			await queryClient.cancelQueries({
+				queryKey: ["release-circles", variables.releaseId],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousReleaseFull = queryClient.getQueryData<ReleaseFullResponse>(
+				["release", variables.releaseId, "full"],
+			);
+
+			// 3. 楽観的更新
+			if (previousReleaseFull) {
+				queryClient.setQueryData<ReleaseFullResponse>(
+					["release", variables.releaseId, "full"],
+					(old) =>
+						old
+							? {
+									...old,
+									circles: old.circles.map((c) =>
+										c.circleId === variables.circleId &&
+										c.participationType === variables.participationType
+											? { ...c, ...variables.data }
+											: c,
+									),
+								}
+							: old,
+				);
+			}
+
+			return { previousReleaseFull };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { releaseId: string },
+			context:
+				| { previousReleaseFull: ReleaseFullResponse | undefined }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousReleaseFull) {
+				queryClient.setQueryData(
+					["release", variables.releaseId, "full"],
+					context.previousReleaseFull,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: ReleaseCircle | undefined,
+			_error: unknown,
+			variables: { releaseId: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({
 				queryKey: ["release", variables.releaseId],
 			});
 			queryClient.invalidateQueries({
 				queryKey: ["release", variables.releaseId, "full"],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["release-circles", variables.releaseId],
 			});
 		},
 	}),
@@ -1104,15 +2530,79 @@ export const releasePublicationMutations = {
 			publicationId: string;
 			data: UpdateReleasePublicationData;
 		}) => releasePublicationsApi.update(releaseId, publicationId, data),
-		onSuccess: (
-			_data: ReleasePublication,
+
+		onMutate: async (variables: {
+			releaseId: string;
+			publicationId: string;
+			data: UpdateReleasePublicationData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({
+				queryKey: ["release", variables.releaseId, "full"],
+			});
+			await queryClient.cancelQueries({
+				queryKey: ["release-publications", variables.releaseId],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousReleaseFull = queryClient.getQueryData<ReleaseFullResponse>(
+				["release", variables.releaseId, "full"],
+			);
+
+			// 3. 楽観的更新
+			if (previousReleaseFull) {
+				queryClient.setQueryData<ReleaseFullResponse>(
+					["release", variables.releaseId, "full"],
+					(old) =>
+						old
+							? {
+									...old,
+									publications: old.publications.map((p) =>
+										p.id === variables.publicationId
+											? { ...p, ...variables.data }
+											: p,
+									),
+								}
+							: old,
+				);
+			}
+
+			return { previousReleaseFull };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { releaseId: string },
+			context:
+				| { previousReleaseFull: ReleaseFullResponse | undefined }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousReleaseFull) {
+				queryClient.setQueryData(
+					["release", variables.releaseId, "full"],
+					context.previousReleaseFull,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: ReleasePublication | undefined,
+			_error: unknown,
 			variables: { releaseId: string },
 		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({
 				queryKey: ["release", variables.releaseId],
 			});
 			queryClient.invalidateQueries({
 				queryKey: ["release", variables.releaseId, "full"],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["release-publications", variables.releaseId],
 			});
 		},
 	}),
@@ -1181,12 +2671,79 @@ export const releaseJanCodeMutations = {
 			janCodeId: string;
 			data: UpdateReleaseJanCodeData;
 		}) => releaseJanCodesApi.update(releaseId, janCodeId, data),
-		onSuccess: (_data: ReleaseJanCode, variables: { releaseId: string }) => {
+
+		onMutate: async (variables: {
+			releaseId: string;
+			janCodeId: string;
+			data: UpdateReleaseJanCodeData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({
+				queryKey: ["release", variables.releaseId, "full"],
+			});
+			await queryClient.cancelQueries({
+				queryKey: ["release-jan-codes", variables.releaseId],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousReleaseFull = queryClient.getQueryData<ReleaseFullResponse>(
+				["release", variables.releaseId, "full"],
+			);
+
+			// 3. 楽観的更新
+			if (previousReleaseFull) {
+				queryClient.setQueryData<ReleaseFullResponse>(
+					["release", variables.releaseId, "full"],
+					(old) =>
+						old
+							? {
+									...old,
+									janCodes: old.janCodes.map((j) =>
+										j.id === variables.janCodeId
+											? { ...j, ...variables.data }
+											: j,
+									),
+								}
+							: old,
+				);
+			}
+
+			return { previousReleaseFull };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { releaseId: string },
+			context:
+				| { previousReleaseFull: ReleaseFullResponse | undefined }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousReleaseFull) {
+				queryClient.setQueryData(
+					["release", variables.releaseId, "full"],
+					context.previousReleaseFull,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: ReleaseJanCode | undefined,
+			_error: unknown,
+			variables: { releaseId: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({
 				queryKey: ["release", variables.releaseId],
 			});
 			queryClient.invalidateQueries({
 				queryKey: ["release", variables.releaseId, "full"],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["release-jan-codes", variables.releaseId],
 			});
 		},
 	}),
@@ -1268,11 +2825,93 @@ export const trackCreditMutations = {
 			creditId: string;
 			data: UpdateTrackCreditData;
 		}) => trackCreditsApi.update(releaseId, trackId, creditId, data),
-		onSuccess: (
-			_data: TrackCredit,
+
+		onMutate: async (variables: {
+			releaseId: string;
+			trackId: string;
+			creditId: string;
+			data: UpdateTrackCreditData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({
+				queryKey: ["release", variables.releaseId, "full"],
+			});
+			await queryClient.cancelQueries({
+				queryKey: ["track", variables.trackId],
+			});
+			await queryClient.cancelQueries({
+				queryKey: ["track-credits", variables.trackId],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousReleaseFull = queryClient.getQueryData<ReleaseFullResponse>(
+				["release", variables.releaseId, "full"],
+			);
+			const previousTrack = queryClient.getQueryData<TrackDetail>([
+				"track",
+				variables.trackId,
+			]);
+
+			// 3. 楽観的更新
+			// トラック詳細データ
+			if (previousTrack) {
+				queryClient.setQueryData<TrackDetail>(
+					["track", variables.trackId],
+					(old) =>
+						old
+							? {
+									...old,
+									credits: old.credits.map((c) =>
+										c.id === variables.creditId
+											? { ...c, ...variables.data }
+											: c,
+									),
+								}
+							: old,
+				);
+			}
+
+			return { previousReleaseFull, previousTrack };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { releaseId: string; trackId: string },
+			context:
+				| {
+						previousReleaseFull: ReleaseFullResponse | undefined;
+						previousTrack: TrackDetail | undefined;
+				  }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousReleaseFull) {
+				queryClient.setQueryData(
+					["release", variables.releaseId, "full"],
+					context.previousReleaseFull,
+				);
+			}
+			if (context?.previousTrack) {
+				queryClient.setQueryData(
+					["track", variables.trackId],
+					context.previousTrack,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: TrackCredit | undefined,
+			_error: unknown,
 			variables: { releaseId: string; trackId: string },
 		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({ queryKey: ["track", variables.trackId] });
+			queryClient.invalidateQueries({
+				queryKey: ["track-credits", variables.trackId],
+			});
 			queryClient.invalidateQueries({
 				queryKey: ["release", variables.releaseId],
 			});
@@ -1350,7 +2989,68 @@ export const trackOfficialSongMutations = {
 			officialSongId: string;
 			data: UpdateTrackOfficialSongData;
 		}) => trackOfficialSongsApi.update(trackId, officialSongId, data),
-		onSuccess: (_data: TrackOfficialSong, variables: { trackId: string }) => {
+
+		onMutate: async (variables: {
+			trackId: string;
+			officialSongId: string;
+			data: UpdateTrackOfficialSongData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({
+				queryKey: ["track-official-songs", variables.trackId],
+			});
+			await queryClient.cancelQueries({
+				queryKey: ["track", variables.trackId],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousOfficialSongs = queryClient.getQueryData<
+				TrackOfficialSong[]
+			>(["track-official-songs", variables.trackId]);
+
+			// 3. 楽観的更新
+			if (previousOfficialSongs) {
+				queryClient.setQueryData<TrackOfficialSong[]>(
+					["track-official-songs", variables.trackId],
+					(old) =>
+						old
+							? old.map((os) =>
+									os.id === variables.officialSongId
+										? { ...os, ...variables.data }
+										: os,
+								)
+							: old,
+				);
+			}
+
+			return { previousOfficialSongs };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { trackId: string },
+			context:
+				| { previousOfficialSongs: TrackOfficialSong[] | undefined }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousOfficialSongs) {
+				queryClient.setQueryData(
+					["track-official-songs", variables.trackId],
+					context.previousOfficialSongs,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: TrackOfficialSong | undefined,
+			_error: unknown,
+			variables: { trackId: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({
 				queryKey: ["track-official-songs", variables.trackId],
 			});
@@ -1475,7 +3175,68 @@ export const trackPublicationMutations = {
 			publicationId: string;
 			data: UpdateTrackPublicationData;
 		}) => trackPublicationsApi.update(trackId, publicationId, data),
-		onSuccess: (_data: TrackPublication, variables: { trackId: string }) => {
+
+		onMutate: async (variables: {
+			trackId: string;
+			publicationId: string;
+			data: UpdateTrackPublicationData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({
+				queryKey: ["track-publications", variables.trackId],
+			});
+			await queryClient.cancelQueries({
+				queryKey: ["track", variables.trackId],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousPublications = queryClient.getQueryData<TrackPublication[]>(
+				["track-publications", variables.trackId],
+			);
+
+			// 3. 楽観的更新
+			if (previousPublications) {
+				queryClient.setQueryData<TrackPublication[]>(
+					["track-publications", variables.trackId],
+					(old) =>
+						old
+							? old.map((p) =>
+									p.id === variables.publicationId
+										? { ...p, ...variables.data }
+										: p,
+								)
+							: old,
+				);
+			}
+
+			return { previousPublications };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { trackId: string },
+			context:
+				| { previousPublications: TrackPublication[] | undefined }
+				| undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousPublications) {
+				queryClient.setQueryData(
+					["track-publications", variables.trackId],
+					context.previousPublications,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: TrackPublication | undefined,
+			_error: unknown,
+			variables: { trackId: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({
 				queryKey: ["track-publications", variables.trackId],
 			});
@@ -1539,7 +3300,67 @@ export const trackIsrcMutations = {
 			isrcId: string;
 			data: UpdateTrackIsrcData;
 		}) => trackIsrcsApi.update(trackId, isrcId, data),
-		onSuccess: (_data: TrackIsrc, variables: { trackId: string }) => {
+
+		onMutate: async (variables: {
+			trackId: string;
+			isrcId: string;
+			data: UpdateTrackIsrcData;
+		}) => {
+			// 1. 進行中のクエリをキャンセル
+			await queryClient.cancelQueries({
+				queryKey: ["track-isrcs", variables.trackId],
+			});
+			await queryClient.cancelQueries({
+				queryKey: ["track", variables.trackId],
+			});
+
+			// 2. 現在のキャッシュを保存（ロールバック用）
+			const previousIsrcs = queryClient.getQueryData<TrackIsrc[]>([
+				"track-isrcs",
+				variables.trackId,
+			]);
+
+			// 3. 楽観的更新
+			if (previousIsrcs) {
+				queryClient.setQueryData<TrackIsrc[]>(
+					["track-isrcs", variables.trackId],
+					(old) =>
+						old
+							? old.map((isrc) =>
+									isrc.id === variables.isrcId
+										? { ...isrc, ...variables.data }
+										: isrc,
+								)
+							: old,
+				);
+			}
+
+			return { previousIsrcs };
+		},
+
+		onError: (
+			err: unknown,
+			variables: { trackId: string },
+			context: { previousIsrcs: TrackIsrc[] | undefined } | undefined,
+		) => {
+			// ConflictErrorの場合はロールバックしない（ConflictDialogで処理するため）
+			if (isConflictError(err)) return;
+
+			// ロールバック処理
+			if (context?.previousIsrcs) {
+				queryClient.setQueryData(
+					["track-isrcs", variables.trackId],
+					context.previousIsrcs,
+				);
+			}
+		},
+
+		onSettled: (
+			_data: TrackIsrc | undefined,
+			_error: unknown,
+			variables: { trackId: string },
+		) => {
+			// 成功・失敗に関わらずサーバーと同期
 			queryClient.invalidateQueries({
 				queryKey: ["track-isrcs", variables.trackId],
 			});

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -6,6 +6,18 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * unknown型のエラーからエラーメッセージを安全に取得
+ */
+export function getErrorMessage(
+	error: unknown,
+	defaultMessage = "エラーが発生しました",
+): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === "string") return error;
+	return defaultMessage;
+}
+
+/**
  * ID生成ユーティリティ
  */
 export const createId = {

--- a/apps/web/src/routes/admin/_admin/circles.tsx
+++ b/apps/web/src/routes/admin/_admin/circles.tsx
@@ -63,7 +63,7 @@ import {
 import { createPageHead } from "@/lib/head";
 import { circleLinkMutations, circleMutations } from "@/lib/mutation-options";
 import { circlesListQueryOptions } from "@/lib/query-options";
-import { getExternalLinkUrl } from "@/lib/utils";
+import { getErrorMessage, getExternalLinkUrl } from "@/lib/utils";
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PAGE_SIZE = 20;
@@ -1167,14 +1167,13 @@ function CirclesPage() {
 								</Label>
 							</div>
 						</div>
-						{(createLinkMutation.error || updateLinkMutation.error) && (
+						{createLinkMutation.error || updateLinkMutation.error ? (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{
-									(createLinkMutation.error || updateLinkMutation.error)
-										?.message
-								}
+								{getErrorMessage(
+									createLinkMutation.error || updateLinkMutation.error,
+								)}
 							</div>
-						)}
+						) : null}
 					</div>
 					<DialogFooter>
 						<Button variant="ghost" onClick={() => setIsLinkDialogOpen(false)}>
@@ -1213,7 +1212,7 @@ function CirclesPage() {
 						</p>
 						{batchDeleteMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{batchDeleteMutation.error.message}
+								{getErrorMessage(batchDeleteMutation.error)}
 							</p>
 						)}
 					</div>

--- a/apps/web/src/routes/admin/_admin/circles_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/circles_.$id.tsx
@@ -53,6 +53,7 @@ import {
 import { createCircleDetailHead } from "@/lib/head";
 import { circleLinkMutations, circleMutations } from "@/lib/mutation-options";
 import { circleFullQueryOptions } from "@/lib/query-options";
+import { getErrorMessage } from "@/lib/utils";
 
 export const Route = createFileRoute("/admin/_admin/circles_/$id")({
 	loader: ({ context, params }) =>
@@ -706,14 +707,13 @@ function CircleDetailPage() {
 						</DialogTitle>
 					</DialogHeader>
 					<div className="grid gap-4 py-4">
-						{(linkCreateMutation.error || linkUpdateMutation.error) && (
+						{linkCreateMutation.error || linkUpdateMutation.error ? (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{
-									(linkCreateMutation.error || linkUpdateMutation.error)
-										?.message
-								}
+								{getErrorMessage(
+									linkCreateMutation.error || linkUpdateMutation.error,
+								)}
 							</div>
-						)}
+						) : null}
 
 						<div className="grid gap-2">
 							<Label>
@@ -836,7 +836,7 @@ function CircleDetailPage() {
 						</p>
 						{deleteMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{deleteMutation.error.message}
+								{getErrorMessage(deleteMutation.error)}
 							</p>
 						)}
 					</div>
@@ -869,7 +869,7 @@ function CircleDetailPage() {
 						</p>
 						{linkDeleteMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{linkDeleteMutation.error.message}
+								{getErrorMessage(linkDeleteMutation.error)}
 							</p>
 						)}
 					</div>

--- a/apps/web/src/routes/admin/_admin/event-series_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/event-series_.$id.tsx
@@ -28,6 +28,7 @@ import type { EventSeries } from "@/lib/api-client";
 import { createEventSeriesDetailHead } from "@/lib/head";
 import { eventSeriesMutations } from "@/lib/mutation-options";
 import { eventSeriesDetailQueryOptions } from "@/lib/query-options";
+import { getErrorMessage } from "@/lib/utils";
 
 export const Route = createFileRoute("/admin/_admin/event-series_/$id")({
 	loader: ({ context, params }) =>
@@ -262,13 +263,11 @@ function EventSeriesDetailPage() {
 							/>
 						</div>
 					</div>
-					{updateMutation.error && (
+					{updateMutation.error ? (
 						<div className="mb-4 text-error text-sm">
-							{updateMutation.error instanceof Error
-								? updateMutation.error.message
-								: "更新に失敗しました"}
+							{getErrorMessage(updateMutation.error, "更新に失敗しました")}
 						</div>
-					)}
+					) : null}
 					<DialogFooter>
 						<Button
 							variant="outline"

--- a/apps/web/src/routes/admin/_admin/events.tsx
+++ b/apps/web/src/routes/admin/_admin/events.tsx
@@ -58,6 +58,7 @@ import {
 	eventSeriesMutations,
 } from "@/lib/mutation-options";
 import { eventsListQueryOptions } from "@/lib/query-options";
+import { getErrorMessage } from "@/lib/utils";
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PAGE_SIZE = 20;
@@ -984,15 +985,14 @@ function EventsPage() {
 								}
 							/>
 						</div>
-						{(createDayMutation.error || updateDayMutation.error) && (
+						{createDayMutation.error || updateDayMutation.error ? (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{(createDayMutation.error || updateDayMutation.error) instanceof
-								Error
-									? (createDayMutation.error || updateDayMutation.error)
-											?.message
-									: "開催日の保存に失敗しました"}
+								{getErrorMessage(
+									createDayMutation.error || updateDayMutation.error,
+									"開催日の保存に失敗しました",
+								)}
 							</div>
-						)}
+						) : null}
 					</div>
 					<DialogFooter>
 						<Button variant="ghost" onClick={() => setIsDayDialogOpen(false)}>

--- a/apps/web/src/routes/admin/_admin/events_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/events_.$id.tsx
@@ -30,6 +30,7 @@ import type { EventDay } from "@/lib/api-client";
 import { createEventDetailHead } from "@/lib/head";
 import { eventDayMutations, eventMutations } from "@/lib/mutation-options";
 import { eventDetailQueryOptions } from "@/lib/query-options";
+import { getErrorMessage } from "@/lib/utils";
 
 export const Route = createFileRoute("/admin/_admin/events_/$id")({
 	loader: ({ context, params }) =>
@@ -364,11 +365,13 @@ function EventDetailPage() {
 						</DialogTitle>
 					</DialogHeader>
 					<div className="grid gap-4 py-4">
-						{(dayCreateMutation.error || dayUpdateMutation.error) && (
+						{dayCreateMutation.error || dayUpdateMutation.error ? (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{(dayCreateMutation.error || dayUpdateMutation.error)?.message}
+								{getErrorMessage(
+									dayCreateMutation.error || dayUpdateMutation.error,
+								)}
 							</div>
-						)}
+						) : null}
 						<div className="grid gap-2">
 							<Label>
 								日目 <span className="text-error">*</span>
@@ -447,7 +450,7 @@ function EventDetailPage() {
 						</p>
 						{deleteMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{deleteMutation.error.message}
+								{getErrorMessage(deleteMutation.error)}
 							</p>
 						)}
 					</div>
@@ -476,7 +479,7 @@ function EventDetailPage() {
 						</p>
 						{dayDeleteMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{dayDeleteMutation.error.message}
+								{getErrorMessage(dayDeleteMutation.error)}
 							</p>
 						)}
 					</div>

--- a/apps/web/src/routes/admin/_admin/releases_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/releases_.$id.tsx
@@ -72,6 +72,7 @@ import {
 	trackMutations,
 } from "@/lib/mutation-options";
 import { releaseFullQueryOptions } from "@/lib/query-options";
+import { getErrorMessage } from "@/lib/utils";
 
 export const Route = createFileRoute("/admin/_admin/releases_/$id")({
 	loader: ({ context, params }) =>
@@ -1623,12 +1624,13 @@ function ReleaseDetailPage() {
 						</DialogTitle>
 					</DialogHeader>
 					<div className="grid gap-4 py-4">
-						{(discCreateMutation.error || discUpdateMutation.error) && (
+						{discCreateMutation.error || discUpdateMutation.error ? (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{discCreateMutation.error?.message ||
-									discUpdateMutation.error?.message}
+								{getErrorMessage(
+									discCreateMutation.error || discUpdateMutation.error,
+								)}
 							</div>
-						)}
+						) : null}
 						<div className="grid gap-2">
 							<Label>
 								ディスク番号 <span className="text-error">*</span>
@@ -1697,7 +1699,7 @@ function ReleaseDetailPage() {
 					<div className="grid gap-4 py-4">
 						{circleAddMutation.error && (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{circleAddMutation.error.message}
+								{getErrorMessage(circleAddMutation.error)}
 							</div>
 						)}
 						<div className="grid gap-2">
@@ -1766,12 +1768,13 @@ function ReleaseDetailPage() {
 						</DialogTitle>
 					</DialogHeader>
 					<div className="grid gap-4 py-4">
-						{(trackCreateMutation.error || trackUpdateMutation.error) && (
+						{trackCreateMutation.error || trackUpdateMutation.error ? (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{trackCreateMutation.error?.message ||
-									trackUpdateMutation.error?.message}
+								{getErrorMessage(
+									trackCreateMutation.error || trackUpdateMutation.error,
+								)}
 							</div>
-						)}
+						) : null}
 						<div className="grid gap-2">
 							<Label>
 								トラック名 <span className="text-error">*</span>
@@ -2018,12 +2021,13 @@ function ReleaseDetailPage() {
 						</DialogTitle>
 					</DialogHeader>
 					<div className="grid gap-4 py-4">
-						{(creditCreateMutation.error || creditUpdateMutation.error) && (
+						{creditCreateMutation.error || creditUpdateMutation.error ? (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{creditCreateMutation.error?.message ||
-									creditUpdateMutation.error?.message}
+								{getErrorMessage(
+									creditCreateMutation.error || creditUpdateMutation.error,
+								)}
 							</div>
-						)}
+						) : null}
 
 						<div className="grid gap-2">
 							<Label>
@@ -2168,13 +2172,15 @@ function ReleaseDetailPage() {
 						</DialogTitle>
 					</DialogHeader>
 					<div className="grid gap-4 py-4">
-						{(publicationCreateMutation.error ||
-							publicationUpdateMutation.error) && (
+						{publicationCreateMutation.error ||
+						publicationUpdateMutation.error ? (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{publicationCreateMutation.error?.message ||
-									publicationUpdateMutation.error?.message}
+								{getErrorMessage(
+									publicationCreateMutation.error ||
+										publicationUpdateMutation.error,
+								)}
 							</div>
-						)}
+						) : null}
 
 						<div className="grid gap-2">
 							<Label>
@@ -2261,12 +2267,13 @@ function ReleaseDetailPage() {
 						</DialogTitle>
 					</DialogHeader>
 					<div className="grid gap-4 py-4">
-						{(janCodeCreateMutation.error || janCodeUpdateMutation.error) && (
+						{janCodeCreateMutation.error || janCodeUpdateMutation.error ? (
 							<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-								{janCodeCreateMutation.error?.message ||
-									janCodeUpdateMutation.error?.message}
+								{getErrorMessage(
+									janCodeCreateMutation.error || janCodeUpdateMutation.error,
+								)}
 							</div>
-						)}
+						) : null}
 
 						<div className="grid gap-2">
 							<Label>
@@ -2414,7 +2421,7 @@ function ReleaseDetailPage() {
 						</p>
 						{discDeleteMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{discDeleteMutation.error.message}
+								{getErrorMessage(discDeleteMutation.error)}
 							</p>
 						)}
 					</div>
@@ -2446,7 +2453,7 @@ function ReleaseDetailPage() {
 						</p>
 						{circleRemoveMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{circleRemoveMutation.error.message}
+								{getErrorMessage(circleRemoveMutation.error)}
 							</p>
 						)}
 					</div>
@@ -2475,7 +2482,7 @@ function ReleaseDetailPage() {
 						</p>
 						{trackDeleteMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{trackDeleteMutation.error.message}
+								{getErrorMessage(trackDeleteMutation.error)}
 							</p>
 						)}
 					</div>
@@ -2504,7 +2511,7 @@ function ReleaseDetailPage() {
 						</p>
 						{creditDeleteMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{creditDeleteMutation.error.message}
+								{getErrorMessage(creditDeleteMutation.error)}
 							</p>
 						)}
 					</div>
@@ -2533,7 +2540,7 @@ function ReleaseDetailPage() {
 						</p>
 						{publicationDeleteMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{publicationDeleteMutation.error.message}
+								{getErrorMessage(publicationDeleteMutation.error)}
 							</p>
 						)}
 					</div>
@@ -2562,7 +2569,7 @@ function ReleaseDetailPage() {
 						</p>
 						{janCodeDeleteMutation.error && (
 							<p className="mt-2 text-error text-sm">
-								{janCodeDeleteMutation.error.message}
+								{getErrorMessage(janCodeDeleteMutation.error)}
 							</p>
 						)}
 					</div>

--- a/apps/web/src/routes/admin/_admin/tracks_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks_.$id.tsx
@@ -72,6 +72,7 @@ import {
 	trackPublicationMutations,
 } from "@/lib/mutation-options";
 import { trackDetailQueryOptions } from "@/lib/query-options";
+import { getErrorMessage } from "@/lib/utils";
 
 export const Route = createFileRoute("/admin/_admin/tracks_/$id")({
 	loader: ({ context, params }) =>
@@ -1621,7 +1622,7 @@ function TrackDetailPage() {
 					</div>
 					{creditCreateMutation.error && (
 						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-							{creditCreateMutation.error.message}
+							{getErrorMessage(creditCreateMutation.error)}
 						</div>
 					)}
 					<DialogFooter>
@@ -1728,11 +1729,11 @@ function TrackDetailPage() {
 							</div>
 						</div>
 					</div>
-					{creditUpdateMutation.error && (
+					{creditUpdateMutation.error ? (
 						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-							{creditUpdateMutation.error.message}
+							{getErrorMessage(creditUpdateMutation.error)}
 						</div>
-					)}
+					) : null}
 					<DialogFooter>
 						<Button variant="ghost" onClick={closeCreditEditDialog}>
 							キャンセル
@@ -1864,18 +1865,19 @@ function TrackDetailPage() {
 							/>
 						</div>
 					</div>
-					{(editingOfficialSong
-						? officialSongUpdateMutation.error
-						: officialSongCreateMutation.error) && (
+					{(
+						editingOfficialSong
+							? officialSongUpdateMutation.error
+							: officialSongCreateMutation.error
+					) ? (
 						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-							{
-								(editingOfficialSong
+							{getErrorMessage(
+								editingOfficialSong
 									? officialSongUpdateMutation.error
-									: officialSongCreateMutation.error
-								)?.message
-							}
+									: officialSongCreateMutation.error,
+							)}
 						</div>
-					)}
+					) : null}
 					<DialogFooter>
 						<Button variant="ghost" onClick={closeOfficialSongDialog}>
 							キャンセル
@@ -1950,7 +1952,7 @@ function TrackDetailPage() {
 					</div>
 					{derivationCreateMutation.error && (
 						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-							{derivationCreateMutation.error.message}
+							{getErrorMessage(derivationCreateMutation.error)}
 						</div>
 					)}
 					<DialogFooter>
@@ -2021,18 +2023,19 @@ function TrackDetailPage() {
 							/>
 						</div>
 					</div>
-					{(editingPublication
-						? publicationUpdateMutation.error
-						: publicationCreateMutation.error) && (
+					{(
+						editingPublication
+							? publicationUpdateMutation.error
+							: publicationCreateMutation.error
+					) ? (
 						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-							{
-								(editingPublication
+							{getErrorMessage(
+								editingPublication
 									? publicationUpdateMutation.error
-									: publicationCreateMutation.error
-								)?.message
-							}
+									: publicationCreateMutation.error,
+							)}
 						</div>
-					)}
+					) : null}
 					<DialogFooter>
 						<Button
 							variant="ghost"
@@ -2115,18 +2118,19 @@ function TrackDetailPage() {
 							<span>主要ISRCとして設定</span>
 						</label>
 					</div>
-					{(editingIsrc
-						? isrcUpdateMutation.error
-						: isrcCreateMutation.error) && (
+					{(
+						editingIsrc
+							? isrcUpdateMutation.error
+							: isrcCreateMutation.error
+					) ? (
 						<div className="rounded-md bg-error/10 p-3 text-error text-sm">
-							{
-								(editingIsrc
+							{getErrorMessage(
+								editingIsrc
 									? isrcUpdateMutation.error
-									: isrcCreateMutation.error
-								)?.message
-							}
+									: isrcCreateMutation.error,
+							)}
 						</div>
-					)}
+					) : null}
 					<DialogFooter>
 						<Button
 							variant="ghost"
@@ -2183,7 +2187,7 @@ function TrackDetailPage() {
 					}
 				}}
 				title="クレジットの削除"
-				description={`クレジット「${deleteCreditTarget?.creditName}」を削除しますか？この操作は取り消せません。${creditDeleteMutation.error ? `\n\nエラー: ${creditDeleteMutation.error.message}` : ""}`}
+				description={`クレジット「${deleteCreditTarget?.creditName}」を削除しますか？この操作は取り消せません。${creditDeleteMutation.error ? `\n\nエラー: ${getErrorMessage(creditDeleteMutation.error)}` : ""}`}
 				confirmLabel="削除する"
 				variant="danger"
 				onConfirm={handleCreditDelete}
@@ -2200,7 +2204,7 @@ function TrackDetailPage() {
 					}
 				}}
 				title="原曲紐付けの削除"
-				description={`原曲紐付け「${deleteOfficialSongTarget?.officialSong?.name ?? deleteOfficialSongTarget?.customSongName ?? "不明"}」を削除しますか？この操作は取り消せません。${officialSongDeleteMutation.error ? `\n\nエラー: ${officialSongDeleteMutation.error.message}` : ""}`}
+				description={`原曲紐付け「${deleteOfficialSongTarget?.officialSong?.name ?? deleteOfficialSongTarget?.customSongName ?? "不明"}」を削除しますか？この操作は取り消せません。${officialSongDeleteMutation.error ? `\n\nエラー: ${getErrorMessage(officialSongDeleteMutation.error)}` : ""}`}
 				confirmLabel="削除する"
 				variant="danger"
 				onConfirm={handleOfficialSongDelete}
@@ -2217,7 +2221,7 @@ function TrackDetailPage() {
 					}
 				}}
 				title="派生関係の削除"
-				description={`派生関係「${deleteDerivationTarget?.parentTrack?.name ?? deleteDerivationTarget?.parentTrackId}」を削除しますか？この操作は取り消せません。${derivationDeleteMutation.error ? `\n\nエラー: ${derivationDeleteMutation.error.message}` : ""}`}
+				description={`派生関係「${deleteDerivationTarget?.parentTrack?.name ?? deleteDerivationTarget?.parentTrackId}」を削除しますか？この操作は取り消せません。${derivationDeleteMutation.error ? `\n\nエラー: ${getErrorMessage(derivationDeleteMutation.error)}` : ""}`}
 				confirmLabel="削除する"
 				variant="danger"
 				onConfirm={handleDerivationDelete}
@@ -2234,7 +2238,7 @@ function TrackDetailPage() {
 					}
 				}}
 				title="公開リンクの削除"
-				description={`公開リンク「${deletePublicationTarget?.url}」を削除しますか？この操作は取り消せません。${publicationDeleteMutation.error ? `\n\nエラー: ${publicationDeleteMutation.error.message}` : ""}`}
+				description={`公開リンク「${deletePublicationTarget?.url}」を削除しますか？この操作は取り消せません。${publicationDeleteMutation.error ? `\n\nエラー: ${getErrorMessage(publicationDeleteMutation.error)}` : ""}`}
 				confirmLabel="削除する"
 				variant="danger"
 				onConfirm={handlePublicationDelete}
@@ -2251,7 +2255,7 @@ function TrackDetailPage() {
 					}
 				}}
 				title="ISRCの削除"
-				description={`ISRC「${deleteIsrcTarget?.isrc}」を削除しますか？この操作は取り消せません。${isrcDeleteMutation.error ? `\n\nエラー: ${isrcDeleteMutation.error.message}` : ""}`}
+				description={`ISRC「${deleteIsrcTarget?.isrc}」を削除しますか？この操作は取り消せません。${isrcDeleteMutation.error ? `\n\nエラー: ${getErrorMessage(isrcDeleteMutation.error)}` : ""}`}
 				confirmLabel="削除する"
 				variant="danger"
 				onConfirm={handleIsrcDelete}


### PR DESCRIPTION
## 概要

TanStack QueryのuseMutationでOptimistic updatesを実装し、更新操作時の即座のUI反映を実現。

## 変更内容

* 全22種類のエンティティのupdateに`onMutate`/`onError`/`onSettled`コールバックを追加
* `onMutate`: 楽観的にキャッシュを更新（APIレスポンスを待たずにUI更新）
* `onError`: エラー時にキャッシュをロールバック（ConflictErrorは除外）
* `onSettled`: 成功・失敗に関わらずサーバーと同期
* `getErrorMessage(error: unknown)`ヘルパー関数を追加して型安全なエラーハンドリングを実現

### 対象エンティティ

| カテゴリ | エンティティ |
|---------|-------------|
| シンプル | Artist, Circle, Event, EventSeries, OfficialWork, OfficialSong |
| マスターデータ | Platform, AliasType, CreditRole, OfficialWorkCategory |
| ネスト | ArtistAlias, CircleLink, EventDay, Disc |
| 複合 | Release, Track |
| リレーション | ReleaseCircle, ReleasePublication, ReleaseJanCode, TrackCredit, TrackOfficialSong, TrackPublication, TrackIsrc |

## 影響範囲

* 管理画面の全編集操作でUIの応答性が向上
* エラー時は自動的に元の状態にロールバック

## 補足事項

* 271件のテスト全てパス
* ConflictError（楽観的ロック競合）の場合はロールバックせず、既存のConflictDialogで処理

closes #162