### PR TITLE
feat: 管理ダッシュボードをミニマルデザインに刷新

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"@libsql/client": "catalog:",
 		"@nivo/bar": "^0.99.0",
+		"date-fns": "^4.1.0",
 		"@nivo/core": "^0.99.0",
 		"@tailwindcss/vite": "^4.1.18",
 		"@tanstack/react-form": "^1.27.7",

--- a/apps/web/src/routes/admin/_admin/index.tsx
+++ b/apps/web/src/routes/admin/_admin/index.tsx
@@ -32,17 +32,17 @@ interface StatCardProps {
 
 function StatCard({ title, value, icon, href, isLoading }: StatCardProps) {
 	const content = (
-		<div className="card-body">
-			<div className="flex items-center justify-between">
-				<div className="text-base-content/60">{icon}</div>
-				<div className="text-right">
-					{isLoading ? (
-						<div className="skeleton h-8 w-16" />
-					) : (
-						<div className="font-bold text-3xl">{value?.toLocaleString()}</div>
-					)}
-					<div className="text-base-content/60 text-sm">{title}</div>
-				</div>
+		<div className="flex items-center gap-3 p-3">
+			<div className="text-base-content/50">{icon}</div>
+			<div>
+				{isLoading ? (
+					<div className="skeleton h-6 w-12" />
+				) : (
+					<div className="font-bold text-2xl leading-tight">
+						{value?.toLocaleString()}
+					</div>
+				)}
+				<div className="text-base-content/60 text-xs">{title}</div>
 			</div>
 		</div>
 	);
@@ -51,7 +51,7 @@ function StatCard({ title, value, icon, href, isLoading }: StatCardProps) {
 		return (
 			<Link
 				to={href}
-				className="card border border-base-300 bg-base-100 shadow-sm transition-shadow hover:shadow-md"
+				className="rounded-lg border border-base-300 bg-base-100 transition-colors hover:bg-base-200"
 			>
 				{content}
 			</Link>
@@ -59,7 +59,7 @@ function StatCard({ title, value, icon, href, isLoading }: StatCardProps) {
 	}
 
 	return (
-		<div className="card border border-base-300 bg-base-100 shadow-sm">
+		<div className="rounded-lg border border-base-300 bg-base-100">
 			{content}
 		</div>
 	);
@@ -76,13 +76,13 @@ function AdminDashboard() {
 		{
 			title: "公式作品",
 			value: data?.officialWorks,
-			icon: <Disc className="h-8 w-8" />,
+			icon: <Disc className="h-5 w-5" />,
 			href: "/admin/official/works" as const,
 		},
 		{
 			title: "公式楽曲",
 			value: data?.officialSongs,
-			icon: <Music className="h-8 w-8" />,
+			icon: <Music className="h-5 w-5" />,
 			href: "/admin/official/songs" as const,
 		},
 	];
@@ -91,19 +91,19 @@ function AdminDashboard() {
 		{
 			title: "アーティスト",
 			value: data?.artists,
-			icon: <UserPen className="h-8 w-8" />,
+			icon: <UserPen className="h-5 w-5" />,
 			href: "/admin/artists" as const,
 		},
 		{
 			title: "アーティスト名義",
 			value: data?.artistAliases,
-			icon: <Users className="h-8 w-8" />,
+			icon: <Users className="h-5 w-5" />,
 			href: "/admin/artist-aliases" as const,
 		},
 		{
 			title: "サークル",
 			value: data?.circles,
-			icon: <CircleUser className="h-8 w-8" />,
+			icon: <CircleUser className="h-5 w-5" />,
 			href: "/admin/circles" as const,
 		},
 	];
@@ -112,13 +112,13 @@ function AdminDashboard() {
 		{
 			title: "イベントシリーズ",
 			value: data?.eventSeries,
-			icon: <Layers className="h-8 w-8" />,
+			icon: <Layers className="h-5 w-5" />,
 			href: "/admin/event-series" as const,
 		},
 		{
 			title: "イベント",
 			value: data?.events,
-			icon: <Calendar className="h-8 w-8" />,
+			icon: <Calendar className="h-5 w-5" />,
 			href: "/admin/events" as const,
 		},
 	];
@@ -127,13 +127,13 @@ function AdminDashboard() {
 		{
 			title: "作品",
 			value: data?.releases,
-			icon: <Disc3 className="h-8 w-8" />,
+			icon: <Disc3 className="h-5 w-5" />,
 			href: "/admin/releases" as const,
 		},
 		{
 			title: "トラック",
 			value: data?.tracks,
-			icon: <Music className="h-8 w-8" />,
+			icon: <Music className="h-5 w-5" />,
 			href: "/admin/tracks" as const,
 		},
 	];
@@ -142,31 +142,31 @@ function AdminDashboard() {
 		{
 			title: "プラットフォーム",
 			value: data?.platforms,
-			icon: <MonitorSmartphone className="h-8 w-8" />,
+			icon: <MonitorSmartphone className="h-5 w-5" />,
 			href: "/admin/master/platforms" as const,
 		},
 		{
 			title: "名義種別",
 			value: data?.aliasTypes,
-			icon: <Users className="h-8 w-8" />,
+			icon: <Users className="h-5 w-5" />,
 			href: "/admin/master/alias-types" as const,
 		},
 		{
 			title: "クレジット役割",
 			value: data?.creditRoles,
-			icon: <UserCog className="h-8 w-8" />,
+			icon: <UserCog className="h-5 w-5" />,
 			href: "/admin/master/credit-roles" as const,
 		},
 		{
 			title: "公式作品カテゴリ",
 			value: data?.officialWorkCategories,
-			icon: <FolderOpen className="h-8 w-8" />,
+			icon: <FolderOpen className="h-5 w-5" />,
 			href: "/admin/master/official-work-categories" as const,
 		},
 	];
 
 	return (
-		<div className="container mx-auto space-y-6 p-6">
+		<div className="container mx-auto space-y-4 p-4">
 			{/* パンくずナビゲーション */}
 			<nav className="breadcrumbs text-sm">
 				<ul>
@@ -180,17 +180,19 @@ function AdminDashboard() {
 			</nav>
 
 			{/* ヘッダー */}
-			<h1 className="font-bold text-2xl">ダッシュボード</h1>
+			<h1 className="font-bold text-xl">ダッシュボード</h1>
 
-			<div className="space-y-6">
+			<div className="space-y-4">
 				{/* ユーザー */}
 				<section>
-					<h2 className="mb-3 font-semibold text-lg">ユーザー</h2>
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+					<h2 className="mb-2 font-medium text-base text-base-content/80">
+						ユーザー
+					</h2>
+					<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
 						<StatCard
 							title="ユーザー"
 							value={data?.users}
-							icon={<Users className="h-8 w-8" />}
+							icon={<Users className="h-5 w-5" />}
 							isLoading={isLoading}
 						/>
 					</div>
@@ -198,8 +200,10 @@ function AdminDashboard() {
 
 				{/* マスタ管理 */}
 				<section>
-					<h2 className="mb-3 font-semibold text-lg">マスタ管理</h2>
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+					<h2 className="mb-2 font-medium text-base text-base-content/80">
+						マスタ管理
+					</h2>
+					<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
 						{masterStats.map((stat) => (
 							<StatCard
 								key={stat.title}
@@ -215,8 +219,10 @@ function AdminDashboard() {
 
 				{/* 公式管理 */}
 				<section>
-					<h2 className="mb-3 font-semibold text-lg">公式管理</h2>
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+					<h2 className="mb-2 font-medium text-base text-base-content/80">
+						公式管理
+					</h2>
+					<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
 						{officialStats.map((stat) => (
 							<StatCard
 								key={stat.title}
@@ -232,8 +238,10 @@ function AdminDashboard() {
 
 				{/* アーティスト・サークル */}
 				<section>
-					<h2 className="mb-3 font-semibold text-lg">アーティスト・サークル</h2>
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+					<h2 className="mb-2 font-medium text-base text-base-content/80">
+						アーティスト・サークル
+					</h2>
+					<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
 						{artistCircleStats.map((stat) => (
 							<StatCard
 								key={stat.title}
@@ -249,8 +257,10 @@ function AdminDashboard() {
 
 				{/* イベント管理 */}
 				<section>
-					<h2 className="mb-3 font-semibold text-lg">イベント管理</h2>
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+					<h2 className="mb-2 font-medium text-base text-base-content/80">
+						イベント管理
+					</h2>
+					<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
 						{eventStats.map((stat) => (
 							<StatCard
 								key={stat.title}
@@ -266,8 +276,10 @@ function AdminDashboard() {
 
 				{/* 作品管理 */}
 				<section>
-					<h2 className="mb-3 font-semibold text-lg">作品管理</h2>
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+					<h2 className="mb-2 font-medium text-base text-base-content/80">
+						作品管理
+					</h2>
+					<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
 						{releaseStats.map((stat) => (
 							<StatCard
 								key={stat.title}

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "lefthook": "^2.0.15",
         "turbo": "^2.7.4",
         "typescript": "catalog:",
-        "web": "^0.0.2",
+        "web": "workspace:*",
       },
     },
     "apps/server": {
@@ -65,6 +65,7 @@
         "better-auth": "catalog:",
         "clsx": "^2.1.1",
         "daisyui": "^5.5.14",
+        "date-fns": "^4.1.0",
         "dotenv": "catalog:",
         "libsql": "catalog:",
         "lucide-react": "^0.562.0",


### PR DESCRIPTION
## 概要

管理ダッシュボード（`/admin`）をミニマル・コンパクトなデザインに刷新

## 変更内容

### StatCardのリデザイン
- `card-body` → `flex items-center gap-3 p-3` でコンパクト化
- アイコンサイズ: `h-8 w-8` → `h-5 w-5`
- 数値フォント: `text-3xl` → `text-2xl leading-tight`
- ラベルフォント: `text-sm` → `text-xs`
- シャドウ削除、ボーダーのみに変更
- hover効果: `hover:shadow-md` → `hover:bg-base-200`

### グリッドレイアウト調整
- Before: `grid-cols-1 sm:grid-cols-2 lg:grid-cols-4`
- After: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6`

### セクション構成の改善
- 全体余白: `p-6` → `p-4`
- セクション間: `space-y-6` → `space-y-4`
- カード間: `gap-4` → `gap-3`
- セクションタイトル: `text-lg font-semibold` → `text-base font-medium text-base-content/80`

### 依存関係
- `date-fns@4.1.0` をwebアプリの依存関係に追加（型エラー解消）

## 影響範囲

- `/admin` ダッシュボードページのみ

## 補足事項

デザイン方針:
- ミニマル・データドリブン管理ツール
- ボーダーで区切り、シャドウは控えめ
- 4px基準のコンパクトなスペーシング