### PR TITLE
feat: 管理画面のUI/UX改善（P0）を実装

### DIFF
--- a/.design-engineer/system.md
+++ b/.design-engineer/system.md
@@ -27,11 +27,11 @@
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| `radius-sm` | 4px | `rounded` - Buttons, inputs, badges |
+| `radius-sm` | 8px | `rounded-lg` - Buttons, inputs, badges |
 | `radius-md` | 8px | `rounded-lg` - Cards, dialogs, dropdowns |
 | `radius-full` | 9999px | `rounded-full` - Avatars, circular buttons |
 
-**Default**: `radius-sm` (4px) for most interactive elements
+**Default**: `radius-sm` (8px) for most interactive elements
 
 ---
 
@@ -121,7 +121,18 @@
 |-------|-------|
 | Hover | `hover:bg-base-200` |
 | Active | `bg-primary/10 border-l-3 border-primary` |
-| Focus | Managed by daisyUI |
+| Focus | `focus-ring` utility class |
+
+### Focus States
+
+| State | Class |
+|-------|-------|
+| Default | `focus-ring` |
+| Inset | `focus-ring-inset` |
+
+**Utility Classes** (defined in index.css):
+- `.focus-ring`: `focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2`
+- `.focus-ring-inset`: `focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset`
 
 ### Semantic Colors
 

