### PR TITLE
feat: SSRレスポンスにキャッシュヘッダーを追加

### DIFF
--- a/apps/web/src/lib/cache-headers.ts
+++ b/apps/web/src/lib/cache-headers.ts
@@ -1,0 +1,29 @@
+/**
+ * SSRレスポンスのキャッシュヘッダー設定
+ *
+ * TanStack Startのheadersプロパティで使用するキャッシュ設定を一元管理
+ */
+export const CACHE_HEADERS = {
+	/**
+	 * 公開詳細ページ用
+	 * - max-age: 5分（300秒）
+	 * - stale-while-revalidate: 10分（600秒）
+	 */
+	PUBLIC_DETAIL: {
+		"Cache-Control": "public, max-age=300, stale-while-revalidate=600",
+	},
+	/**
+	 * 静的ページ用（about, privacy, stats）
+	 * - max-age: 1時間（3600秒）
+	 * - stale-while-revalidate: 24時間（86400秒）
+	 */
+	PUBLIC_STATIC: {
+		"Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+	},
+	/**
+	 * 管理画面用（キャッシュ無効化）
+	 */
+	PRIVATE: {
+		"Cache-Control": "private, no-cache",
+	},
+} as const;

--- a/apps/web/src/routes/_public/about.tsx
+++ b/apps/web/src/routes/_public/about.tsx
@@ -1,10 +1,12 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ExternalLink, Github, Music } from "lucide-react";
 import { PublicBreadcrumb } from "@/components/public";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/_public/about")({
 	head: () => createPageHead("About"),
+	headers: () => CACHE_HEADERS.PUBLIC_STATIC,
 	component: AboutPage,
 });
 

--- a/apps/web/src/routes/_public/artists_.$id.tsx
+++ b/apps/web/src/routes/_public/artists_.$id.tsx
@@ -10,6 +10,7 @@ import {
 	WorkStatsSection,
 	WorkStatsSkeleton,
 } from "@/components/public";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 import {
 	type ArtistDetailTab,
 	parseArtistDetailTab,
@@ -51,6 +52,7 @@ export const Route = createFileRoute("/_public/artists_/$id")({
 		}
 	},
 	head: ({ loaderData }) => createPublicArtistHead(loaderData?.artist),
+	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	component: ArtistDetailPage,
 });
 

--- a/apps/web/src/routes/_public/circles_.$id.tsx
+++ b/apps/web/src/routes/_public/circles_.$id.tsx
@@ -12,6 +12,7 @@ import {
 	WorkStatsSection,
 	WorkStatsSkeleton,
 } from "@/components/public";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 import {
 	type CircleDetailTab,
 	parseCircleDetailTab,
@@ -57,6 +58,7 @@ export const Route = createFileRoute("/_public/circles_/$id")({
 		}
 	},
 	head: ({ loaderData }) => createPublicCircleHead(loaderData?.circle),
+	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	component: CircleDetailPage,
 });
 

--- a/apps/web/src/routes/_public/events_.$id.tsx
+++ b/apps/web/src/routes/_public/events_.$id.tsx
@@ -12,6 +12,7 @@ import {
 	WorkStatsSection,
 	WorkStatsSkeleton,
 } from "@/components/public";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 import {
 	type EventDetailTab,
 	parseEventDetailTab,
@@ -53,6 +54,7 @@ export const Route = createFileRoute("/_public/events_/$id")({
 		}
 	},
 	head: ({ loaderData }) => createPublicEventHead(loaderData?.event),
+	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	component: EventDetailPage,
 });
 

--- a/apps/web/src/routes/_public/official-works_.$id.tsx
+++ b/apps/web/src/routes/_public/official-works_.$id.tsx
@@ -9,6 +9,7 @@ import {
 	TrendingUp,
 } from "lucide-react";
 import { ExternalLink, PublicBreadcrumb } from "@/components/public";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { formatNumber } from "@/lib/format";
 import { createPublicOfficialWorkHead } from "@/lib/head";
 import { type PublicWorkDetail, publicApi } from "@/lib/public-api";
@@ -23,6 +24,7 @@ export const Route = createFileRoute("/_public/official-works_/$id")({
 		}
 	},
 	head: ({ loaderData }) => createPublicOfficialWorkHead(loaderData?.work),
+	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	component: OfficialWorkDetailPage,
 });
 

--- a/apps/web/src/routes/_public/original-songs_.$id.tsx
+++ b/apps/web/src/routes/_public/original-songs_.$id.tsx
@@ -11,6 +11,7 @@ import {
 	Users,
 } from "lucide-react";
 import { ExternalLink, PublicBreadcrumb } from "@/components/public";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { formatNumber } from "@/lib/format";
 import { createPublicOriginalSongHead } from "@/lib/head";
 import {
@@ -32,6 +33,7 @@ export const Route = createFileRoute("/_public/original-songs_/$id")({
 		}
 	},
 	head: ({ loaderData }) => createPublicOriginalSongHead(loaderData?.song),
+	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	component: OriginalSongDetailPage,
 });
 

