### PR TITLE
fix(deps): 依存パッケージをアップデート

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,7 +36,7 @@
 		"react-dom": "19.2.3",
 		"tailwindcss": "^4.1.18",
 		"tw-animate-css": "^1.4.0",
-		"vite-tsconfig-paths": "^5.1.4",
+		"vite-tsconfig-paths": "^6.0.4",
 		"zod": "catalog:"
 	},
 	"devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
         "react-dom": "19.2.3",
         "tailwindcss": "^4.1.18",
         "tw-animate-css": "^1.4.0",
-        "vite-tsconfig-paths": "^5.1.4",
+        "vite-tsconfig-paths": "^6.0.4",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -1463,7 +1463,7 @@
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
-    "vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
+    "vite-tsconfig-paths": ["vite-tsconfig-paths@6.0.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3", "vite": "*" } }, "sha512-iIsEJ+ek5KqRTK17pmxtgIxXtqr3qDdE6OxrP9mVeGhVDNXRJTKN/l9oMbujTQNzMLe6XZ8qmpztfbkPu2TiFQ=="],
 
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 


### PR DESCRIPTION
## 概要

apps/web の依存パッケージを最新バージョンにアップデート

## 変更内容

* jsdom を v26.0.0 から v27.4.0 にアップデート（メジャー）
* vite-tsconfig-paths を v5.1.4 から v6.0.4 にアップデート（メジャー）

## 影響範囲

- テスト環境（jsdom）
- ビルド設定（vite-tsconfig-paths）

## 補足事項

### jsdom v27 の主な変更点
- Node.js v20.19.0+ が必要
- CSS セレクターエンジンが `nwsapi` から `@asamuzakjp/dom-selector` に変更
- `element.click()` が `PointerEvent` を発火するように

### vite-tsconfig-paths v6 の主な変更点
- 内部リファクタリングによるメジャーバージョンアップ（破壊的変更なし）
- 遅延プロジェクト検出機能の追加
- ファイル監視の強化