### PR TITLE
fix: 統計ページでサークル未紐付けリリースが表示エラーになる問題を修正

### DIFF
--- a/apps/server/src/routes/public/stats.ts
+++ b/apps/server/src/routes/public/stats.ts
@@ -225,8 +225,8 @@ statsRouter.get("/recent-updates", async (c) => {
 			data: recentReleasesResult.map((row) => ({
 				id: row.id,
 				title: row.title,
-				circleName: row.circleName,
-				circleId: row.circleId,
+				circleName: row.circleName ?? null,
+				circleId: row.circleId ?? null,
 				date: row.updatedAt?.toISOString() ?? null,
 				type:
 					row.createdAt?.getTime() === row.updatedAt?.getTime()

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -60,9 +60,9 @@ export interface PublicStatsRankings {
 export interface RecentUpdateItem {
 	id: string;
 	title: string;
-	circleName: string;
-	circleId: string;
-	date: string;
+	circleName: string | null;
+	circleId: string | null;
+	date: string | null;
 	type: "new" | "update";
 }
 

--- a/apps/web/src/routes/_public/stats.tsx
+++ b/apps/web/src/routes/_public/stats.tsx
@@ -326,14 +326,18 @@ function RecentUpdatesSection() {
 									</Link>
 								</td>
 								<td className="px-5 py-4">
-									<Link
-										to="/circles/$id"
-										params={{ id: update.circleId }}
-										preload="intent"
-										className="text-base-content/60 hover:text-primary"
-									>
-										{update.circleName}
-									</Link>
+									{update.circleId && update.circleName ? (
+										<Link
+											to="/circles/$id"
+											params={{ id: update.circleId }}
+											preload="intent"
+											className="text-base-content/60 hover:text-primary"
+										>
+											{update.circleName}
+										</Link>
+									) : (
+										<span className="text-base-content/40">-</span>
+									)}
 								</td>
 								<td className="px-5 py-4 text-base-content/60">
 									{update.date}


### PR DESCRIPTION
## 概要

統計ページでサークル未紐付けリリースが表示エラーになる問題を修正

## 問題の原因

サークル未紐付けリリース（circleName/circleIdがnull）の場合、`Cannot read properties of undefined (reading 'toString')`エラーが発生していた。
- API側で`circleName`/`circleId`が`undefined`として返されていた
- UI側でnullチェックなしで直接リンクを表示しようとしていた

## 変更内容

* API側（`apps/server/src/routes/public/stats.ts`）で`circleName`/`circleId`が`undefined`の場合に明示的に`null`を返すように変更
* 型定義（`apps/web/src/lib/public-api.ts`）を`string | null`に変更
* UI側（`apps/web/src/routes/_public/stats.tsx`）でnullチェックを追加し、未紐付け時は「-」を表示

## 影響範囲

- 統計ページの「最近の更新」セクション