### PR TITLE
fix: Renovate lockfileワークフローの無限ループを修正

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -14,10 +14,11 @@ permissions:
 
 jobs:
   update-lockfile:
-    # Renovate PRのみ対象
+    # Renovate PRのみ対象、github-actions[bot]がトリガーした場合はスキップ（無限ループ防止）
     if: |
       startsWith(github.head_ref, 'renovate/') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     env:
       HEAD_REF: ${{ github.head_ref }}
@@ -26,30 +27,15 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 2
-
-      - name: Check if last commit is from github-actions[bot]
-        id: check-author
-        run: |
-          LAST_AUTHOR=$(git log -1 --format='%an')
-          echo "Last commit author: $LAST_AUTHOR"
-          if [ "$LAST_AUTHOR" = "github-actions[bot]" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
 
       - uses: oven-sh/setup-bun@v2
-        if: steps.check-author.outputs.skip != 'true'
         with:
           bun-version: "1.3.6"
 
       - name: Update lockfile
-        if: steps.check-author.outputs.skip != 'true'
         run: bun install --no-frozen-lockfile
 
       - name: Commit and push changes
-        if: steps.check-author.outputs.skip != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## 概要

Renovate PRでlockfile更新ワークフローが無限ループする問題を修正。

## 問題の原因

- `git log -1`でコミット作者をチェックしていたが、checkout時点ではgithub-actions[bot]のコミットがまだ存在しない
- そのため、github-actions[bot]がプッシュした後もワークフローが再実行されていた

## 変更内容

* `github.actor != 'github-actions[bot]'` をジョブ条件に追加
* ワークフローをトリガーしたアクターが`github-actions[bot]`ならジョブ全体をスキップ
* 冗長だったcheck-authorステップを削除

## 動作フロー

```
renovate[bot]がプッシュ → github.actor=renovate[bot] → ワークフロー実行
  ↓
github-actions[bot]がbun.lockをプッシュ → github.actor=github-actions[bot] → ジョブスキップ ✅
```