### PR TITLE
fix: イベント一覧の先頭アコーディオンが閉じない問題を修正

### DIFF
--- a/apps/web/src/routes/_public/events.tsx
+++ b/apps/web/src/routes/_public/events.tsx
@@ -111,16 +111,6 @@ function EventsPage() {
 		}
 	}, [events, selectedYear]);
 
-	// 初期展開シリーズを設定
-	useEffect(() => {
-		if (expandedSeries.size === 0 && events.length > 0) {
-			const firstSeriesId = events.find((e) => e.eventSeriesId)?.eventSeriesId;
-			if (firstSeriesId) {
-				setExpandedSeriesState(new Set([firstSeriesId]));
-			}
-		}
-	}, [events, expandedSeries.size]);
-
 	const setViewMode = (view: EventsViewMode) => {
 		setViewModeState(view);
 		localStorage.setItem(STORAGE_KEY_VIEW, view);


### PR DESCRIPTION
## 概要

イベント一覧ページ（シリーズ別表示モード）で、先頭のアコーディオンを閉じても即座に再展開されてしまうバグを修正。

## 問題の原因

自動展開useEffectの依存配列に`expandedSeries.size`が含まれていたため、以下のループが発生していた：

```
ユーザーがアコーディオンを閉じる
  → expandedSeriesが空になる
  → useEffect再発火（依存配列にexpandedSeries.sizeがあるため）
  → 自動展開ロジック実行
  → アコーディオンが再び開く
```

## 変更内容

* 問題のuseEffect（自動展開ロジック）を削除
* localStorageからの復元のみで展開状態を管理するように変更

## 影響範囲

* 公開画面: `/events`（イベント一覧ページ）
* 初回アクセス時はすべてのアコーディオンが閉じた状態で表示される（以前は先頭が自動展開されていた）