--- a/apps/web/src/components/admin/alias-type-edit-dialog.tsx
+++ b/apps/web/src/components/admin/alias-type-edit-dialog.tsx
@@ -8,6 +8,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -164,7 +165,7 @@ export function AliasTypeEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -212,7 +213,7 @@ export function AliasTypeEditDialog({
 								disabled={isPending}
 							/>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/artist-alias-edit-dialog.tsx
+++ b/apps/web/src/components/admin/artist-alias-edit-dialog.tsx
@@ -18,6 +18,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -317,7 +318,7 @@ export function ArtistAliasEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -405,7 +406,7 @@ export function ArtistAliasEditDialog({
 								/>
 							</div>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/artist-edit-dialog.tsx
+++ b/apps/web/src/components/admin/artist-edit-dialog.tsx
@@ -15,6 +15,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -259,7 +260,7 @@ export function ArtistEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -328,7 +329,7 @@ export function ArtistEditDialog({
 								disabled={isPending}
 							/>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/circle-edit-dialog.tsx
+++ b/apps/web/src/components/admin/circle-edit-dialog.tsx
@@ -15,6 +15,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -259,7 +260,7 @@ export function CircleEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -328,7 +329,7 @@ export function CircleEditDialog({
 								disabled={isPending}
 							/>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/credit-role-edit-dialog.tsx
+++ b/apps/web/src/components/admin/credit-role-edit-dialog.tsx
@@ -8,6 +8,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -167,7 +168,7 @@ export function CreditRoleEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -215,7 +216,7 @@ export function CreditRoleEditDialog({
 								disabled={isPending}
 							/>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/event-edit-dialog.tsx
+++ b/apps/web/src/components/admin/event-edit-dialog.tsx
@@ -16,6 +16,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -298,7 +299,7 @@ export function EventEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -400,7 +401,7 @@ export function EventEditDialog({
 								/>
 							</div>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/event-series-edit-dialog.tsx
+++ b/apps/web/src/components/admin/event-series-edit-dialog.tsx
@@ -10,6 +10,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -218,7 +219,7 @@ export function EventSeriesEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -255,7 +256,7 @@ export function EventSeriesEditDialog({
 								/>
 							</div>
 						)}
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/official-song-edit-dialog.tsx
+++ b/apps/web/src/components/admin/official-song-edit-dialog.tsx
@@ -15,6 +15,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -383,7 +384,7 @@ export function OfficialSongEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -544,7 +545,7 @@ export function OfficialSongEditDialog({
 								disabled={isPending}
 							/>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/official-work-category-edit-dialog.tsx
+++ b/apps/web/src/components/admin/official-work-category-edit-dialog.tsx
@@ -8,6 +8,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -174,7 +175,7 @@ export function OfficialWorkCategoryEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -225,7 +226,7 @@ export function OfficialWorkCategoryEditDialog({
 								autoComplete="off"
 							/>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/official-work-edit-dialog.tsx
+++ b/apps/web/src/components/admin/official-work-edit-dialog.tsx
@@ -14,6 +14,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -360,7 +361,7 @@ export function OfficialWorkEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -528,7 +529,7 @@ export function OfficialWorkEditDialog({
 								disabled={isPending}
 							/>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/platform-edit-dialog.tsx
+++ b/apps/web/src/components/admin/platform-edit-dialog.tsx
@@ -9,6 +9,7 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -242,7 +243,7 @@ export function PlatformEditDialog({
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -309,7 +310,7 @@ export function PlatformEditDialog({
 								autoComplete="off"
 							/>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/release-edit-dialog.tsx
+++ b/apps/web/src/components/admin/release-edit-dialog.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -232,7 +233,7 @@ export function ReleaseEditDialog({
 					<DialogHeader>
 						<DialogTitle>リリースの編集</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{mutationError && !isConflictError(mutationError) ? (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{getErrorMessage(mutationError)}
@@ -367,7 +368,7 @@ export function ReleaseEditDialog({
 								/>
 							</div>
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/admin/row-action-menu.tsx
+++ b/apps/web/src/components/admin/row-action-menu.tsx
@@ -1,0 +1,153 @@
+import { Link } from "@tanstack/react-router";
+import { Eye, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface RowAction {
+	label: string;
+	icon: ReactNode;
+	onClick: () => void;
+	variant?: "default" | "danger";
+	href?: string;
+	linkParams?: Record<string, string>;
+}
+
+interface RowActionMenuProps {
+	actions: RowAction[];
+	className?: string;
+}
+
+export function RowActionMenu({ actions, className }: RowActionMenuProps) {
+	return (
+		<div className={cn("flex items-center", className)}>
+			{/* Desktop actions */}
+			<div className="hidden items-center gap-1 md:flex">
+				{actions.map((action) => {
+					const buttonClassName = cn(
+						action.variant === "danger" && "text-error hover:text-error",
+					);
+
+					if (action.href) {
+						return (
+							<Link
+								key={action.label}
+								to={action.href}
+								params={action.linkParams}
+								className={cn(
+									"btn btn-ghost btn-square btn-sm focus-ring",
+									buttonClassName,
+								)}
+							>
+								{action.icon}
+								<span className="sr-only">{action.label}</span>
+							</Link>
+						);
+					}
+
+					return (
+						<Button
+							key={action.label}
+							variant="ghost"
+							size="icon"
+							className={buttonClassName}
+							onClick={action.onClick}
+						>
+							{action.icon}
+							<span className="sr-only">{action.label}</span>
+						</Button>
+					);
+				})}
+			</div>
+
+			{/* Mobile dropdown */}
+			<div className="dropdown dropdown-end md:hidden">
+				<button className="btn btn-ghost btn-square btn-sm" type="button">
+					<MoreHorizontal className="h-4 w-4" />
+					<span className="sr-only">メニュー</span>
+				</button>
+				<ul className="menu dropdown-content z-[1] w-40 rounded-box border border-base-300 bg-base-100 p-2 shadow-lg">
+					{actions.map((action) => {
+						const itemClassName = cn(
+							action.variant === "danger" && "text-error",
+						);
+
+						if (action.href) {
+							return (
+								<li key={action.label}>
+									<Link
+										to={action.href}
+										params={action.linkParams}
+										className={itemClassName}
+									>
+										{action.icon}
+										{action.label}
+									</Link>
+								</li>
+							);
+						}
+
+						return (
+							<li key={action.label}>
+								<button
+									type="button"
+									className={itemClassName}
+									onClick={action.onClick}
+								>
+									{action.icon}
+									{action.label}
+								</button>
+							</li>
+						);
+					})}
+				</ul>
+			</div>
+		</div>
+	);
+}
+
+interface AdminRowActionsProps {
+	onView?: () => void;
+	viewHref?: string;
+	viewParams?: Record<string, string>;
+	onEdit: () => void;
+	onDelete: () => void;
+	className?: string;
+}
+
+export function AdminRowActions({
+	onView,
+	viewHref,
+	viewParams,
+	onEdit,
+	onDelete,
+	className,
+}: AdminRowActionsProps) {
+	const actions: RowAction[] = [];
+
+	if (onView || viewHref) {
+		actions.push({
+			label: "詳細",
+			icon: <Eye className="h-4 w-4" />,
+			onClick: onView || (() => {}),
+			href: viewHref,
+			linkParams: viewParams,
+		});
+	}
+
+	actions.push(
+		{
+			label: "編集",
+			icon: <Pencil className="h-4 w-4" />,
+			onClick: onEdit,
+		},
+		{
+			label: "削除",
+			icon: <Trash2 className="h-4 w-4" />,
+			onClick: onDelete,
+			variant: "danger",
+		},
+	);
+
+	return <RowActionMenu actions={actions} className={className} />;
+}

--- a/apps/web/src/components/admin/track-edit-dialog.tsx
+++ b/apps/web/src/components/admin/track-edit-dialog.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
 	Dialog,
+	DialogBody,
 	DialogContent,
 	DialogFooter,
 	DialogHeader,
@@ -292,7 +293,7 @@ export function TrackEditDialog({
 					<DialogHeader>
 						<DialogTitle>トラックの編集</DialogTitle>
 					</DialogHeader>
-					<div className="grid gap-4 py-4">
+					<DialogBody className="grid gap-4 py-4">
 						{displayError && (
 							<div className="rounded-lg bg-error/10 p-4 text-error text-sm">
 								{displayError}
@@ -492,7 +493,7 @@ export function TrackEditDialog({
 								</p>
 							)}
 						</div>
-					</div>
+					</DialogBody>
 					<DialogFooter>
 						<Button
 							variant="ghost"

--- a/apps/web/src/components/ui/banner.tsx
+++ b/apps/web/src/components/ui/banner.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle, AlertTriangle, CheckCircle, Info, X } from "lucide-react";
 import type * as React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -11,6 +12,10 @@ interface BannerProps {
 	onDismiss?: () => void;
 	dismissible?: boolean;
 	className?: string;
+	/** 自動非表示までの時間（ミリ秒）。0または未指定で自動非表示なし */
+	autoHideDuration?: number;
+	/** 自動非表示時のコールバック */
+	onAutoHide?: () => void;
 }
 
 const variantConfig: Record<
@@ -32,22 +37,82 @@ function Banner({
 	onDismiss,
 	dismissible = true,
 	className,
+	autoHideDuration,
+	onAutoHide,
 }: BannerProps) {
 	const config = variantConfig[variant];
 	const Icon = config.icon;
+	const [isVisible, setIsVisible] = useState(true);
+	const [isFadingOut, setIsFadingOut] = useState(false);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	// タイマーをクリア
+	const clearTimers = useCallback(() => {
+		if (timerRef.current) {
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+		}
+		if (fadeTimerRef.current) {
+			clearTimeout(fadeTimerRef.current);
+			fadeTimerRef.current = null;
+		}
+	}, []);
+
+	// 自動非表示タイマー
+	useEffect(() => {
+		if (!autoHideDuration || autoHideDuration <= 0) {
+			return;
+		}
+
+		// フェードアウト開始までの時間（トランジション時間を考慮して300ms早く開始）
+		const fadeStartTime = Math.max(autoHideDuration - 300, 0);
+
+		timerRef.current = setTimeout(() => {
+			setIsFadingOut(true);
+			// フェードアウト完了後に非表示
+			fadeTimerRef.current = setTimeout(() => {
+				setIsVisible(false);
+				onAutoHide?.();
+			}, 300);
+		}, fadeStartTime);
+
+		return () => {
+			clearTimers();
+		};
+	}, [autoHideDuration, onAutoHide, clearTimers]);
+
+	// 手動で閉じた場合
+	const handleDismiss = () => {
+		clearTimers();
+		setIsFadingOut(true);
+		fadeTimerRef.current = setTimeout(() => {
+			setIsVisible(false);
+			onDismiss?.();
+		}, 300);
+	};
+
+	if (!isVisible) {
+		return null;
+	}
 
 	return (
 		<div
 			role="alert"
 			aria-live={variant === "error" ? "assertive" : "polite"}
-			className={cn("alert", config.alertClass, className)}
+			className={cn(
+				"alert transition-opacity duration-300",
+				config.alertClass,
+				isFadingOut && "opacity-0",
+				className,
+			)}
 		>
 			<Icon className="h-5 w-5 shrink-0" />
 			<div className="flex-1">{children}</div>
 			{dismissible && onDismiss && (
 				<button
 					type="button"
-					onClick={onDismiss}
+					onClick={handleDismiss}
 					className="btn btn-ghost btn-sm btn-circle"
 					aria-label="閉じる"
 				>

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -60,7 +60,7 @@ function Button({
 		return (
 			<span
 				className={cn(
-					"btn",
+					"btn focus-ring",
 					variantClasses[variant],
 					sizeClasses[size],
 					className,
@@ -76,7 +76,7 @@ function Button({
 			type="button"
 			data-slot="button"
 			className={cn(
-				"btn",
+				"btn focus-ring",
 				variantClasses[variant],
 				sizeClasses[size],
 				className,

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -33,7 +33,7 @@ function Checkbox({
 			ref={ref}
 			type="checkbox"
 			data-slot="checkbox"
-			className={cn("checkbox", className)}
+			className={cn("checkbox focus-ring", className)}
 			onChange={handleChange}
 			{...props}
 		/>

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -5,6 +5,7 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
+	useId,
 	useRef,
 	useState,
 } from "react";
@@ -16,6 +17,7 @@ interface DialogContextValue {
 	open: boolean;
 	setOpen: (open: boolean) => void;
 	dialogRef: React.RefObject<HTMLDialogElement | null>;
+	titleId: string;
 }
 
 const DialogContext = createContext<DialogContextValue | undefined>(undefined);
@@ -37,6 +39,7 @@ interface DialogProps {
 function Dialog({ open: controlledOpen, onOpenChange, children }: DialogProps) {
 	const [internalOpen, setInternalOpen] = useState(false);
 	const dialogRef = useRef<HTMLDialogElement>(null);
+	const titleId = useId();
 
 	const isControlled = controlledOpen !== undefined;
 	const open = isControlled ? controlledOpen : internalOpen;
@@ -52,7 +55,7 @@ function Dialog({ open: controlledOpen, onOpenChange, children }: DialogProps) {
 	);
 
 	return (
-		<DialogContext.Provider value={{ open, setOpen, dialogRef }}>
+		<DialogContext.Provider value={{ open, setOpen, dialogRef, titleId }}>
 			{children}
 		</DialogContext.Provider>
 	);
@@ -103,7 +106,7 @@ function DialogContent({
 	showCloseButton = true,
 	...props
 }: DialogContentProps) {
-	const { open, setOpen, dialogRef } = useDialogContext();
+	const { open, setOpen, dialogRef, titleId } = useDialogContext();
 
 	useEffect(() => {
 		const dialog = dialogRef.current;
@@ -136,9 +139,14 @@ function DialogContent({
 			ref={dialogRef}
 			data-slot="dialog-content"
 			className="modal"
+			aria-labelledby={titleId}
+			aria-modal="true"
 			onClick={handleBackdropClick}
 		>
-			<div className={cn("modal-box", className)} {...props}>
+			<div
+				className={cn("modal-box flex max-h-[90vh] flex-col", className)}
+				{...props}
+			>
 				{children}
 				{showCloseButton && (
 					<button
@@ -162,7 +170,17 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="dialog-header"
-			className={cn("mb-4", className)}
+			className={cn("mb-4 shrink-0", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogBody({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="dialog-body"
+			className={cn("flex-1 overflow-y-auto", className)}
 			{...props}
 		/>
 	);
@@ -172,15 +190,20 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="dialog-footer"
-			className={cn("modal-action mt-4", className)}
+			className={cn(
+				"modal-action sticky bottom-0 mt-4 border-base-300 border-t bg-base-100 pt-4",
+				className,
+			)}
 			{...props}
 		/>
 	);
 }
 
 function DialogTitle({ className, ...props }: React.ComponentProps<"h3">) {
+	const { titleId } = useDialogContext();
 	return (
 		<h3
+			id={titleId}
 			data-slot="dialog-title"
 			className={cn("font-bold text-lg", className)}
 			{...props}
@@ -218,6 +241,7 @@ function DialogClose({ children, ...props }: React.ComponentProps<"button">) {
 
 export {
 	Dialog,
+	DialogBody,
 	DialogClose,
 	DialogContent,
 	DialogDescription,

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -2,12 +2,23 @@ import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+interface InputProps extends React.ComponentProps<"input"> {
+	error?: boolean;
+	errorId?: string;
+}
+
+function Input({ className, type, error, errorId, ...props }: InputProps) {
 	return (
 		<input
 			type={type}
 			data-slot="input"
-			className={cn("input input-bordered w-full", className)}
+			aria-invalid={error || undefined}
+			aria-describedby={errorId || undefined}
+			className={cn(
+				"input input-bordered w-full",
+				error && "input-error",
+				className,
+			)}
 			{...props}
 		/>
 	);

--- a/apps/web/src/components/ui/searchable-select.tsx
+++ b/apps/web/src/components/ui/searchable-select.tsx
@@ -1,5 +1,5 @@
 import { Check, Search, X } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
 interface Option {
@@ -32,6 +32,10 @@ export function SearchableSelect({
 	disabled = false,
 	className,
 }: SearchableSelectProps) {
+	const generatedId = useId();
+	const componentId = id || generatedId;
+	const listboxId = `${componentId}-listbox`;
+
 	const [isOpen, setIsOpen] = useState(false);
 	const [search, setSearch] = useState("");
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -90,7 +94,14 @@ export function SearchableSelect({
 			{/* トリガーボタン */}
 			<button
 				type="button"
-				id={id}
+				id={componentId}
+				role="combobox"
+				aria-expanded={isOpen}
+				aria-haspopup="listbox"
+				aria-controls={listboxId}
+				aria-activedescendant={
+					isOpen && value ? `${componentId}-option-${value}` : undefined
+				}
 				onClick={() => !disabled && setIsOpen(!isOpen)}
 				disabled={disabled}
 				className={cn(
@@ -133,7 +144,12 @@ export function SearchableSelect({
 					</div>
 
 					{/* オプションリスト */}
-					<div className="max-h-60 overflow-y-auto">
+					<div
+						role="listbox"
+						id={listboxId}
+						aria-label={placeholder}
+						className="max-h-60 overflow-y-auto"
+					>
 						{filteredOptions.length === 0 ? (
 							<div className="p-4 text-center text-base-content/50">
 								{emptyMessage}
@@ -143,6 +159,9 @@ export function SearchableSelect({
 								<button
 									key={option.value}
 									type="button"
+									role="option"
+									id={`${componentId}-option-${option.value}`}
+									aria-selected={value === option.value}
 									onClick={() => handleSelect(option.value)}
 									className={cn(
 										"flex w-full items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-base-200",

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -6,6 +6,16 @@ interface TableProps extends React.ComponentProps<"table"> {
 	zebra?: boolean;
 }
 
+interface TableHeadProps extends React.ComponentProps<"th"> {
+	sticky?: "left" | "right";
+	sortable?: boolean;
+	sorted?: "asc" | "desc" | false;
+}
+
+interface TableCellProps extends React.ComponentProps<"td"> {
+	sticky?: "left" | "right";
+}
+
 function Table({ className, zebra = false, ...props }: TableProps) {
 	return (
 		<div data-slot="table-container" className="w-full overflow-x-auto">
@@ -44,18 +54,54 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
 	);
 }
 
-function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+function TableHead({
+	className,
+	sticky,
+	sortable,
+	sorted,
+	...props
+}: TableHeadProps) {
+	const ariaSort =
+		sorted === "asc"
+			? "ascending"
+			: sorted === "desc"
+				? "descending"
+				: sorted === false
+					? "none"
+					: undefined;
+
 	return (
 		<th
 			data-slot="table-head"
-			className={cn("font-semibold text-base-content", className)}
+			scope="col"
+			aria-sort={ariaSort}
+			className={cn(
+				"font-semibold text-base-content",
+				sticky === "left" &&
+					"sticky left-0 bg-base-100 shadow-[2px_0_4px_rgba(0,0,0,0.1)]",
+				sticky === "right" &&
+					"sticky right-0 bg-base-100 shadow-[-2px_0_4px_rgba(0,0,0,0.1)]",
+				className,
+			)}
 			{...props}
 		/>
 	);
 }
 
-function TableCell({ className, ...props }: React.ComponentProps<"td">) {
-	return <td data-slot="table-cell" className={cn(className)} {...props} />;
+function TableCell({ className, sticky, ...props }: TableCellProps) {
+	return (
+		<td
+			data-slot="table-cell"
+			className={cn(
+				sticky === "left" &&
+					"sticky left-0 bg-base-100 shadow-[2px_0_4px_rgba(0,0,0,0.1)]",
+				sticky === "right" &&
+					"sticky right-0 bg-base-100 shadow-[-2px_0_4px_rgba(0,0,0,0.1)]",
+				className,
+			)}
+			{...props}
+		/>
+	);
 }
 
 function TableCaption({

--- a/apps/web/src/hooks/use-banner.ts
+++ b/apps/web/src/hooks/use-banner.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { BannerVariant } from "@/components/ui/banner";
+
+interface BannerState {
+	message: string;
+	variant: BannerVariant;
+	visible: boolean;
+}
+
+interface UseBannerOptions {
+	/** 自動非表示までの時間（ミリ秒）。デフォルト: 5000ms */
+	autoHideDuration?: number;
+}
+
+const DEFAULT_AUTO_HIDE_DURATION = 5000;
+
+/**
+ * バナー表示を管理するカスタムフック
+ * @param options オプション設定
+ * @returns バナー状態と制御関数
+ */
+export function useBanner(options: UseBannerOptions = {}) {
+	const { autoHideDuration = DEFAULT_AUTO_HIDE_DURATION } = options;
+
+	const [bannerState, setBannerState] = useState<BannerState>({
+		message: "",
+		variant: "info",
+		visible: false,
+	});
+
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const clearTimer = useCallback(() => {
+		if (timerRef.current) {
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+		}
+	}, []);
+
+	const dismiss = useCallback(() => {
+		clearTimer();
+		setBannerState((prev) => ({ ...prev, visible: false }));
+	}, [clearTimer]);
+
+	const show = useCallback(
+		(message: string, variant: BannerVariant = "info") => {
+			clearTimer();
+			setBannerState({ message, variant, visible: true });
+
+			if (autoHideDuration > 0) {
+				timerRef.current = setTimeout(() => {
+					setBannerState((prev) => ({ ...prev, visible: false }));
+				}, autoHideDuration);
+			}
+		},
+		[autoHideDuration, clearTimer],
+	);
+
+	// クリーンアップ
+	useEffect(() => {
+		return () => {
+			clearTimer();
+		};
+	}, [clearTimer]);
+
+	return { bannerState, show, dismiss };
+}
+
+export type { BannerState, UseBannerOptions };

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -69,6 +69,14 @@
 	display: none;
 }
 
+/* Focus ring utilities */
+.focus-ring {
+	@apply focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2;
+}
+.focus-ring-inset {
+	@apply focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset;
+}
+
 /* Sidebar animations */
 .menu details > ul {
 	animation: sidebarSlideDown 200ms ease-out;

--- a/apps/web/src/routes/admin/_admin/artists.tsx
+++ b/apps/web/src/routes/admin/_admin/artists.tsx
@@ -6,11 +6,12 @@ import {
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
-import { Download, Eye, Home, Pencil, Trash2 } from "lucide-react";
+import { Download, Home, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { ArtistEditDialog } from "@/components/admin/artist-edit-dialog";
 import { DataTableActionBar } from "@/components/admin/data-table-action-bar";
 import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
+import { AdminRowActions } from "@/components/admin/row-action-menu";
 import { SortIcon } from "@/components/admin/sort-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -410,7 +411,7 @@ function ArtistsPage() {
 											/>
 										</TableHead>
 									)}
-									<TableHead className="w-[70px]" />
+									<TableHead sticky="right" className="w-[70px]" />
 								</TableRow>
 							</TableHeader>
 							<TableBody>
@@ -509,36 +510,13 @@ function ArtistsPage() {
 													)}
 												</TableCell>
 											)}
-											<TableCell>
-												<div className="flex items-center gap-1">
-													<Link
-														to="/admin/artists/$id"
-														params={{ id: artist.id }}
-														className="btn btn-ghost btn-sm"
-													>
-														<Eye className="h-4 w-4" />
-														<span className="sr-only">詳細</span>
-													</Link>
-													<Button
-														variant="ghost"
-														size="icon"
-														onClick={() => {
-															setEditingArtist(artist);
-														}}
-													>
-														<Pencil className="h-4 w-4" />
-														<span className="sr-only">編集</span>
-													</Button>
-													<Button
-														variant="ghost"
-														size="icon"
-														className="text-error hover:text-error"
-														onClick={() => setDeleteTarget(artist)}
-													>
-														<Trash2 className="h-4 w-4" />
-														<span className="sr-only">削除</span>
-													</Button>
-												</div>
+											<TableCell sticky="right">
+												<AdminRowActions
+													viewHref="/admin/artists/$id"
+													viewParams={{ id: artist.id }}
+													onEdit={() => setEditingArtist(artist)}
+													onDelete={() => setDeleteTarget(artist)}
+												/>
 											</TableCell>
 										</TableRow>
 									))


### PR DESCRIPTION
## 概要

管理画面の使いやすさを向上させるため、P0の優先改善項目を実装。フォーカスインジケーター統一、ダイアログスクロール対応、テーブルsticky化、エラー表示統一、アクセシビリティ強化を行った。

## 変更内容

### Phase 1: 基盤コンポーネント改修
- `index.css`: フォーカスリングユーティリティ（`.focus-ring`, `.focus-ring-inset`）を追加
- `dialog.tsx`: `DialogBody`コンポーネント追加、`max-h-[90vh]`制限、aria属性対応
- `button.tsx`, `checkbox.tsx`: focus-ringクラスを適用

### Phase 2: テーブルレスポンシブ改善
- `table.tsx`: `sticky` prop、`sortable/sorted` props、`aria-sort`属性を追加
- `row-action-menu.tsx`: レスポンシブ対応の行アクションメニューを新規作成
- `artists.tsx`: sticky列と`AdminRowActions`コンポーネントを適用

### Phase 3: エラー表示統一
- `use-banner.ts`: バナー状態管理フックを新規作成（自動タイムアウト対応）
- `banner.tsx`: `autoHideDuration` propとフェードアニメーションを追加

### Phase 4: アクセシビリティ強化
- `input.tsx`: `error/errorId` props、`aria-invalid`属性を追加
- `searchable-select.tsx`: ARIA comboboxパターンを実装
- `table.tsx`: `scope="col"`、`aria-sort`属性を追加

### Phase 5: 編集ダイアログ更新
- 13個の編集ダイアログに`DialogBody`を適用してスクロール対応

### Phase 6: デザインシステム更新
- `system.md`: radius-smを8pxに更新、Focus Statesセクションを追加

## 影響範囲

- 管理画面全体のUIコンポーネント
- 13個の編集ダイアログ（アーティスト、リリース、トラック、サークル、イベント等）
- アーティスト一覧ページ（sticky列とレスポンシブアクションメニューの適用例）

## 補足事項

- 新規ファイル: `row-action-menu.tsx`, `use-banner.ts`
- 型チェック・Lint: 全て成功
- デザインシステムとの整合性を維持