### PR TITLE
fix: 管理画面のデザインシステム違反を修正

### DIFF
--- a/apps/web/src/components/admin/conflict-dialog.tsx
+++ b/apps/web/src/components/admin/conflict-dialog.tsx
@@ -68,7 +68,7 @@ function ConflictDialog<T>({
 				<DialogHeader>
 					<div className="flex items-center gap-3">
 						<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-warning/10">
-							<AlertTriangle className="h-5 w-5 text-warning" />
+							<AlertTriangle className="h-4 w-4 text-warning" />
 						</div>
 						<DialogTitle>編集の競合が発生しました</DialogTitle>
 					</div>

--- a/apps/web/src/components/admin/official-links-card.tsx
+++ b/apps/web/src/components/admin/official-links-card.tsx
@@ -173,7 +173,7 @@ export function OfficialLinksCard({
 			<Card className="card-bordered">
 				<div className="flex items-center justify-between border-base-300 border-b p-4">
 					<h3 className="flex items-center gap-2 font-semibold text-lg">
-						<ExternalLink className="h-5 w-5" />
+						<ExternalLink className="h-4 w-4" />
 						外部リンク
 					</h3>
 				</div>
@@ -192,7 +192,7 @@ export function OfficialLinksCard({
 			<Card className="card-bordered">
 				<div className="flex items-center justify-between border-base-300 border-b p-4">
 					<h3 className="flex items-center gap-2 font-semibold text-lg">
-						<ExternalLink className="h-5 w-5" />
+						<ExternalLink className="h-4 w-4" />
 						外部リンク
 					</h3>
 					<Button variant="outline" size="sm" onClick={openCreateDialog}>

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -202,7 +202,7 @@ function DropdownMenuItem({
 			tabIndex={disabled ? -1 : 0}
 			onClick={handleClick}
 			className={cn(
-				"flex cursor-pointer items-center rounded-lg px-3 py-2 text-sm hover:bg-base-200 focus:bg-base-200 focus:outline-none",
+				"flex cursor-pointer items-center rounded-box px-3 py-2 text-sm hover:bg-base-200 focus:bg-base-200 focus:outline-none",
 				inset && "pl-8",
 				disabled && "cursor-not-allowed opacity-50",
 				className,

--- a/apps/web/src/components/ui/searchable-select.tsx
+++ b/apps/web/src/components/ui/searchable-select.tsx
@@ -114,7 +114,7 @@ export function SearchableSelect({
 
 			{/* ドロップダウン */}
 			{isOpen && (
-				<div className="absolute z-50 mt-1 max-h-80 w-full overflow-hidden rounded-lg border border-base-300 bg-base-100 shadow-lg">
+				<div className="absolute z-50 mt-1 max-h-80 w-full overflow-hidden rounded-box border border-base-300 bg-base-100 shadow-lg">
 					{/* 検索欄 */}
 					<div className="border-base-300 border-b p-2">
 						<div className="relative">

--- a/apps/web/src/routes/admin/_admin/artist-aliases.tsx
+++ b/apps/web/src/routes/admin/_admin/artist-aliases.tsx
@@ -279,7 +279,7 @@ function ArtistAliasesPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">アーティスト名義管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="名義名で検索..."

--- a/apps/web/src/routes/admin/_admin/artist-aliases_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/artist-aliases_.$id.tsx
@@ -199,11 +199,11 @@ function ArtistAliasDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">名義名</Label>
+							<Label className="text-base-content/70">名義名</Label>
 							<p className="font-medium">{alias.name}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">アーティスト</Label>
+							<Label className="text-base-content/70">アーティスト</Label>
 							<p>
 								{alias.artistName ? (
 									<Link
@@ -219,7 +219,7 @@ function ArtistAliasDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">名義種別</Label>
+							<Label className="text-base-content/70">名義種別</Label>
 							<p>
 								{alias.aliasTypeCode ? (
 									<Badge
@@ -234,7 +234,7 @@ function ArtistAliasDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">文字種</Label>
+							<Label className="text-base-content/70">文字種</Label>
 							<p>
 								<Badge
 									variant={INITIAL_SCRIPT_BADGE_VARIANTS[alias.initialScript]}
@@ -244,11 +244,11 @@ function ArtistAliasDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">頭文字</Label>
+							<Label className="text-base-content/70">頭文字</Label>
 							<p className="font-mono">{alias.nameInitial || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">使用期間</Label>
+							<Label className="text-base-content/70">使用期間</Label>
 							<p>
 								{alias.periodFrom || alias.periodTo
 									? `${alias.periodFrom || "?"} 〜 ${alias.periodTo || "現在"}`
@@ -269,33 +269,33 @@ function ArtistAliasDetailPage() {
 							<span className="loading loading-spinner loading-md" />
 						</div>
 					) : !tracksData ? (
-						<p className="text-base-content/60">統計情報を取得できません</p>
+						<p className="text-base-content/70">統計情報を取得できません</p>
 					) : (
 						<div className="space-y-4">
 							{/* 基本統計 */}
 							<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
 								<div className="rounded-lg bg-base-200/50 p-4">
-									<Label className="text-base-content/60">参加トラック数</Label>
+									<Label className="text-base-content/70">参加トラック数</Label>
 									<p className="font-bold text-2xl">
 										{tracksData.totalUniqueTrackCount}
-										<span className="font-normal text-base-content/60 text-sm">
+										<span className="font-normal text-base-content/70 text-sm">
 											{" "}
 											曲
 										</span>
 									</p>
 								</div>
 								<div className="rounded-lg bg-base-200/50 p-4">
-									<Label className="text-base-content/60">参加リリース数</Label>
+									<Label className="text-base-content/70">参加リリース数</Label>
 									<p className="font-bold text-2xl">
 										{tracksData.statistics.releaseCount}
-										<span className="font-normal text-base-content/60 text-sm">
+										<span className="font-normal text-base-content/70 text-sm">
 											{" "}
 											作品
 										</span>
 									</p>
 								</div>
 								<div className="rounded-lg bg-base-200/50 p-4">
-									<Label className="text-base-content/60">活動期間</Label>
+									<Label className="text-base-content/70">活動期間</Label>
 									<p className="font-medium">
 										{tracksData.statistics.earliestReleaseDate &&
 										tracksData.statistics.latestReleaseDate
@@ -333,7 +333,7 @@ function ArtistAliasDetailPage() {
 			<div className="card bg-base-100 shadow-xl">
 				<div className="card-body">
 					<div className="flex items-center gap-2">
-						<Users className="h-5 w-5" />
+						<Users className="h-4 w-4" />
 						<h2 className="card-title">参加サークル</h2>
 						{circlesData && circlesData.length > 0 && (
 							<Badge variant="secondary">{circlesData.length}件</Badge>
@@ -345,7 +345,7 @@ function ArtistAliasDetailPage() {
 							<span className="loading loading-spinner loading-md" />
 						</div>
 					) : !circlesData || circlesData.length === 0 ? (
-						<p className="text-base-content/60">参加サークルがありません</p>
+						<p className="text-base-content/70">参加サークルがありません</p>
 					) : (
 						<div className="overflow-x-auto">
 							<Table zebra>
@@ -397,7 +397,7 @@ function ArtistAliasDetailPage() {
 			<div className="card bg-base-100 shadow-xl">
 				<div className="card-body">
 					<div className="flex items-center gap-2">
-						<Music className="h-5 w-5" />
+						<Music className="h-4 w-4" />
 						<h2 className="card-title">関連楽曲</h2>
 						{tracksData && (
 							<Badge variant="secondary">
@@ -411,7 +411,7 @@ function ArtistAliasDetailPage() {
 							<span className="loading loading-spinner loading-md" />
 						</div>
 					) : !tracksData || tracksData.totalUniqueTrackCount === 0 ? (
-						<p className="text-base-content/60">関連する楽曲がありません</p>
+						<p className="text-base-content/70">関連する楽曲がありません</p>
 					) : (
 						<div className="space-y-4">
 							<div className="overflow-x-auto">
@@ -458,7 +458,7 @@ function ArtistAliasDetailPage() {
 															{track.name}
 														</Link>
 														{track.nameJa && track.nameJa !== track.name && (
-															<span className="ml-2 text-base-content/60 text-sm">
+															<span className="ml-2 text-base-content/70 text-sm">
 																({track.nameJa})
 															</span>
 														)}
@@ -478,7 +478,7 @@ function ArtistAliasDetailPage() {
 							{/* ページネーション */}
 							{tracksData.tracks.length > tracksPageSize && (
 								<div className="flex items-center justify-between">
-									<p className="text-base-content/60 text-sm">
+									<p className="text-base-content/70 text-sm">
 										全{tracksData.tracks.length}件中{" "}
 										{(tracksPage - 1) * tracksPageSize + 1}〜
 										{Math.min(

--- a/apps/web/src/routes/admin/_admin/artists.tsx
+++ b/apps/web/src/routes/admin/_admin/artists.tsx
@@ -235,7 +235,7 @@ function ArtistsPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">アーティスト管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="名前で検索..."

--- a/apps/web/src/routes/admin/_admin/artists_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/artists_.$id.tsx
@@ -230,23 +230,23 @@ function ArtistDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">名前</Label>
+							<Label className="text-base-content/70">名前</Label>
 							<p className="font-medium">{artist.name}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">日本語名</Label>
+							<Label className="text-base-content/70">日本語名</Label>
 							<p>{artist.nameJa || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">英語名</Label>
+							<Label className="text-base-content/70">英語名</Label>
 							<p>{artist.nameEn || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">ソート用名</Label>
+							<Label className="text-base-content/70">ソート用名</Label>
 							<p>{artist.sortName || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">文字種</Label>
+							<Label className="text-base-content/70">文字種</Label>
 							<p>
 								<Badge
 									variant={INITIAL_SCRIPT_BADGE_VARIANTS[artist.initialScript]}
@@ -256,11 +256,11 @@ function ArtistDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">頭文字</Label>
+							<Label className="text-base-content/70">頭文字</Label>
 							<p className="font-mono">{artist.nameInitial || "-"}</p>
 						</div>
 						<div className="md:col-span-2">
-							<Label className="text-base-content/60">備考</Label>
+							<Label className="text-base-content/70">備考</Label>
 							<p className="whitespace-pre-wrap">{artist.notes || "-"}</p>
 						</div>
 					</div>
@@ -284,7 +284,7 @@ function ArtistDetailPage() {
 					</div>
 
 					{artist.aliases.length === 0 ? (
-						<p className="text-base-content/60">別名義が登録されていません</p>
+						<p className="text-base-content/70">別名義が登録されていません</p>
 					) : (
 						<div className="overflow-x-auto">
 							<Table zebra>
@@ -362,33 +362,33 @@ function ArtistDetailPage() {
 							<span className="loading loading-spinner loading-md" />
 						</div>
 					) : !tracksData ? (
-						<p className="text-base-content/60">統計情報を取得できません</p>
+						<p className="text-base-content/70">統計情報を取得できません</p>
 					) : (
 						<div className="space-y-4">
 							{/* 基本統計 */}
 							<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
 								<div className="rounded-lg bg-base-200/50 p-4">
-									<Label className="text-base-content/60">参加トラック数</Label>
+									<Label className="text-base-content/70">参加トラック数</Label>
 									<p className="font-bold text-2xl">
 										{tracksData.totalUniqueTrackCount}
-										<span className="font-normal text-base-content/60 text-sm">
+										<span className="font-normal text-base-content/70 text-sm">
 											{" "}
 											曲
 										</span>
 									</p>
 								</div>
 								<div className="rounded-lg bg-base-200/50 p-4">
-									<Label className="text-base-content/60">参加リリース数</Label>
+									<Label className="text-base-content/70">参加リリース数</Label>
 									<p className="font-bold text-2xl">
 										{tracksData.statistics.releaseCount}
-										<span className="font-normal text-base-content/60 text-sm">
+										<span className="font-normal text-base-content/70 text-sm">
 											{" "}
 											作品
 										</span>
 									</p>
 								</div>
 								<div className="rounded-lg bg-base-200/50 p-4">
-									<Label className="text-base-content/60">活動期間</Label>
+									<Label className="text-base-content/70">活動期間</Label>
 									<p className="font-medium">
 										{tracksData.statistics.earliestReleaseDate &&
 										tracksData.statistics.latestReleaseDate
@@ -426,7 +426,7 @@ function ArtistDetailPage() {
 			<div className="card bg-base-100 shadow-xl">
 				<div className="card-body">
 					<div className="flex items-center gap-2">
-						<Users className="h-5 w-5" />
+						<Users className="h-4 w-4" />
 						<h2 className="card-title">参加サークル</h2>
 						{circlesData && circlesData.length > 0 && (
 							<Badge variant="secondary">{circlesData.length}件</Badge>
@@ -438,7 +438,7 @@ function ArtistDetailPage() {
 							<span className="loading loading-spinner loading-md" />
 						</div>
 					) : !circlesData || circlesData.length === 0 ? (
-						<p className="text-base-content/60">参加サークルがありません</p>
+						<p className="text-base-content/70">参加サークルがありません</p>
 					) : (
 						<div className="overflow-x-auto">
 							<Table zebra>
@@ -490,7 +490,7 @@ function ArtistDetailPage() {
 			<div className="card bg-base-100 shadow-xl">
 				<div className="card-body">
 					<div className="flex items-center gap-2">
-						<Music className="h-5 w-5" />
+						<Music className="h-4 w-4" />
 						<h2 className="card-title">関連楽曲</h2>
 						{tracksData && (
 							<Badge variant="secondary">
@@ -504,7 +504,7 @@ function ArtistDetailPage() {
 							<span className="loading loading-spinner loading-md" />
 						</div>
 					) : !tracksData || tracksData.totalUniqueTrackCount === 0 ? (
-						<p className="text-base-content/60">関連する楽曲がありません</p>
+						<p className="text-base-content/70">関連する楽曲がありません</p>
 					) : (
 						<div className="space-y-4">
 							<div className="overflow-x-auto">
@@ -551,7 +551,7 @@ function ArtistDetailPage() {
 															{track.name}
 														</Link>
 														{track.nameJa && track.nameJa !== track.name && (
-															<span className="ml-2 text-base-content/60 text-sm">
+															<span className="ml-2 text-base-content/70 text-sm">
 																({track.nameJa})
 															</span>
 														)}
@@ -571,7 +571,7 @@ function ArtistDetailPage() {
 							{/* ページネーション */}
 							{tracksData.tracks.length > tracksPageSize && (
 								<div className="flex items-center justify-between">
-									<p className="text-base-content/60 text-sm">
+									<p className="text-base-content/70 text-sm">
 										全{tracksData.tracks.length}件中{" "}
 										{(tracksPage - 1) * tracksPageSize + 1}〜
 										{Math.min(

--- a/apps/web/src/routes/admin/_admin/circles.tsx
+++ b/apps/web/src/routes/admin/_admin/circles.tsx
@@ -464,7 +464,7 @@ function CirclesPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">サークル管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="名前で検索..."

--- a/apps/web/src/routes/admin/_admin/circles_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/circles_.$id.tsx
@@ -315,23 +315,23 @@ function CircleDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">名前</Label>
+							<Label className="text-base-content/70">名前</Label>
 							<p className="font-medium">{circle.name}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">日本語名</Label>
+							<Label className="text-base-content/70">日本語名</Label>
 							<p>{circle.nameJa || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">英語名</Label>
+							<Label className="text-base-content/70">英語名</Label>
 							<p>{circle.nameEn || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">ソート用名</Label>
+							<Label className="text-base-content/70">ソート用名</Label>
 							<p>{circle.sortName || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">文字種</Label>
+							<Label className="text-base-content/70">文字種</Label>
 							<p>
 								<Badge
 									variant={INITIAL_SCRIPT_BADGE_VARIANTS[circle.initialScript]}
@@ -341,11 +341,11 @@ function CircleDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">頭文字</Label>
+							<Label className="text-base-content/70">頭文字</Label>
 							<p className="font-mono">{circle.nameInitial || "-"}</p>
 						</div>
 						<div className="md:col-span-2">
-							<Label className="text-base-content/60">備考</Label>
+							<Label className="text-base-content/70">備考</Label>
 							<p className="whitespace-pre-wrap">{circle.notes || "-"}</p>
 						</div>
 					</div>
@@ -357,7 +357,7 @@ function CircleDetailPage() {
 				<div className="card-body">
 					<div className="flex items-center justify-between">
 						<h2 className="card-title">
-							<ExternalLink className="h-5 w-5" />
+							<ExternalLink className="h-4 w-4" />
 							外部リンク一覧
 						</h2>
 						<Button
@@ -371,7 +371,7 @@ function CircleDetailPage() {
 					</div>
 
 					{circle.links.length === 0 ? (
-						<p className="text-base-content/60">
+						<p className="text-base-content/70">
 							外部リンクが登録されていません
 						</p>
 					) : (
@@ -453,7 +453,7 @@ function CircleDetailPage() {
 			<div className="card bg-base-100 shadow-xl">
 				<div className="card-body">
 					<div className="flex items-center gap-2">
-						<BarChart3 className="h-5 w-5" />
+						<BarChart3 className="h-4 w-4" />
 						<h2 className="card-title">統計情報</h2>
 					</div>
 
@@ -462,43 +462,43 @@ function CircleDetailPage() {
 							<span className="loading loading-spinner loading-md" />
 						</div>
 					) : !artistsData ? (
-						<p className="text-base-content/60">統計情報を取得できません</p>
+						<p className="text-base-content/70">統計情報を取得できません</p>
 					) : (
 						<div className="grid grid-cols-1 gap-4 md:grid-cols-4">
 							<div className="rounded-lg bg-base-200/50 p-4">
-								<Label className="text-base-content/60">参加作品数</Label>
+								<Label className="text-base-content/70">参加作品数</Label>
 								<p className="font-bold text-2xl">
 									{artistsData.statistics.releaseCount}
-									<span className="font-normal text-base-content/60 text-sm">
+									<span className="font-normal text-base-content/70 text-sm">
 										{" "}
 										作品
 									</span>
 								</p>
 							</div>
 							<div className="rounded-lg bg-base-200/50 p-4">
-								<Label className="text-base-content/60">トラック総数</Label>
+								<Label className="text-base-content/70">トラック総数</Label>
 								<p className="font-bold text-2xl">
 									{artistsData.statistics.totalTrackCount}
-									<span className="font-normal text-base-content/60 text-sm">
+									<span className="font-normal text-base-content/70 text-sm">
 										{" "}
 										曲
 									</span>
 								</p>
 							</div>
 							<div className="rounded-lg bg-base-200/50 p-4">
-								<Label className="text-base-content/60">
+								<Label className="text-base-content/70">
 									参加アーティスト数
 								</Label>
 								<p className="font-bold text-2xl">
 									{artistsData.statistics.totalArtistCount}
-									<span className="font-normal text-base-content/60 text-sm">
+									<span className="font-normal text-base-content/70 text-sm">
 										{" "}
 										名
 									</span>
 								</p>
 							</div>
 							<div className="rounded-lg bg-base-200/50 p-4">
-								<Label className="text-base-content/60">活動期間</Label>
+								<Label className="text-base-content/70">活動期間</Label>
 								<p className="font-medium">
 									{artistsData.statistics.earliestReleaseDate &&
 									artistsData.statistics.latestReleaseDate
@@ -517,7 +517,7 @@ function CircleDetailPage() {
 			<div className="card bg-base-100 shadow-xl">
 				<div className="card-body">
 					<div className="flex items-center gap-2">
-						<Users className="h-5 w-5" />
+						<Users className="h-4 w-4" />
 						<h2 className="card-title">参加アーティスト</h2>
 						{artistsData && artistsData.artists.length > 0 && (
 							<Badge variant="secondary">{artistsData.artists.length}名</Badge>
@@ -529,7 +529,7 @@ function CircleDetailPage() {
 							<span className="loading loading-spinner loading-md" />
 						</div>
 					) : !artistsData || artistsData.artists.length === 0 ? (
-						<p className="text-base-content/60">参加アーティストがいません</p>
+						<p className="text-base-content/70">参加アーティストがいません</p>
 					) : (
 						<div className="space-y-4">
 							<div className="overflow-x-auto">
@@ -591,7 +591,7 @@ function CircleDetailPage() {
 									>
 										前へ
 									</Button>
-									<span className="text-base-content/60 text-sm">
+									<span className="text-base-content/70 text-sm">
 										{artistsPage} /{" "}
 										{Math.ceil(artistsData.artists.length / artistsPageSize)}
 									</span>
@@ -619,7 +619,7 @@ function CircleDetailPage() {
 					<h2 className="card-title">参加作品一覧</h2>
 
 					{!releasesByType || releasesByType.length === 0 ? (
-						<p className="text-base-content/60">参加作品が登録されていません</p>
+						<p className="text-base-content/70">参加作品が登録されていません</p>
 					) : (
 						<div className="space-y-6">
 							{releasesByType.map((group) => (
@@ -632,7 +632,7 @@ function CircleDetailPage() {
 										>
 											{PARTICIPATION_TYPE_LABELS[group.participationType]}
 										</Badge>
-										<span className="text-base-content/60 text-sm">
+										<span className="text-base-content/70 text-sm">
 											({group.releases.length}件)
 										</span>
 									</div>

--- a/apps/web/src/routes/admin/_admin/event-series.tsx
+++ b/apps/web/src/routes/admin/_admin/event-series.tsx
@@ -179,7 +179,7 @@ function EventSeriesPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">イベントシリーズ管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="シリーズ名で検索..."

--- a/apps/web/src/routes/admin/_admin/event-series_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/event-series_.$id.tsx
@@ -177,11 +177,11 @@ function EventSeriesDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">名前</Label>
+							<Label className="text-base-content/70">名前</Label>
 							<p className="font-medium">{series.name}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">表示順序</Label>
+							<Label className="text-base-content/70">表示順序</Label>
 							<p>{series.sortOrder ?? "-"}</p>
 						</div>
 					</div>
@@ -194,7 +194,7 @@ function EventSeriesDetailPage() {
 					<h2 className="card-title">所属イベント一覧</h2>
 
 					{sortedEvents.length === 0 ? (
-						<p className="text-base-content/60">イベントが登録されていません</p>
+						<p className="text-base-content/70">イベントが登録されていません</p>
 					) : (
 						<div className="overflow-x-auto">
 							<Table zebra>

--- a/apps/web/src/routes/admin/_admin/events.tsx
+++ b/apps/web/src/routes/admin/_admin/events.tsx
@@ -404,7 +404,7 @@ function EventsPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">イベント管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="イベント名で検索..."

--- a/apps/web/src/routes/admin/_admin/events_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/events_.$id.tsx
@@ -225,11 +225,11 @@ function EventDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">名前</Label>
+							<Label className="text-base-content/70">名前</Label>
 							<p className="font-medium">{event.name}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">イベントシリーズ</Label>
+							<Label className="text-base-content/70">イベントシリーズ</Label>
 							<p>
 								{event.eventSeriesId && event.seriesName ? (
 									<Link
@@ -245,15 +245,15 @@ function EventDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">回次</Label>
+							<Label className="text-base-content/70">回次</Label>
 							<p>{event.edition != null ? `第${event.edition}回` : "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">開催日数</Label>
+							<Label className="text-base-content/70">開催日数</Label>
 							<p>{event.totalDays != null ? `${event.totalDays}日間` : "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">開始日</Label>
+							<Label className="text-base-content/70">開始日</Label>
 							<p>
 								{event.startDate
 									? format(new Date(event.startDate), "yyyy年M月d日", {
@@ -263,7 +263,7 @@ function EventDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">終了日</Label>
+							<Label className="text-base-content/70">終了日</Label>
 							<p>
 								{event.endDate
 									? format(new Date(event.endDate), "yyyy年M月d日", {
@@ -273,7 +273,7 @@ function EventDetailPage() {
 							</p>
 						</div>
 						<div className="md:col-span-2">
-							<Label className="text-base-content/60">会場</Label>
+							<Label className="text-base-content/70">会場</Label>
 							<p>{event.venue || "-"}</p>
 						</div>
 					</div>
@@ -285,7 +285,7 @@ function EventDetailPage() {
 				<div className="card-body">
 					<div className="flex items-center justify-between">
 						<h2 className="card-title">
-							<Calendar className="h-5 w-5" />
+							<Calendar className="h-4 w-4" />
 							開催日一覧
 						</h2>
 						<Button variant="outline" size="sm" onClick={() => openDayDialog()}>
@@ -295,7 +295,7 @@ function EventDetailPage() {
 					</div>
 
 					{sortedDays.length === 0 ? (
-						<p className="text-base-content/60">開催日が登録されていません</p>
+						<p className="text-base-content/70">開催日が登録されていません</p>
 					) : (
 						<div className="overflow-x-auto">
 							<Table zebra>

--- a/apps/web/src/routes/admin/_admin/import-legacy.tsx
+++ b/apps/web/src/routes/admin/_admin/import-legacy.tsx
@@ -294,7 +294,7 @@ function LegacyImportPage() {
 
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">レガシーCSVインポート</h1>
-			<p className="text-base-content/60">
+			<p className="text-base-content/70">
 				旧システムのCSVデータをインポートします
 			</p>
 
@@ -464,7 +464,7 @@ function UploadStep({ onUpload, isLoading, errors }: UploadStepProps) {
 		<div className="space-y-6">
 			<div className="text-center">
 				<h3 className="font-semibold text-lg">CSVファイルをアップロード</h3>
-				<p className="text-base-content/60 text-sm">
+				<p className="text-base-content/70 text-sm">
 					旧システムからエクスポートしたCSVファイルをドラッグ&ドロップまたは選択してください
 				</p>
 			</div>
@@ -491,7 +491,7 @@ function UploadStep({ onUpload, isLoading, errors }: UploadStepProps) {
 				) : (
 					<>
 						<FileUp className="mx-auto h-12 w-12 text-base-content/40" />
-						<p className="mt-4 text-base-content/60">
+						<p className="mt-4 text-base-content/70">
 							ここにCSVファイルをドロップ
 						</p>
 						<p className="text-base-content/40 text-sm">または</p>
@@ -512,7 +512,7 @@ function UploadStep({ onUpload, isLoading, errors }: UploadStepProps) {
 			{/* エラー表示 */}
 			{errors.length > 0 && (
 				<div className="alert alert-error">
-					<AlertCircle className="h-5 w-5" />
+					<AlertCircle className="h-4 w-4" />
 					<div>
 						<h4 className="font-semibold">パースエラー</h4>
 						<ul className="list-disc pl-4 text-sm">
@@ -623,7 +623,7 @@ function MappingStep({
 		<div className="space-y-6">
 			<div className="text-center">
 				<h3 className="font-semibold text-lg">原曲マッピング</h3>
-				<p className="text-base-content/60 text-sm">
+				<p className="text-base-content/70 text-sm">
 					CSVの原曲名を公式楽曲データベースにマッピングしてください
 				</p>
 			</div>
@@ -774,7 +774,7 @@ function EventRegistrationStep({
 				<div className="space-y-4">
 					<div className="text-center">
 						<h3 className="font-semibold text-lg">イベント日の選択</h3>
-						<p className="text-base-content/60 text-sm">
+						<p className="text-base-content/70 text-sm">
 							以下のイベントは複数日開催されています。リリースを紐付ける日を選択してください
 						</p>
 					</div>
@@ -798,7 +798,7 @@ function EventRegistrationStep({
 										<span>
 											{day.dayNumber}日目
 											{day.eventDate && (
-												<span className="ml-1 text-base-content/60 text-sm">
+												<span className="ml-1 text-base-content/70 text-sm">
 													({day.eventDate})
 												</span>
 											)}
@@ -816,7 +816,7 @@ function EventRegistrationStep({
 				<div className="space-y-4">
 					<div className="text-center">
 						<h3 className="font-semibold text-lg">新規イベント登録</h3>
-						<p className="text-base-content/60 text-sm">
+						<p className="text-base-content/70 text-sm">
 							以下のイベントはデータベースに存在しないため、情報を入力してください
 						</p>
 					</div>
@@ -891,7 +891,7 @@ function EventInputCard({ event, input, onChange }: EventInputCardProps) {
 		<div className="card border border-base-300 bg-base-100">
 			<div className="card-body">
 				<div className="flex items-center gap-2">
-					<Calendar className="h-5 w-5 text-primary" />
+					<Calendar className="h-4 w-4 text-primary" />
 					<h4 className="card-title text-lg">{event.name}</h4>
 					{event.edition && (
 						<span className="badge badge-primary">第{event.edition}回</span>
@@ -1013,39 +1013,39 @@ function ImportingStep({
 	> = {
 		preparing: {
 			label: "準備中",
-			icon: <Loader2 className="h-5 w-5 animate-spin" />,
+			icon: <Loader2 className="h-4 w-4 animate-spin" />,
 		},
 		events: {
 			label: "イベント",
-			icon: <Calendar className="h-5 w-5" />,
+			icon: <Calendar className="h-4 w-4" />,
 		},
 		circles: {
 			label: "サークル",
-			icon: <CheckCircle className="h-5 w-5" />,
+			icon: <CheckCircle className="h-4 w-4" />,
 		},
 		artists: {
 			label: "アーティスト",
-			icon: <CheckCircle className="h-5 w-5" />,
+			icon: <CheckCircle className="h-4 w-4" />,
 		},
 		releases: {
 			label: "作品",
-			icon: <CheckCircle className="h-5 w-5" />,
+			icon: <CheckCircle className="h-4 w-4" />,
 		},
 		tracks: {
 			label: "トラック",
-			icon: <Music className="h-5 w-5" />,
+			icon: <Music className="h-4 w-4" />,
 		},
 		credits: {
 			label: "クレジット",
-			icon: <CheckCircle className="h-5 w-5" />,
+			icon: <CheckCircle className="h-4 w-4" />,
 		},
 		links: {
 			label: "原曲紐付け",
-			icon: <CheckCircle className="h-5 w-5" />,
+			icon: <CheckCircle className="h-4 w-4" />,
 		},
 		complete: {
 			label: "完了",
-			icon: <CheckCircle className="h-5 w-5 text-success" />,
+			icon: <CheckCircle className="h-4 w-4 text-success" />,
 		},
 	};
 
@@ -1102,7 +1102,7 @@ function ImportingStep({
 				<h3 className="mt-4 font-semibold text-lg">
 					{isComplete ? "インポート完了" : "インポート実行中"}
 				</h3>
-				<p className="text-base-content/60 text-sm">
+				<p className="text-base-content/70 text-sm">
 					{isComplete
 						? "結果画面に移動します..."
 						: "データベースにレコードを登録しています。しばらくお待ちください..."}
@@ -1291,7 +1291,7 @@ function ResultStep({ result, onReset }: ResultStepProps) {
 			{/* エラー詳細 */}
 			{result.errors.length > 0 && (
 				<div className="alert alert-warning">
-					<AlertCircle className="h-5 w-5" />
+					<AlertCircle className="h-4 w-4" />
 					<div>
 						<h4 className="font-semibold">警告</h4>
 						<ul className="list-disc pl-4 text-sm">

--- a/apps/web/src/routes/admin/_admin/index.tsx
+++ b/apps/web/src/routes/admin/_admin/index.tsx
@@ -42,7 +42,7 @@ function StatCard({ title, value, icon, href, isLoading }: StatCardProps) {
 						{value?.toLocaleString()}
 					</div>
 				)}
-				<div className="text-base-content/60 text-xs">{title}</div>
+				<div className="text-base-content/70 text-xs">{title}</div>
 			</div>
 		</div>
 	);
@@ -76,13 +76,13 @@ function AdminDashboard() {
 		{
 			title: "公式作品",
 			value: data?.officialWorks,
-			icon: <Disc className="h-5 w-5" />,
+			icon: <Disc className="h-4 w-4" />,
 			href: "/admin/official/works" as const,
 		},
 		{
 			title: "公式楽曲",
 			value: data?.officialSongs,
-			icon: <Music className="h-5 w-5" />,
+			icon: <Music className="h-4 w-4" />,
 			href: "/admin/official/songs" as const,
 		},
 	];
@@ -91,19 +91,19 @@ function AdminDashboard() {
 		{
 			title: "アーティスト",
 			value: data?.artists,
-			icon: <UserPen className="h-5 w-5" />,
+			icon: <UserPen className="h-4 w-4" />,
 			href: "/admin/artists" as const,
 		},
 		{
 			title: "アーティスト名義",
 			value: data?.artistAliases,
-			icon: <Users className="h-5 w-5" />,
+			icon: <Users className="h-4 w-4" />,
 			href: "/admin/artist-aliases" as const,
 		},
 		{
 			title: "サークル",
 			value: data?.circles,
-			icon: <CircleUser className="h-5 w-5" />,
+			icon: <CircleUser className="h-4 w-4" />,
 			href: "/admin/circles" as const,
 		},
 	];
@@ -112,13 +112,13 @@ function AdminDashboard() {
 		{
 			title: "イベントシリーズ",
 			value: data?.eventSeries,
-			icon: <Layers className="h-5 w-5" />,
+			icon: <Layers className="h-4 w-4" />,
 			href: "/admin/event-series" as const,
 		},
 		{
 			title: "イベント",
 			value: data?.events,
-			icon: <Calendar className="h-5 w-5" />,
+			icon: <Calendar className="h-4 w-4" />,
 			href: "/admin/events" as const,
 		},
 	];
@@ -127,13 +127,13 @@ function AdminDashboard() {
 		{
 			title: "作品",
 			value: data?.releases,
-			icon: <Disc3 className="h-5 w-5" />,
+			icon: <Disc3 className="h-4 w-4" />,
 			href: "/admin/releases" as const,
 		},
 		{
 			title: "トラック",
 			value: data?.tracks,
-			icon: <Music className="h-5 w-5" />,
+			icon: <Music className="h-4 w-4" />,
 			href: "/admin/tracks" as const,
 		},
 	];
@@ -142,25 +142,25 @@ function AdminDashboard() {
 		{
 			title: "プラットフォーム",
 			value: data?.platforms,
-			icon: <MonitorSmartphone className="h-5 w-5" />,
+			icon: <MonitorSmartphone className="h-4 w-4" />,
 			href: "/admin/master/platforms" as const,
 		},
 		{
 			title: "名義種別",
 			value: data?.aliasTypes,
-			icon: <Users className="h-5 w-5" />,
+			icon: <Users className="h-4 w-4" />,
 			href: "/admin/master/alias-types" as const,
 		},
 		{
 			title: "クレジット役割",
 			value: data?.creditRoles,
-			icon: <UserCog className="h-5 w-5" />,
+			icon: <UserCog className="h-4 w-4" />,
 			href: "/admin/master/credit-roles" as const,
 		},
 		{
 			title: "公式作品カテゴリ",
 			value: data?.officialWorkCategories,
-			icon: <FolderOpen className="h-5 w-5" />,
+			icon: <FolderOpen className="h-4 w-4" />,
 			href: "/admin/master/official-work-categories" as const,
 		},
 	];
@@ -192,7 +192,7 @@ function AdminDashboard() {
 						<StatCard
 							title="ユーザー"
 							value={data?.users}
-							icon={<Users className="h-5 w-5" />}
+							icon={<Users className="h-4 w-4" />}
 							isLoading={isLoading}
 						/>
 					</div>

--- a/apps/web/src/routes/admin/_admin/master/alias-types.tsx
+++ b/apps/web/src/routes/admin/_admin/master/alias-types.tsx
@@ -212,7 +212,7 @@ function AliasTypesPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">名義種別管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="ラベルまたはコードで検索..."

--- a/apps/web/src/routes/admin/_admin/master/alias-types_.$code.tsx
+++ b/apps/web/src/routes/admin/_admin/master/alias-types_.$code.tsx
@@ -123,19 +123,19 @@ function AliasTypeDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">コード</Label>
+							<Label className="text-base-content/70">コード</Label>
 							<p className="font-mono">{aliasType.code}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">ラベル</Label>
+							<Label className="text-base-content/70">ラベル</Label>
 							<p className="font-medium">{aliasType.label}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">表示順序</Label>
+							<Label className="text-base-content/70">表示順序</Label>
 							<p>{aliasType.sortOrder ?? "-"}</p>
 						</div>
 						<div className="md:col-span-2">
-							<Label className="text-base-content/60">説明</Label>
+							<Label className="text-base-content/70">説明</Label>
 							<p>{aliasType.description || "-"}</p>
 						</div>
 					</div>

--- a/apps/web/src/routes/admin/_admin/master/credit-roles.tsx
+++ b/apps/web/src/routes/admin/_admin/master/credit-roles.tsx
@@ -215,7 +215,7 @@ function CreditRolesPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">クレジット役割管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="ラベルまたはコードで検索..."

--- a/apps/web/src/routes/admin/_admin/master/credit-roles_.$code.tsx
+++ b/apps/web/src/routes/admin/_admin/master/credit-roles_.$code.tsx
@@ -121,19 +121,19 @@ function CreditRoleDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">コード</Label>
+							<Label className="text-base-content/70">コード</Label>
 							<p className="font-mono">{creditRole.code}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">ラベル</Label>
+							<Label className="text-base-content/70">ラベル</Label>
 							<p className="font-medium">{creditRole.label}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">表示順序</Label>
+							<Label className="text-base-content/70">表示順序</Label>
 							<p>{creditRole.sortOrder ?? "-"}</p>
 						</div>
 						<div className="md:col-span-2">
-							<Label className="text-base-content/60">説明</Label>
+							<Label className="text-base-content/70">説明</Label>
 							<p>{creditRole.description || "-"}</p>
 						</div>
 					</div>

--- a/apps/web/src/routes/admin/_admin/master/official-work-categories.tsx
+++ b/apps/web/src/routes/admin/_admin/master/official-work-categories.tsx
@@ -230,7 +230,7 @@ function OfficialWorkCategoriesPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">公式作品カテゴリ管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="名前またはコードで検索..."

--- a/apps/web/src/routes/admin/_admin/master/official-work-categories_.$code.tsx
+++ b/apps/web/src/routes/admin/_admin/master/official-work-categories_.$code.tsx
@@ -134,19 +134,19 @@ function OfficialWorkCategoryDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">コード</Label>
+							<Label className="text-base-content/70">コード</Label>
 							<p className="font-mono">{category.code}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">名前</Label>
+							<Label className="text-base-content/70">名前</Label>
 							<p className="font-medium">{category.name}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">表示順序</Label>
+							<Label className="text-base-content/70">表示順序</Label>
 							<p>{category.sortOrder ?? "-"}</p>
 						</div>
 						<div className="md:col-span-2">
-							<Label className="text-base-content/60">説明</Label>
+							<Label className="text-base-content/70">説明</Label>
 							<p>{category.description || "-"}</p>
 						</div>
 					</div>

--- a/apps/web/src/routes/admin/_admin/master/platforms.tsx
+++ b/apps/web/src/routes/admin/_admin/master/platforms.tsx
@@ -243,7 +243,7 @@ function PlatformsPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">プラットフォーム管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="名前またはコードで検索..."

--- a/apps/web/src/routes/admin/_admin/master/platforms_.$code.tsx
+++ b/apps/web/src/routes/admin/_admin/master/platforms_.$code.tsx
@@ -131,23 +131,23 @@ function PlatformDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">コード</Label>
+							<Label className="text-base-content/70">コード</Label>
 							<p className="font-mono">{platform.code}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">名前</Label>
+							<Label className="text-base-content/70">名前</Label>
 							<p className="font-medium">{platform.name}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">カテゴリ</Label>
+							<Label className="text-base-content/70">カテゴリ</Label>
 							<p>{platform.category || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">表示順序</Label>
+							<Label className="text-base-content/70">表示順序</Label>
 							<p>{platform.sortOrder ?? "-"}</p>
 						</div>
 						<div className="md:col-span-2">
-							<Label className="text-base-content/60">URLパターン</Label>
+							<Label className="text-base-content/70">URLパターン</Label>
 							<p className="font-mono text-sm">{platform.urlPattern || "-"}</p>
 						</div>
 					</div>

--- a/apps/web/src/routes/admin/_admin/official/songs.tsx
+++ b/apps/web/src/routes/admin/_admin/official/songs.tsx
@@ -249,7 +249,7 @@ function OfficialSongsPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">公式楽曲管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="楽曲名で検索..."

--- a/apps/web/src/routes/admin/_admin/official/songs_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/official/songs_.$id.tsx
@@ -108,11 +108,11 @@ function OfficialSongDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">ID</Label>
+							<Label className="text-base-content/70">ID</Label>
 							<p className="font-mono text-sm">{song.id}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">作品</Label>
+							<Label className="text-base-content/70">作品</Label>
 							<p>
 								{song.workName && song.officialWorkId ? (
 									<Link
@@ -128,31 +128,31 @@ function OfficialSongDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">トラック番号</Label>
+							<Label className="text-base-content/70">トラック番号</Label>
 							<p>{song.trackNumber ?? "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">名前</Label>
+							<Label className="text-base-content/70">名前</Label>
 							<p>{song.name}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">日本語名</Label>
+							<Label className="text-base-content/70">日本語名</Label>
 							<p>{song.nameJa || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">英語名</Label>
+							<Label className="text-base-content/70">英語名</Label>
 							<p>{song.nameEn || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">作曲者名</Label>
+							<Label className="text-base-content/70">作曲者名</Label>
 							<p>{song.composerName || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">編曲者名</Label>
+							<Label className="text-base-content/70">編曲者名</Label>
 							<p>{song.arrangerName || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">オリジナル</Label>
+							<Label className="text-base-content/70">オリジナル</Label>
 							<p>
 								{song.isOriginal ? (
 									<Badge variant="outline">はい</Badge>
@@ -163,7 +163,7 @@ function OfficialSongDetailPage() {
 						</div>
 						{!song.isOriginal && (
 							<div>
-								<Label className="text-base-content/60">原曲</Label>
+								<Label className="text-base-content/70">原曲</Label>
 								<p>
 									{song.sourceSongId ? (
 										<Link
@@ -180,11 +180,11 @@ function OfficialSongDetailPage() {
 							</div>
 						)}
 						<div className="md:col-span-2">
-							<Label className="text-base-content/60">備考</Label>
+							<Label className="text-base-content/70">備考</Label>
 							<p className="whitespace-pre-wrap">{song.notes || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">作成日時</Label>
+							<Label className="text-base-content/70">作成日時</Label>
 							<p>
 								{format(new Date(song.createdAt), "yyyy年M月d日 HH:mm:ss", {
 									locale: ja,
@@ -192,7 +192,7 @@ function OfficialSongDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">更新日時</Label>
+							<Label className="text-base-content/70">更新日時</Label>
 							<p>
 								{format(new Date(song.updatedAt), "yyyy年M月d日 HH:mm:ss", {
 									locale: ja,

--- a/apps/web/src/routes/admin/_admin/official/works.tsx
+++ b/apps/web/src/routes/admin/_admin/official/works.tsx
@@ -227,7 +227,7 @@ function OfficialWorksPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">公式作品管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="作品名で検索..."

--- a/apps/web/src/routes/admin/_admin/official/works_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/official/works_.$id.tsx
@@ -138,31 +138,31 @@ function OfficialWorkDetailPage() {
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">ID</Label>
+							<Label className="text-base-content/70">ID</Label>
 							<p className="font-mono text-sm">{work.id}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">名前</Label>
+							<Label className="text-base-content/70">名前</Label>
 							<p>{work.name}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">日本語名</Label>
+							<Label className="text-base-content/70">日本語名</Label>
 							<p>{work.nameJa || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">英語名</Label>
+							<Label className="text-base-content/70">英語名</Label>
 							<p>{work.nameEn || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">短縮名</Label>
+							<Label className="text-base-content/70">短縮名</Label>
 							<p>{work.shortNameJa || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">短縮名（英語）</Label>
+							<Label className="text-base-content/70">短縮名（英語）</Label>
 							<p>{work.shortNameEn || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">カテゴリ</Label>
+							<Label className="text-base-content/70">カテゴリ</Label>
 							<p>
 								{work.categoryCode ? (
 									<Badge variant={getCategoryColor(work.categoryCode)}>
@@ -174,11 +174,11 @@ function OfficialWorkDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">シリーズ番号</Label>
+							<Label className="text-base-content/70">シリーズ番号</Label>
 							<p>{work.numberInSeries ?? "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">発売日</Label>
+							<Label className="text-base-content/70">発売日</Label>
 							<p>
 								{work.releaseDate
 									? format(new Date(work.releaseDate), "yyyy年M月d日", {
@@ -188,15 +188,15 @@ function OfficialWorkDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">発行元</Label>
+							<Label className="text-base-content/70">発行元</Label>
 							<p>{work.officialOrganization || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">表示順</Label>
+							<Label className="text-base-content/70">表示順</Label>
 							<p>{work.position ?? "-"}</p>
 						</div>
 						<div className="md:col-span-2">
-							<Label className="text-base-content/60">備考</Label>
+							<Label className="text-base-content/70">備考</Label>
 							<p className="whitespace-pre-wrap">{work.notes || "-"}</p>
 						</div>
 					</div>
@@ -211,14 +211,14 @@ function OfficialWorkDetailPage() {
 				<div className="card-body">
 					<div className="flex items-center justify-between">
 						<h2 className="card-title">
-							<Music className="h-5 w-5" />
+							<Music className="h-4 w-4" />
 							関連楽曲
 							<Badge variant="ghost">{songs.length}曲</Badge>
 						</h2>
 					</div>
 
 					{songs.length === 0 ? (
-						<p className="text-base-content/60">楽曲が登録されていません</p>
+						<p className="text-base-content/70">楽曲が登録されていません</p>
 					) : (
 						<div className="overflow-x-auto">
 							<table className="table">

--- a/apps/web/src/routes/admin/_admin/releases.tsx
+++ b/apps/web/src/routes/admin/_admin/releases.tsx
@@ -392,7 +392,7 @@ function ReleasesPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">作品管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="作品名で検索..."
@@ -754,7 +754,7 @@ function ReleasesPage() {
 							<Label htmlFor="create-name">
 								作品名 <span className="text-error">*</span>
 							</Label>
-							<p className="text-base-content/60 text-xs">
+							<p className="text-base-content/70 text-xs">
 								アルバム名、シングル名、EP名などを入力してください
 							</p>
 							<Input

--- a/apps/web/src/routes/admin/_admin/releases_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/releases_.$id.tsx
@@ -972,25 +972,25 @@ function ReleaseDetailPage() {
 			</div>
 
 			{/* 基本情報カード */}
-			<div className="card bg-base-100 shadow-xl">
+			<div className="card bg-base-100">
 				<div className="card-body">
 					<h2 className="card-title">基本情報</h2>
 
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<div>
-							<Label className="text-base-content/60">作品名</Label>
+							<Label className="text-base-content/70">作品名</Label>
 							<p>{release.name}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">日本語名</Label>
+							<Label className="text-base-content/70">日本語名</Label>
 							<p>{release.nameJa || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">英語名</Label>
+							<Label className="text-base-content/70">英語名</Label>
 							<p>{release.nameEn || "-"}</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">タイプ</Label>
+							<Label className="text-base-content/70">タイプ</Label>
 							<p>
 								{release.releaseType
 									? RELEASE_TYPE_LABELS[release.releaseType]
@@ -998,7 +998,7 @@ function ReleaseDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">発売日</Label>
+							<Label className="text-base-content/70">発売日</Label>
 							<p>
 								{release.releaseDate
 									? format(new Date(release.releaseDate), "yyyy年M月d日", {
@@ -1008,14 +1008,14 @@ function ReleaseDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">発売年/月/日</Label>
+							<Label className="text-base-content/70">発売年/月/日</Label>
 							<p>
 								{release.releaseYear ?? "-"} / {release.releaseMonth ?? "-"} /{" "}
 								{release.releaseDay ?? "-"}
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">イベント</Label>
+							<Label className="text-base-content/70">イベント</Label>
 							<p>
 								{release.eventId ? (
 									<Link
@@ -1032,7 +1032,7 @@ function ReleaseDetailPage() {
 							</p>
 						</div>
 						<div>
-							<Label className="text-base-content/60">イベント日</Label>
+							<Label className="text-base-content/70">イベント日</Label>
 							<p>
 								{release.eventDayId
 									? eventDayOptions.find((d) => d.value === release.eventDayId)
@@ -1041,7 +1041,7 @@ function ReleaseDetailPage() {
 							</p>
 						</div>
 						<div className="md:col-span-2">
-							<Label className="text-base-content/60">メモ</Label>
+							<Label className="text-base-content/70">メモ</Label>
 							<p className="whitespace-pre-wrap">{release.notes || "-"}</p>
 						</div>
 					</div>
@@ -1049,11 +1049,11 @@ function ReleaseDetailPage() {
 			</div>
 
 			{/* ディスク一覧カード */}
-			<div className="card bg-base-100 shadow-xl">
+			<div className="card bg-base-100">
 				<div className="card-body">
 					<div className="flex items-center justify-between">
 						<h2 className="card-title">
-							<Disc3 className="h-5 w-5" />
+							<Disc3 className="h-4 w-4" />
 							ディスク一覧
 						</h2>
 						<Button
@@ -1067,7 +1067,7 @@ function ReleaseDetailPage() {
 					</div>
 
 					{release.discs.length === 0 ? (
-						<p className="text-base-content/60">ディスクが登録されていません</p>
+						<p className="text-base-content/70">ディスクが登録されていません</p>
 					) : (
 						<div className="overflow-x-auto">
 							<table className="table">
@@ -1116,11 +1116,11 @@ function ReleaseDetailPage() {
 			</div>
 
 			{/* サークル関連付けカード */}
-			<div className="card bg-base-100 shadow-xl">
+			<div className="card bg-base-100">
 				<div className="card-body">
 					<div className="flex items-center justify-between">
 						<h2 className="card-title">
-							<Users className="h-5 w-5" />
+							<Users className="h-4 w-4" />
 							関連サークル
 						</h2>
 						<Button variant="outline" size="sm" onClick={openCircleDialog}>
@@ -1130,7 +1130,7 @@ function ReleaseDetailPage() {
 					</div>
 
 					{releaseCircles.length === 0 ? (
-						<p className="text-base-content/60">
+						<p className="text-base-content/70">
 							サークルが関連付けられていません
 						</p>
 					) : (
@@ -1202,11 +1202,11 @@ function ReleaseDetailPage() {
 			</div>
 
 			{/* 公開リンクカード */}
-			<div className="card bg-base-100 shadow-xl">
+			<div className="card bg-base-100">
 				<div className="card-body">
 					<div className="flex items-center justify-between">
 						<h2 className="card-title">
-							<ExternalLink className="h-5 w-5" />
+							<ExternalLink className="h-4 w-4" />
 							公開リンク
 						</h2>
 						<Button
@@ -1220,7 +1220,7 @@ function ReleaseDetailPage() {
 					</div>
 
 					{publications.length === 0 ? (
-						<p className="text-base-content/60">
+						<p className="text-base-content/70">
 							公開リンクが登録されていません
 						</p>
 					) : (
@@ -1284,11 +1284,11 @@ function ReleaseDetailPage() {
 			</div>
 
 			{/* JANコードカード */}
-			<div className="card bg-base-100 shadow-xl">
+			<div className="card bg-base-100">
 				<div className="card-body">
 					<div className="flex items-center justify-between">
 						<h2 className="card-title">
-							<Barcode className="h-5 w-5" />
+							<Barcode className="h-4 w-4" />
 							JANコード
 						</h2>
 						<Button
@@ -1302,7 +1302,7 @@ function ReleaseDetailPage() {
 					</div>
 
 					{janCodes.length === 0 ? (
-						<p className="text-base-content/60">
+						<p className="text-base-content/70">
 							JANコードが登録されていません
 						</p>
 					) : (
@@ -1357,11 +1357,11 @@ function ReleaseDetailPage() {
 			</div>
 
 			{/* トラック一覧カード */}
-			<div className="card bg-base-100 shadow-xl">
+			<div className="card bg-base-100">
 				<div className="card-body">
 					<div className="flex items-center justify-between">
 						<h2 className="card-title">
-							<Music className="h-5 w-5" />
+							<Music className="h-4 w-4" />
 							トラック一覧
 						</h2>
 						<Button
@@ -1375,7 +1375,7 @@ function ReleaseDetailPage() {
 					</div>
 
 					{tracks.length === 0 ? (
-						<p className="text-base-content/60">トラックが登録されていません</p>
+						<p className="text-base-content/70">トラックが登録されていません</p>
 					) : (
 						<div className="space-y-6">
 							{/* ディスクごとにグループ化 */}
@@ -1451,7 +1451,7 @@ function ReleaseDetailPage() {
 																			{track.name}
 																		</Link>
 																		{track.nameJa && (
-																			<p className="text-base-content/60 text-sm">
+																			<p className="text-base-content/70 text-sm">
 																				{track.nameJa}
 																			</p>
 																		)}
@@ -1566,7 +1566,7 @@ function ReleaseDetailPage() {
 																		{track.name}
 																	</Link>
 																	{track.nameJa && (
-																		<p className="text-base-content/60 text-sm">
+																		<p className="text-base-content/70 text-sm">
 																			{track.nameJa}
 																		</p>
 																	)}
@@ -1902,7 +1902,7 @@ function ReleaseDetailPage() {
 					</DialogHeader>
 					<div className="py-4">
 						<div className="mb-4 flex items-center justify-between">
-							<span className="text-base-content/60 text-sm">
+							<span className="text-base-content/70 text-sm">
 								{credits.length}件のクレジット
 							</span>
 							<Button
@@ -1916,7 +1916,7 @@ function ReleaseDetailPage() {
 						</div>
 
 						{credits.length === 0 ? (
-							<p className="py-8 text-center text-base-content/60">
+							<p className="py-8 text-center text-base-content/70">
 								クレジットが登録されていません
 							</p>
 						) : (
@@ -1942,7 +1942,7 @@ function ReleaseDetailPage() {
 														<div>
 															<p className="font-medium">{credit.creditName}</p>
 															{credit.artistAlias && (
-																<p className="text-base-content/60 text-xs">
+																<p className="text-base-content/70 text-xs">
 																	名義
 																</p>
 															)}
@@ -2046,7 +2046,7 @@ function ReleaseDetailPage() {
 								clearable={false}
 							/>
 							{creditForm.artistId && (
-								<p className="text-base-content/60 text-xs">
+								<p className="text-base-content/70 text-xs">
 									アーティスト:{" "}
 									{artistsData?.data.find((a) => a.id === creditForm.artistId)
 										?.name ?? "-"}{" "}
@@ -2073,7 +2073,7 @@ function ReleaseDetailPage() {
 								}
 								placeholder="盤面に表示される名前"
 							/>
-							<p className="text-base-content/60 text-xs">
+							<p className="text-base-content/70 text-xs">
 								アーティスト名義から自動入力されます。必要に応じて編集してください。
 							</p>
 						</div>
@@ -2123,7 +2123,7 @@ function ReleaseDetailPage() {
 									</span>
 								)}
 							</div>
-							<p className="text-base-content/60 text-xs">
+							<p className="text-base-content/70 text-xs">
 								選択した順序で役割が表示されます。
 							</p>
 						</div>
@@ -2292,7 +2292,7 @@ function ReleaseDetailPage() {
 								disabled={!!editingJanCode}
 								className="font-mono"
 							/>
-							<p className="text-base-content/60 text-xs">
+							<p className="text-base-content/70 text-xs">
 								8桁または13桁の数字（編集時は変更不可）
 							</p>
 						</div>

--- a/apps/web/src/routes/admin/_admin/tracks.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks.tsx
@@ -324,7 +324,7 @@ function TracksPage() {
 			{/* ヘッダー */}
 			<h1 className="font-bold text-2xl">トラック管理</h1>
 
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<DataTableActionBar
 					className="border-base-300 border-b p-4"
 					searchPlaceholder="トラック名で検索..."
@@ -567,7 +567,7 @@ function TracksPage() {
 													<div>
 														<p>{track.name}</p>
 														{track.nameJa && (
-															<p className="text-base-content/60 text-sm">
+															<p className="text-base-content/70 text-sm">
 																{track.nameJa}
 															</p>
 														)}

--- a/apps/web/src/routes/admin/_admin/tracks_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/tracks_.$id.tsx
@@ -941,7 +941,7 @@ function TrackDetailPage() {
 			{/* mutation エラーは各ダイアログ内で表示 */}
 
 			{/* トラック情報カード */}
-			<div className="rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="rounded-lg border border-base-300 bg-base-100">
 				<div className="border-base-300 border-b p-4">
 					<div className="flex items-center justify-between">
 						<h2 className="font-bold text-xl">{track.name}</h2>
@@ -960,19 +960,19 @@ function TrackDetailPage() {
 					<div className="grid gap-4">
 						<div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
 							<div>
-								<p className="text-base-content/60 text-sm">トラック名</p>
+								<p className="text-base-content/70 text-sm">トラック名</p>
 								<p>{track.name}</p>
 							</div>
 							<div>
-								<p className="text-base-content/60 text-sm">トラック番号</p>
+								<p className="text-base-content/70 text-sm">トラック番号</p>
 								<p>{track.trackNumber}</p>
 							</div>
 							<div>
-								<p className="text-base-content/60 text-sm">日本語名</p>
+								<p className="text-base-content/70 text-sm">日本語名</p>
 								<p>{track.nameJa || "-"}</p>
 							</div>
 							<div>
-								<p className="text-base-content/60 text-sm">英語名</p>
+								<p className="text-base-content/70 text-sm">英語名</p>
 								<p>{track.nameEn || "-"}</p>
 							</div>
 						</div>
@@ -980,7 +980,7 @@ function TrackDetailPage() {
 						<div className="border-base-300 border-t pt-4">
 							<div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
 								<div>
-									<p className="text-base-content/60 text-sm">作品</p>
+									<p className="text-base-content/70 text-sm">作品</p>
 									{track.release ? (
 										<Link
 											to="/admin/releases/$id"
@@ -994,7 +994,7 @@ function TrackDetailPage() {
 									)}
 								</div>
 								<div>
-									<p className="text-base-content/60 text-sm">ディスク</p>
+									<p className="text-base-content/70 text-sm">ディスク</p>
 									<p>
 										{track.disc
 											? `Disc ${track.disc.discNumber}${track.disc.discName ? ` - ${track.disc.discName}` : ""}`
@@ -1002,7 +1002,7 @@ function TrackDetailPage() {
 									</p>
 								</div>
 								<div>
-									<p className="text-base-content/60 text-sm">イベント</p>
+									<p className="text-base-content/70 text-sm">イベント</p>
 									{track.eventId && track.eventName ? (
 										<Link
 											to="/admin/events/$id"
@@ -1016,7 +1016,7 @@ function TrackDetailPage() {
 									)}
 								</div>
 								<div>
-									<p className="text-base-content/60 text-sm">イベント日</p>
+									<p className="text-base-content/70 text-sm">イベント日</p>
 									<p>
 										{track.eventDayDate
 											? `${track.eventDayDate}${track.eventDayNumber ? ` (Day ${track.eventDayNumber})` : ""}`
@@ -1028,7 +1028,7 @@ function TrackDetailPage() {
 						<div className="border-base-300 border-t pt-4">
 							<div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
 								<div>
-									<p className="text-base-content/60 text-sm">
+									<p className="text-base-content/70 text-sm">
 										リリース年/月/日
 									</p>
 									<p>
@@ -1038,7 +1038,7 @@ function TrackDetailPage() {
 									</p>
 								</div>
 								<div>
-									<p className="text-base-content/60 text-sm">作成日時</p>
+									<p className="text-base-content/70 text-sm">作成日時</p>
 									<p className="text-sm">
 										{format(new Date(track.createdAt), "yyyy/MM/dd HH:mm:ss", {
 											locale: ja,
@@ -1046,7 +1046,7 @@ function TrackDetailPage() {
 									</p>
 								</div>
 								<div>
-									<p className="text-base-content/60 text-sm">更新日時</p>
+									<p className="text-base-content/70 text-sm">更新日時</p>
 									<p className="text-sm">
 										{format(new Date(track.updatedAt), "yyyy/MM/dd HH:mm:ss", {
 											locale: ja,
@@ -1057,7 +1057,7 @@ function TrackDetailPage() {
 						</div>
 
 						<div className="border-base-300 border-t pt-4">
-							<p className="text-base-content/60 text-sm">ID</p>
+							<p className="text-base-content/70 text-sm">ID</p>
 							<p className="font-mono text-xs">{track.id}</p>
 						</div>
 					</div>
@@ -1066,7 +1066,7 @@ function TrackDetailPage() {
 
 			{/* ロール別サマリー */}
 			{track.credits.length > 0 && (
-				<div className="mt-6 rounded-lg border border-base-300 bg-base-100 shadow-sm">
+				<div className="mt-6 rounded-lg border border-base-300 bg-base-100">
 					<div className="border-base-300 border-b p-4">
 						<h2 className="font-bold text-lg">役割別担当者</h2>
 					</div>
@@ -1116,7 +1116,7 @@ function TrackDetailPage() {
 			)}
 
 			{/* クレジット一覧 */}
-			<div className="mt-6 rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="mt-6 rounded-lg border border-base-300 bg-base-100">
 				<div className="flex items-center justify-between border-base-300 border-b p-4">
 					<h2 className="font-bold text-lg">クレジット</h2>
 					<Button variant="outline" size="sm" onClick={openCreditDialog}>
@@ -1220,10 +1220,10 @@ function TrackDetailPage() {
 			</div>
 
 			{/* 原曲紐付け一覧 */}
-			<div className="mt-6 rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="mt-6 rounded-lg border border-base-300 bg-base-100">
 				<div className="flex items-center justify-between border-base-300 border-b p-4">
 					<h2 className="font-bold text-lg">
-						<Music className="mr-2 inline-block h-5 w-5" />
+						<Music className="mr-2 inline-block h-4 w-4" />
 						原曲紐付け
 					</h2>
 					<Button variant="outline" size="sm" onClick={openOfficialSongDialog}>
@@ -1315,10 +1315,10 @@ function TrackDetailPage() {
 			</div>
 
 			{/* 派生関係一覧 */}
-			<div className="mt-6 rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="mt-6 rounded-lg border border-base-300 bg-base-100">
 				<div className="flex items-center justify-between border-base-300 border-b p-4">
 					<h2 className="font-bold text-lg">
-						<GitFork className="mr-2 inline-block h-5 w-5" />
+						<GitFork className="mr-2 inline-block h-4 w-4" />
 						派生関係
 					</h2>
 					<Button variant="outline" size="sm" onClick={openDerivationDialog}>
@@ -1353,7 +1353,7 @@ function TrackDetailPage() {
 												>
 													{derivation.parentTrack.name}
 													{derivation.parentTrack.releaseName && (
-														<span className="ml-1 text-base-content/60 text-sm">
+														<span className="ml-1 text-base-content/70 text-sm">
 															（{derivation.parentTrack.releaseName}）
 														</span>
 													)}
@@ -1383,10 +1383,10 @@ function TrackDetailPage() {
 			</div>
 
 			{/* 公開リンク一覧 */}
-			<div className="mt-6 rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="mt-6 rounded-lg border border-base-300 bg-base-100">
 				<div className="flex items-center justify-between border-base-300 border-b p-4">
 					<h2 className="font-bold text-lg">
-						<ExternalLink className="mr-2 inline-block h-5 w-5" />
+						<ExternalLink className="mr-2 inline-block h-4 w-4" />
 						公開リンク
 					</h2>
 					<Button variant="outline" size="sm" onClick={openPublicationDialog}>
@@ -1452,7 +1452,7 @@ function TrackDetailPage() {
 			</div>
 
 			{/* ISRC一覧 */}
-			<div className="mt-6 rounded-lg border border-base-300 bg-base-100 shadow-sm">
+			<div className="mt-6 rounded-lg border border-base-300 bg-base-100">
 				<div className="flex items-center justify-between border-base-300 border-b p-4">
 					<h2 className="font-bold text-lg">ISRC</h2>
 					<Button variant="outline" size="sm" onClick={openIsrcDialog}>
@@ -1562,7 +1562,7 @@ function TrackDetailPage() {
 								clearable={true}
 							/>
 							{creditForm.artistId && (
-								<p className="text-base-content/60 text-xs">
+								<p className="text-base-content/70 text-xs">
 									アーティスト:{" "}
 									{artistsData?.data.find((a) => a.id === creditForm.artistId)
 										?.name ?? "-"}{" "}
@@ -1671,7 +1671,7 @@ function TrackDetailPage() {
 								clearable={true}
 							/>
 							{creditForm.artistId && (
-								<p className="text-base-content/60 text-xs">
+								<p className="text-base-content/70 text-xs">
 									アーティスト:{" "}
 									{artistsData?.data.find((a) => a.id === creditForm.artistId)
 										?.name ?? "-"}{" "}
@@ -2101,7 +2101,7 @@ function TrackDetailPage() {
 									maxLength={12}
 									className="font-mono"
 								/>
-								<p className="text-base-content/60 text-xs">
+								<p className="text-base-content/70 text-xs">
 									12桁：国コード(2) + 登録者コード(3) + 年(2) + コード(5)
 								</p>
 							</div>


### PR DESCRIPTION
## 概要

デザインシステム監査 (`.design-engineer/system.md`) に基づき、管理画面のスタイル違反を修正

## 変更内容

* **アイコンサイズ統一**: `h-5 w-5` (20px) → `h-4 w-4` (16px) に修正（11ファイル）
* **シャドウ削除**: 静的カードから `shadow-sm`/`shadow-xl` を削除（15ファイル）
* **テキスト階層修正**: `text-base-content/60` → `text-base-content/70` に修正（17ファイル）
* **角丸統一**: `rounded-lg` → `rounded-box` に修正（2ファイル）

## 影響範囲

* `apps/web/src/routes/admin/_admin/` 配下の管理画面ページ（32ファイル）
* `apps/web/src/components/ui/` のUIコンポーネント（2ファイル）
* `apps/web/src/components/admin/` の管理用コンポーネント（2ファイル）

## 補足事項

視覚的な変更のみで、機能への影響はありません。