### PR TITLE
refactor: 公開画面のアーティストリンクでartistAliasIdを統一使用

### DIFF
--- a/apps/server/src/routes/public/circles.ts
+++ b/apps/server/src/routes/public/circles.ts
@@ -518,7 +518,7 @@ circlesRouter.get("/:id/tracks", async (c) => {
 			} else {
 				existing.push({
 					id: cr.artistId,
-					artistAliasId: cr.artistAliasId,
+					artistAliasId: cr.artistAliasId ?? `${cr.artistId}__main__`,
 					creditName: cr.creditName,
 					roles: cr.roleName ? [cr.roleName] : [],
 				});

--- a/apps/server/src/routes/public/original-songs.ts
+++ b/apps/server/src/routes/public/original-songs.ts
@@ -512,7 +512,7 @@ originalSongsRouter.get("/:id/tracks", async (c) => {
 			} else {
 				existing.push({
 					id: cr.artistId,
-					artistAliasId: cr.artistAliasId,
+					artistAliasId: cr.artistAliasId ?? `${cr.artistId}__main__`,
 					creditName: cr.creditName,
 					roles: cr.roleName ? [cr.roleName] : [],
 				});

--- a/apps/server/src/routes/public/releases.ts
+++ b/apps/server/src/routes/public/releases.ts
@@ -274,7 +274,7 @@ releasesRouter.get("/:id", async (c) => {
 			}
 			existing.push({
 				artistId: credit.artistId,
-				artistAliasId: credit.artistAliasId,
+				artistAliasId: credit.artistAliasId ?? `${credit.artistId}__main__`,
 				creditName: credit.creditName,
 				aliasName: credit.aliasName,
 				artistName: credit.artistName,

--- a/apps/server/src/routes/public/stats.ts
+++ b/apps/server/src/routes/public/stats.ts
@@ -15,6 +15,7 @@ import {
 	officialWorks,
 	releaseCircles,
 	releases,
+	sql,
 	trackCredits,
 	trackOfficialSongs,
 } from "@thac/db";
@@ -150,16 +151,40 @@ statsRouter.get("/rankings", async (c) => {
 					.orderBy(desc(countDistinct(releaseCircles.releaseId)))
 					.limit(5),
 
-				// アクティブアーティスト: track_creditsをartist_idでグループ化し、トラック数で降順ソート
+				// アクティブアーティスト（名義単位）: track_creditsを名義単位でグループ化し、トラック数で降順ソート
+				// artistAliasIdがnullの場合はメイン名義、存在する場合は別名義として扱う
 				db
 					.select({
-						id: artists.id,
-						name: artists.name,
+						id: sql<string>`CASE
+							WHEN ${trackCredits.artistAliasId} IS NULL
+							THEN ${trackCredits.artistId} || '__main__'
+							ELSE ${trackCredits.artistAliasId}
+						END`,
+						name: sql<string>`CASE
+							WHEN ${trackCredits.artistAliasId} IS NULL
+							THEN ${artists.name}
+							ELSE ${artistAliases.name}
+						END`,
 						count: countDistinct(trackCredits.trackId),
 					})
 					.from(trackCredits)
 					.innerJoin(artists, eq(trackCredits.artistId, artists.id))
-					.groupBy(artists.id)
+					.leftJoin(
+						artistAliases,
+						eq(trackCredits.artistAliasId, artistAliases.id),
+					)
+					.groupBy(
+						sql`CASE
+							WHEN ${trackCredits.artistAliasId} IS NULL
+							THEN ${trackCredits.artistId} || '__main__'
+							ELSE ${trackCredits.artistAliasId}
+						END`,
+						sql`CASE
+							WHEN ${trackCredits.artistAliasId} IS NULL
+							THEN ${artists.name}
+							ELSE ${artistAliases.name}
+						END`,
+					)
 					.orderBy(desc(countDistinct(trackCredits.trackId)))
 					.limit(5),
 			]);
@@ -176,7 +201,7 @@ statsRouter.get("/rankings", async (c) => {
 				count: row.count,
 			})),
 			activeArtists: activeArtistsResult.map((row) => ({
-				id: `${row.id}__main__`, // メイン名義IDとして返す
+				id: row.id, // クエリで既に正しいID形式（メイン名義: {artistId}__main__、別名義: artistAliasId）
 				name: row.name,
 				count: row.count,
 			})),

--- a/apps/server/src/routes/public/tracks.ts
+++ b/apps/server/src/routes/public/tracks.ts
@@ -242,7 +242,7 @@ tracksRouter.get("/:id", async (c) => {
 		// クレジットデータを構築
 		const credits = creditsData.map((credit) => ({
 			artistId: credit.artistId,
-			artistAliasId: credit.artistAliasId,
+			artistAliasId: credit.artistAliasId ?? `${credit.artistId}__main__`,
 			creditName: credit.creditName,
 			roles: rolesByCredit.get(credit.creditId) ?? [],
 		}));

--- a/apps/web/src/lib/head.test.ts
+++ b/apps/web/src/lib/head.test.ts
@@ -300,19 +300,19 @@ const mockTrack: PublicTrackDetail = {
 	credits: [
 		{
 			artistId: "a1",
-			artistAliasId: null,
+			artistAliasId: "a1__main__",
 			creditName: "Artist1",
 			roles: [{ roleCode: "arrange", roleName: "編曲" }],
 		},
 		{
 			artistId: "a2",
-			artistAliasId: null,
+			artistAliasId: "a2__main__",
 			creditName: "Artist2",
 			roles: [{ roleCode: "vocal", roleName: "Vo" }],
 		},
 		{
 			artistId: "a3",
-			artistAliasId: null,
+			artistAliasId: "a3__main__",
 			creditName: "Artist3",
 			roles: [{ roleCode: "lyric", roleName: "作詞" }],
 		},
@@ -356,7 +356,7 @@ const mockTrackSingleCredit: PublicTrackDetail = {
 	credits: [
 		{
 			artistId: "a1",
-			artistAliasId: null,
+			artistAliasId: "a1__main__",
 			creditName: "Artist1",
 			roles: [
 				{ roleCode: "arrange", roleName: "編曲" },

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -181,7 +181,7 @@ export interface PublicArrangeTrack {
 	}>;
 	artists: Array<{
 		id: string;
-		artistAliasId: string | null;
+		artistAliasId: string;
 		creditName: string;
 		roles: string[];
 	}>;
@@ -253,7 +253,7 @@ export interface PublicCircleTrack {
 	trackNumber: number;
 	artists: Array<{
 		id: string;
-		artistAliasId: string | null;
+		artistAliasId: string;
 		creditName: string;
 		roles: string[];
 	}>;
@@ -419,7 +419,7 @@ export interface PublicReleaseDetail {
 		nameEn: string | null;
 		credits: Array<{
 			artistId: string;
-			artistAliasId: string | null;
+			artistAliasId: string;
 			creditName: string;
 			aliasName: string | null;
 			artistName: string | null;
@@ -496,7 +496,7 @@ export interface PublicTrackDetail {
 	trackNumber: number;
 	credits: Array<{
 		artistId: string;
-		artistAliasId: string | null;
+		artistAliasId: string;
 		creditName: string;
 		roles: Array<{ roleCode: string; roleName: string | null }>;
 	}>;

--- a/apps/web/src/routes/_public/circles_.$id.tsx
+++ b/apps/web/src/routes/_public/circles_.$id.tsx
@@ -531,29 +531,25 @@ function CircleDetailPage() {
 											</td>
 											<td className="hidden md:table-cell">
 												<div className="flex flex-wrap gap-1">
-													{track.artists.map((artist) => {
-														const linkId =
-															artist.artistAliasId ?? `${artist.id}__main__`;
-														return (
-															<Link
-																key={linkId}
-																to="/artists/$id"
-																params={{ id: linkId }}
-																preload="intent"
-																className="inline-flex items-center gap-1 hover:text-primary"
-															>
-																<Users className="size-3" />
-																<span>{artist.creditName}</span>
-																<span className="text-base-content/60 text-xs">
-																	(
-																	{artist.roles
-																		.map((r) => roleNames[r] || r)
-																		.join("/")}
-																	)
-																</span>
-															</Link>
-														);
-													})}
+													{track.artists.map((artist) => (
+														<Link
+															key={artist.artistAliasId}
+															to="/artists/$id"
+															params={{ id: artist.artistAliasId }}
+															preload="intent"
+															className="inline-flex items-center gap-1 hover:text-primary"
+														>
+															<Users className="size-3" />
+															<span>{artist.creditName}</span>
+															<span className="text-base-content/60 text-xs">
+																(
+																{artist.roles
+																	.map((r) => roleNames[r] || r)
+																	.join("/")}
+																)
+															</span>
+														</Link>
+													))}
 												</div>
 											</td>
 											<td className="hidden sm:table-cell">

--- a/apps/web/src/routes/_public/original-songs_.$id.tsx
+++ b/apps/web/src/routes/_public/original-songs_.$id.tsx
@@ -279,31 +279,27 @@ function OriginalSongDetailPage() {
 										</td>
 										<td className="hidden md:table-cell">
 											<div className="flex flex-wrap gap-1">
-												{track.artists.map((artist) => {
-													const linkId =
-														artist.artistAliasId ?? `${artist.id}__main__`;
-													return (
-														<Link
-															key={linkId}
-															to="/artists/$id"
-															params={{ id: linkId }}
-															preload="intent"
-															className="inline-flex items-center gap-1 hover:text-primary"
-														>
-															<Users className="size-3" />
-															<span>{artist.creditName}</span>
-															{artist.roles.length > 0 && (
-																<span className="text-base-content/60 text-xs">
-																	(
-																	{artist.roles
-																		.map((r) => roleNames[r] || r)
-																		.join("/")}
-																	)
-																</span>
-															)}
-														</Link>
-													);
-												})}
+												{track.artists.map((artist) => (
+													<Link
+														key={artist.artistAliasId}
+														to="/artists/$id"
+														params={{ id: artist.artistAliasId }}
+														preload="intent"
+														className="inline-flex items-center gap-1 hover:text-primary"
+													>
+														<Users className="size-3" />
+														<span>{artist.creditName}</span>
+														{artist.roles.length > 0 && (
+															<span className="text-base-content/60 text-xs">
+																(
+																{artist.roles
+																	.map((r) => roleNames[r] || r)
+																	.join("/")}
+																)
+															</span>
+														)}
+													</Link>
+												))}
 											</div>
 										</td>
 										<td className="hidden text-base-content/70 sm:table-cell">

--- a/apps/web/src/routes/_public/releases_.$id.tsx
+++ b/apps/web/src/routes/_public/releases_.$id.tsx
@@ -315,15 +315,12 @@ function TrackTable({ tracks }: { tracks: PublicReleaseDetail["tracks"] }) {
 											credit.aliasName ||
 											credit.artistName ||
 											"Unknown";
-										// リンク先ID: artistAliasId があればそれを使用、なければ artistId__main__
-										const linkId =
-											credit.artistAliasId ?? `${credit.artistId}__main__`;
 										return (
-											<span key={credit.artistAliasId ?? credit.artistId}>
+											<span key={credit.artistAliasId}>
 												{idx > 0 && ", "}
 												<Link
 													to="/artists/$id"
-													params={{ id: linkId }}
+													params={{ id: credit.artistAliasId }}
 													preload="intent"
 													className="hover:text-primary"
 												>

--- a/apps/web/src/routes/_public/tracks_.$id.tsx
+++ b/apps/web/src/routes/_public/tracks_.$id.tsx
@@ -169,25 +169,21 @@ function TrackDetailPage() {
 											{roleNames[roleCode] ?? roleCode}
 										</p>
 										<div className="flex flex-wrap gap-x-2 gap-y-1">
-											{credits.map((credit, idx) => {
-												const linkId =
-													credit.artistAliasId ?? `${credit.artistId}__main__`;
-												return (
-													<span key={linkId}>
-														{idx > 0 && (
-															<span className="text-base-content/40"> / </span>
-														)}
-														<Link
-															to="/artists/$id"
-															params={{ id: linkId }}
-															preload="intent"
-															className="hover:text-primary"
-														>
-															{credit.creditName}
-														</Link>
-													</span>
-												);
-											})}
+											{credits.map((credit, idx) => (
+												<span key={credit.artistAliasId}>
+													{idx > 0 && (
+														<span className="text-base-content/40"> / </span>
+													)}
+													<Link
+														to="/artists/$id"
+														params={{ id: credit.artistAliasId }}
+														preload="intent"
+														className="hover:text-primary"
+													>
+														{credit.creditName}
+													</Link>
+												</span>
+											))}
 										</div>
 									</div>
 								),


### PR DESCRIPTION
## 概要

公開画面のアーティストリンクが正しい名義ページに遷移するよう修正し、APIのartistAliasIdを常に返すよう統一。

## 問題の原因

一部の公開画面では、アーティストリンクに「アーティストID」を直接使用していたため、アーティスト名義が考慮されていなかった。

## 変更内容

### バックエンド（API統一）

* すべてのAPIで`artistAliasId`を常に返すよう統一
  - 存在する場合 → そのまま返す
  - nullの場合（メイン名義） → `{artistId}__main__`形式で返す
* 対象API: `original-songs.ts`, `tracks.ts`, `circles.ts`, `releases.ts`, `stats.ts`
* 統計ページのアーティストランキングを名義単位の集計に変更

### フロントエンド（簡素化）

* `artistAliasId`の型を`string | null`から`string`に変更
* フォールバックロジック（`?? __main__`）を削除
* `artistAliasId`を直接使用するよう簡素化
* 対象ページ: 原曲詳細、トラック詳細、サークル詳細、リリース詳細、統計

## 影響範囲

* 公開画面の原曲詳細、トラック詳細、サークル詳細、リリース詳細、統計ページ
* APIレスポンスの`artistAliasId`フィールドが必須（non-null）に変更

## 補足事項

統計ページのアーティストランキングをアーティスト単位から名義単位の集計に変更。同じアーティストでも別名義であれば別々にカウントされるようになる。