--- a/apps/web/src/routes/_public/privacy.tsx
+++ b/apps/web/src/routes/_public/privacy.tsx
@@ -1,10 +1,12 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Shield } from "lucide-react";
 import { PublicBreadcrumb } from "@/components/public";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/_public/privacy")({
 	head: () => createPageHead("プライバシーポリシー"),
+	headers: () => CACHE_HEADERS.PUBLIC_STATIC,
 	component: PrivacyPage,
 });
 

--- a/apps/web/src/routes/_public/releases_.$id.tsx
+++ b/apps/web/src/routes/_public/releases_.$id.tsx
@@ -6,6 +6,7 @@ import {
 	PublicationLinks,
 	PublicBreadcrumb,
 } from "@/components/public";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPublicReleaseHead } from "@/lib/head";
 import { type PublicReleaseDetail, publicApi } from "@/lib/public-api";
 
@@ -55,6 +56,7 @@ export const Route = createFileRoute("/_public/releases_/$id")({
 		}
 	},
 	head: ({ loaderData }) => createPublicReleaseHead(loaderData?.release),
+	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	component: ReleaseDetailPage,
 });
 

--- a/apps/web/src/routes/_public/stats.tsx
+++ b/apps/web/src/routes/_public/stats.tsx
@@ -19,6 +19,7 @@ import {
 	RankingsSkeleton,
 	RecentUpdatesSkeleton,
 } from "@/components/public/stats-skeleton";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { formatNumber } from "@/lib/format";
 import { createPageHead } from "@/lib/head";
 import { publicApi } from "@/lib/public-api";
@@ -29,6 +30,7 @@ import {
 
 export const Route = createFileRoute("/_public/stats")({
 	head: () => createPageHead("統計"),
+	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	loader: async ({ context }) => {
 		// 基本統計を await（ブロッキング）
 		const stats = await publicApi.stats();

--- a/apps/web/src/routes/_public/tracks_.$id.tsx
+++ b/apps/web/src/routes/_public/tracks_.$id.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useMemo } from "react";
 import { PublicationLinks, PublicBreadcrumb } from "@/components/public";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPublicTrackHead } from "@/lib/head";
 import { type PublicTrackDetail, publicApi } from "@/lib/public-api";
 
@@ -39,6 +40,7 @@ export const Route = createFileRoute("/_public/tracks_/$id")({
 		}
 	},
 	head: ({ loaderData }) => createPublicTrackHead(loaderData?.track),
+	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	component: TrackDetailPage,
 });
 

--- a/apps/web/src/routes/admin/_admin.tsx
+++ b/apps/web/src/routes/admin/_admin.tsx
@@ -3,8 +3,10 @@ import { AdminErrorBoundary } from "@/components/admin-error-boundary";
 import { AdminLayout } from "@/components/admin-layout";
 import ForbiddenPage from "@/components/forbidden-page";
 import { getAdminUser } from "@/functions/get-admin-user";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
 
 export const Route = createFileRoute("/admin/_admin")({
+	headers: () => CACHE_HEADERS.PRIVATE,
 	beforeLoad: async () => {
 		try {
 			// サーバー関数経由でセッション確認（Cookie転送を含む）

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "lefthook": "^2.0.15",
         "turbo": "^2.7.4",
         "typescript": "catalog:",
-        "web": "workspace:*",
+        "web": "^0.0.2",
       },
     },
     "apps/server": {


### PR DESCRIPTION
## 概要

TanStack Startの`headers`プロパティを使用してSSRレスポンスにキャッシュヘッダーを追加し、CDN/ブラウザキャッシュを有効化する。

## 変更内容

* キャッシュヘッダー定数ファイル（`cache-headers.ts`）を新規作成
* 公開詳細ページ（8ファイル）に`PUBLIC_DETAIL`ヘッダーを追加
  - artists, circles, events, original-songs, releases, tracks, official-works, stats
  - `Cache-Control: public, max-age=300, stale-while-revalidate=600`
* 静的ページ（2ファイル）に`PUBLIC_STATIC`ヘッダーを追加
  - about, privacy
  - `Cache-Control: public, max-age=3600, stale-while-revalidate=86400`
* 管理画面レイアウトに`PRIVATE`ヘッダーを追加
  - `Cache-Control: private, no-cache`

## 影響範囲

* 公開ページのレスポンスにCache-Controlヘッダーが付与される
* CDN配置時にキャッシュが有効化され、パフォーマンスが向上する

## 補足事項

* 一覧ページはクライアントサイドフェッチのため対象外
* 管理画面はセキュリティのためキャッシュ無効化

Closes #177