### PR TITLE
feat: 公開画面のUI/UX改善（モバイル対応強化・デザイン統一）

### DIFF
--- a/apps/web/src/components/public/entity-detail-header.tsx
+++ b/apps/web/src/components/public/entity-detail-header.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from "react";
+
+/**
+ * EntityDetailHeader のプロパティ
+ */
+export interface EntityDetailHeaderProps {
+	/**
+	 * グラデーションクラス名（例: "gradient-artist", "gradient-circle", "gradient-release"）
+	 * 指定しない場合は bg-base-100 を使用
+	 */
+	gradientClass?: string;
+	/**
+	 * ヘッダーに表示するアイコン（Lucide アイコンなど）
+	 * アイコンのサイズはコンポーネント内で適切に設定されるため、
+	 * アイコン自体には色クラスのみを指定することを推奨
+	 */
+	icon: ReactNode;
+	/**
+	 * アイコンコンテナのリングカラークラス（例: "ring-primary/20", "ring-info/20"）
+	 * デフォルトは "ring-primary/20"
+	 */
+	iconRingClass?: string;
+	/**
+	 * メインタイトル
+	 */
+	title: string;
+	/**
+	 * サブタイトル（日本語名、別名など）
+	 */
+	subtitle?: string;
+	/**
+	 * バッジ要素の配列
+	 */
+	badges?: ReactNode[];
+	/**
+	 * 追加コンテンツ（外部リンク、メタ情報など）
+	 * ヘッダー右側に表示される
+	 */
+	children?: ReactNode;
+}
+
+/**
+ * 詳細ページ用の統一ヘッダーコンポーネント
+ *
+ * 各エンティティ（アーティスト、サークル、イベント、リリース、トラック、原曲）の
+ * 詳細ページで使用できる再利用可能なヘッダーを提供します。
+ *
+ * @example
+ * ```tsx
+ * // アーティスト詳細ページでの使用例
+ * <EntityDetailHeader
+ *   gradientClass="gradient-artist"
+ *   icon={<User className="size-10 text-primary sm:size-12" />}
+ *   iconRingClass="ring-primary/20"
+ *   title={artist.name}
+ *   subtitle={!artist.isMainName ? artist.artistName : undefined}
+ *   badges={artist.roles.map((role) => (
+ *     <span key={role.roleCode} className="badge badge-primary badge-outline">
+ *       {role.label}
+ *     </span>
+ *   ))}
+ * />
+ *
+ * // サークル詳細ページでの使用例
+ * <EntityDetailHeader
+ *   gradientClass="gradient-circle"
+ *   icon={<Building2 className="size-10 text-info sm:size-12" />}
+ *   iconRingClass="ring-info/20"
+ *   title={circle.name}
+ *   subtitle={circle.nameJa !== circle.name ? circle.nameJa : undefined}
+ *   badges={[
+ *     <span key="initial" className="badge badge-ghost badge-sm">
+ *       {circle.nameInitial}
+ *     </span>
+ *   ]}
+ * >
+ *   {circle.links.map((link) => (
+ *     <ExternalLink key={link.id} href={link.url} className="btn btn-outline btn-sm">
+ *       {link.platformName}
+ *     </ExternalLink>
+ *   ))}
+ * </EntityDetailHeader>
+ * ```
+ */
+export function EntityDetailHeader({
+	gradientClass,
+	icon,
+	iconRingClass = "ring-primary/20",
+	title,
+	subtitle,
+	badges,
+	children,
+}: EntityDetailHeaderProps) {
+	const containerClass = gradientClass
+		? `${gradientClass} rounded-2xl shadow-sm transition-shadow duration-300 hover:shadow-lg`
+		: "rounded-2xl bg-base-100 shadow-sm transition-shadow duration-300 hover:shadow-lg";
+
+	const innerClass = gradientClass ? "glass-card-light rounded-2xl p-6" : "p-6";
+
+	return (
+		<div className={containerClass}>
+			<div className={innerClass}>
+				<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+					{/* 左側: アイコン、タイトル、バッジ */}
+					<div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+						{/* アバター/アイコン */}
+						<div
+							className={`flex size-20 shrink-0 items-center justify-center rounded-full bg-base-100/80 shadow-lg ring-2 ${iconRingClass} transition-transform duration-300 hover:scale-105 sm:size-24`}
+						>
+							{icon}
+						</div>
+
+						<div className="min-w-0 flex-1 space-y-3">
+							{/* タイトルとサブタイトル */}
+							<div>
+								<h1 className="font-bold text-2xl sm:text-3xl">{title}</h1>
+								{subtitle && (
+									<p className="mt-1 text-base-content/70">{subtitle}</p>
+								)}
+							</div>
+
+							{/* バッジ */}
+							{badges && badges.length > 0 && (
+								<div className="flex flex-wrap gap-2">{badges}</div>
+							)}
+						</div>
+					</div>
+
+					{/* 右側: 追加コンテンツ（外部リンクなど） */}
+					{children && (
+						<div className="flex flex-wrap gap-2 sm:shrink-0">{children}</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/public/filter-drawer.tsx
+++ b/apps/web/src/components/public/filter-drawer.tsx
@@ -1,0 +1,169 @@
+import { Filter, RotateCcw, X } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface FilterDrawerProps {
+	/** ドロワーの開閉状態 */
+	isOpen: boolean;
+	/** ドロワーを閉じるコールバック */
+	onClose: () => void;
+	/** ドロワーのタイトル */
+	title?: string;
+	/** フィルターコントロール */
+	children: ReactNode;
+	/** 適用ボタンのコールバック（省略可能） */
+	onApply?: () => void;
+	/** リセットボタンのコールバック（省略可能） */
+	onReset?: () => void;
+	/** トリガーボタンのクラス名 */
+	triggerClassName?: string;
+	/** アクティブなフィルター数（バッジ表示用） */
+	activeFilterCount?: number;
+}
+
+/**
+ * FilterDrawerTrigger: モバイル用フィルタートリガーボタン
+ *
+ * md以上の画面では非表示
+ */
+export function FilterDrawerTrigger({
+	onClick,
+	className,
+	activeFilterCount,
+}: {
+	onClick: () => void;
+	className?: string;
+	activeFilterCount?: number;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={cn(
+				"btn btn-primary gap-2 md:hidden",
+				"min-h-11 px-4",
+				"transition-all duration-300",
+				className,
+			)}
+			aria-label="フィルターを開く"
+		>
+			<Filter className="size-5" aria-hidden="true" />
+			<span>フィルター</span>
+			{activeFilterCount !== undefined && activeFilterCount > 0 && (
+				<span className="badge badge-sm badge-secondary">
+					{activeFilterCount}
+				</span>
+			)}
+		</button>
+	);
+}
+
+/**
+ * FilterDrawer: モバイル用フィルタードロワー
+ *
+ * - 画面下部からスライドアップ表示
+ * - md以上の画面では非表示（デスクトップでは別のフィルターUIを使用）
+ * - glass-card スタイリング
+ * - 適用/リセットボタン（オプション）
+ */
+export function FilterDrawer({
+	isOpen,
+	onClose,
+	title = "フィルター",
+	children,
+	onApply,
+	onReset,
+}: Omit<FilterDrawerProps, "triggerClassName" | "activeFilterCount">) {
+	if (!isOpen) return null;
+
+	const handleApply = () => {
+		onApply?.();
+		onClose();
+	};
+
+	return (
+		<div
+			className="fixed inset-0 z-50 md:hidden"
+			role="dialog"
+			aria-modal="true"
+			aria-label={title}
+		>
+			{/* Backdrop */}
+			<div
+				className="absolute inset-0 animate-[fadeIn_300ms_ease-out] bg-black/60"
+				onClick={onClose}
+				onKeyDown={(e) => e.key === "Escape" && onClose()}
+				role="button"
+				tabIndex={0}
+				aria-label="フィルターを閉じる（背景クリック）"
+			/>
+
+			{/* Drawer - slides up from bottom */}
+			<aside
+				className={cn(
+					"glass-card-strong",
+					"absolute right-0 bottom-0 left-0",
+					"max-h-[85vh] overflow-hidden",
+					"rounded-t-3xl shadow-2xl",
+					"animate-[slideInFromBottom_300ms_ease-out]",
+					"flex flex-col",
+				)}
+			>
+				{/* Header */}
+				<div className="flex shrink-0 items-center justify-between border-base-content/10 border-b p-4">
+					<div className="flex items-center gap-2">
+						<Filter className="size-5 text-primary" aria-hidden="true" />
+						<span className="font-bold text-lg">{title}</span>
+					</div>
+					<button
+						type="button"
+						className="btn btn-ghost btn-circle btn-sm transition-all duration-300 hover:bg-base-200/60"
+						aria-label="フィルターを閉じる"
+						onClick={onClose}
+					>
+						<X className="size-5" />
+					</button>
+				</div>
+
+				{/* Scroll indicator bar */}
+				<div className="flex justify-center py-2">
+					<div className="h-1 w-12 rounded-full bg-base-content/20" />
+				</div>
+
+				{/* Content - scrollable */}
+				<div className="flex-1 overflow-y-auto overscroll-contain px-4 pb-4">
+					{children}
+				</div>
+
+				{/* Footer with action buttons */}
+				{(onApply || onReset) && (
+					<div className="shrink-0 border-base-content/10 border-t bg-base-100/50 p-4">
+						<div className="flex gap-3">
+							{onReset && (
+								<button
+									type="button"
+									onClick={onReset}
+									className="btn btn-ghost flex-1 gap-2"
+								>
+									<RotateCcw className="size-4" aria-hidden="true" />
+									リセット
+								</button>
+							)}
+							{onApply && (
+								<button
+									type="button"
+									onClick={handleApply}
+									className="btn btn-primary flex-1"
+								>
+									適用
+								</button>
+							)}
+						</div>
+					</div>
+				)}
+			</aside>
+		</div>
+	);
+}
+
+export type { FilterDrawerProps };

--- a/apps/web/src/components/public/index.ts
+++ b/apps/web/src/components/public/index.ts
@@ -13,6 +13,10 @@ export {
 } from "./embeds";
 export { EmptyState, type EmptyStateType } from "./empty-state";
 export { type BadgeInfo, EntityCard } from "./entity-card";
+export {
+	EntityDetailHeader,
+	type EntityDetailHeaderProps,
+} from "./entity-detail-header";
 export { ExternalLink } from "./external-link";
 export { FeaturesSection } from "./features-section";
 export {
@@ -28,7 +32,18 @@ export {
 	type FilterButtonProps,
 	type FilterButtonSize,
 } from "./filter-button";
+export {
+	FilterDrawer,
+	type FilterDrawerProps,
+	FilterDrawerTrigger,
+} from "./filter-drawer";
 export { HeroSection } from "./hero-section";
+export {
+	MobileCardItem,
+	type MobileCardItemProps,
+	MobileCardList,
+	type MobileCardListProps,
+} from "./mobile-card-list";
 export { NavigationSection } from "./navigation-section";
 export {
 	calculateTotalPages,
@@ -55,6 +70,11 @@ export {
 	ScriptFilter,
 	TwoStageScriptFilter,
 } from "./script-filter";
+export {
+	type StatItem,
+	StatsCardGrid,
+	type StatsCardGridProps,
+} from "./stats-card-grid";
 export { StatsCards } from "./stats-cards";
 export { StatsPlaceholder } from "./stats-placeholder";
 export { type ViewMode, ViewToggle } from "./view-toggle";

--- a/apps/web/src/components/public/mobile-card-list.tsx
+++ b/apps/web/src/components/public/mobile-card-list.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from "react";
+import { Card } from "../ui/card";
+
+export interface MobileCardListProps<T> {
+	/** Array of items to render */
+	items: T[];
+	/** Render function for each card */
+	renderCard: (item: T, index: number) => ReactNode;
+	/** Function to extract unique key for each item */
+	keyExtractor: (item: T) => string;
+	/** Message to display when items array is empty */
+	emptyMessage?: string;
+	/** Optional className for the container */
+	className?: string;
+}
+
+/**
+ * MobileCardList - A mobile-optimized card list component
+ *
+ * Displays items as cards on mobile (sm breakpoint and below).
+ * Automatically hides on larger screens where table views are shown.
+ *
+ * Features:
+ * - Touch-friendly tap targets (minimum 44px as per WCAG 2.1)
+ * - Glass-card styling with consistent spacing
+ * - Responsive visibility (hidden on sm: and above)
+ */
+export function MobileCardList<T>({
+	items,
+	renderCard,
+	keyExtractor,
+	emptyMessage = "データがありません",
+	className,
+}: MobileCardListProps<T>) {
+	// Only visible on mobile (hidden on sm: breakpoint and above)
+	if (items.length === 0) {
+		return (
+			<div className={`sm:hidden ${className ?? ""}`}>
+				<Card variant="glass" className="p-6 text-center">
+					<p className="text-base-content/60 text-sm">{emptyMessage}</p>
+				</Card>
+			</div>
+		);
+	}
+
+	return (
+		<div className={`space-y-3 sm:hidden ${className ?? ""}`}>
+			{items.map((item, index) => (
+				<div
+					key={keyExtractor(item)}
+					className="min-h-[44px]" // WCAG 2.1 minimum touch target size
+				>
+					{renderCard(item, index)}
+				</div>
+			))}
+		</div>
+	);
+}
+
+/**
+ * MobileCardItem - A pre-styled card item for use within MobileCardList
+ *
+ * Provides consistent glass-card styling with proper padding
+ * and touch-friendly sizing.
+ */
+export interface MobileCardItemProps {
+	children: ReactNode;
+	className?: string;
+	/** Optional onClick handler */
+	onClick?: () => void;
+}
+
+export function MobileCardItem({
+	children,
+	className,
+	onClick,
+}: MobileCardItemProps) {
+	const baseClasses =
+		"min-h-[44px] p-4 transition-all duration-200 active:scale-[0.98]";
+
+	if (onClick) {
+		return (
+			<Card
+				variant="glass"
+				hoverEffect="glow"
+				className={`${baseClasses} cursor-pointer ${className ?? ""}`}
+				onClick={onClick}
+				role="button"
+				tabIndex={0}
+				onKeyDown={(e) => {
+					if (e.key === "Enter" || e.key === " ") {
+						e.preventDefault();
+						onClick();
+					}
+				}}
+			>
+				{children}
+			</Card>
+		);
+	}
+
+	return (
+		<Card variant="glass" className={`${baseClasses} ${className ?? ""}`}>
+			{children}
+		</Card>
+	);
+}

--- a/apps/web/src/components/public/stats-card-grid.tsx
+++ b/apps/web/src/components/public/stats-card-grid.tsx
@@ -1,0 +1,101 @@
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+import { formatNumber } from "../../lib/format";
+
+/**
+ * 統計情報の1項目を表すオブジェクト
+ */
+export interface StatItem {
+	/** 統計ラベル（例: "トラック"、"リリース"） */
+	label: string;
+	/** 統計値（数値または文字列） */
+	value: string | number;
+	/** アイコン（Lucide React等のReactNode、省略可） */
+	icon?: ReactNode;
+	/** リンク先（省略可） */
+	href?: string;
+	/** アイコンの色クラス（例: "text-primary"、"text-secondary"） */
+	iconColorClass?: string;
+}
+
+export interface StatsCardGridProps {
+	/** 統計項目の配列 */
+	items: StatItem[];
+	/** グリッドの列数（デフォルト: 2） */
+	columns?: 2 | 3 | 4;
+	/** カードのスタイルバリアント */
+	variant?: "default" | "glass";
+}
+
+/**
+ * 統計カードを一貫したグリッドレイアウトで表示するコンポーネント
+ *
+ * @example
+ * ```tsx
+ * <StatsCardGrid
+ *   items={[
+ *     { label: "トラック", value: 1234, icon: <Music className="size-5" />, iconColorClass: "text-primary" },
+ *     { label: "リリース", value: 567, icon: <Disc3 className="size-5" />, iconColorClass: "text-secondary" },
+ *   ]}
+ * />
+ * ```
+ */
+export function StatsCardGrid({
+	items,
+	columns = 2,
+	variant = "default",
+}: StatsCardGridProps) {
+	const gridColsClass =
+		columns === 2
+			? "grid-cols-2"
+			: columns === 3
+				? "grid-cols-2 sm:grid-cols-3"
+				: "grid-cols-2 sm:grid-cols-4";
+
+	const cardBaseClass =
+		variant === "glass"
+			? "glass-card-light rounded-2xl p-4 text-center transition-all duration-300 hover:shadow-md"
+			: "rounded-2xl bg-base-200/50 p-4 text-center transition-all duration-300 hover:bg-base-200/70 hover:ring-2 hover:ring-primary/10";
+
+	return (
+		<div className={`grid gap-4 ${gridColsClass}`}>
+			{items.map((item) => (
+				<StatCard key={item.label} item={item} cardClassName={cardBaseClass} />
+			))}
+		</div>
+	);
+}
+
+interface StatCardInternalProps {
+	item: StatItem;
+	cardClassName: string;
+}
+
+function StatCard({ item, cardClassName }: StatCardInternalProps) {
+	const { label, value, icon, href, iconColorClass = "text-primary" } = item;
+
+	const formattedValue =
+		typeof value === "number" ? formatNumber(value) : value;
+
+	const content = (
+		<div className={cardClassName}>
+			<div
+				className={`flex items-center justify-center gap-2 ${iconColorClass}`}
+			>
+				{icon}
+				<span className="font-bold text-2xl">{formattedValue}</span>
+			</div>
+			<p className="mt-1 text-base-content/70 text-sm">{label}</p>
+		</div>
+	);
+
+	if (href) {
+		return (
+			<Link to={href} preload="intent" className="block">
+				{content}
+			</Link>
+		);
+	}
+
+	return content;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -112,6 +112,15 @@
 	}
 }
 
+@keyframes slideInFromBottom {
+	from {
+		transform: translateY(100%);
+	}
+	to {
+		transform: translateY(0);
+	}
+}
+
 /* ========================================
    Entity-specific gradient patterns
    ======================================== */
@@ -153,6 +162,26 @@
 		oklch(from var(--s) l c h / 0.12) 0%,
 		oklch(from var(--n) l c h / 0.08) 50%,
 		oklch(from var(--p) l c h / 0.06) 100%
+	);
+}
+
+/* Event: warm orange-amber gradient */
+.gradient-event {
+	background: linear-gradient(
+		135deg,
+		oklch(from var(--wa) l c h / 0.15) 0%,
+		oklch(from var(--a) l c h / 0.1) 50%,
+		oklch(from var(--s) l c h / 0.08) 100%
+	);
+}
+
+/* Song: calm green-teal gradient */
+.gradient-song {
+	background: linear-gradient(
+		135deg,
+		oklch(from var(--su) l c h / 0.15) 0%,
+		oklch(from var(--in) l c h / 0.1) 50%,
+		oklch(from var(--p) l c h / 0.08) 100%
 	);
 }
 

--- a/apps/web/src/routes/_public/artists.tsx
+++ b/apps/web/src/routes/_public/artists.tsx
@@ -4,6 +4,10 @@ import { Music, Users } from "lucide-react";
 import { useRef, useState } from "react";
 import {
 	EmptyState,
+	FilterDrawer,
+	FilterDrawerTrigger,
+	MobileCardItem,
+	MobileCardList,
 	PublicBreadcrumb,
 	TwoStageScriptFilter,
 	type ViewMode,
@@ -113,6 +117,8 @@ function ArtistsPage() {
 	// 検索入力のローカルステート（IME対応）
 	const [searchInput, setSearchInput] = useState(search);
 	const isComposingRef = useRef(false);
+	// モバイルフィルタードロワーの状態
+	const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false);
 
 	// 型安全なパラメータ
 	const scriptCategory = script as ScriptCategory;
@@ -244,6 +250,21 @@ function ArtistsPage() {
 		});
 	};
 
+	// アクティブフィルターの数を計算（モバイル用）
+	const activeFilterCount =
+		(search ? 1 : 0) +
+		(roleFilter !== "all" ? 1 : 0) +
+		(scriptCategory !== "all" ? 1 : 0);
+
+	// フィルターリセット
+	const handleFilterReset = () => {
+		setSearchInput("");
+		navigate({
+			to: "/artists",
+			search: { view },
+		});
+	};
+
 	return (
 		<div className="space-y-6">
 			<PublicBreadcrumb items={[{ label: "アーティスト" }]} />
@@ -256,11 +277,76 @@ function ArtistsPage() {
 						アーティスト · {formatNumber(total)}件
 					</p>
 				</div>
-				<ViewToggle value={view} onChange={handleViewChange} />
+				<div className="flex items-center gap-2">
+					{/* モバイル用フィルタートリガー */}
+					<FilterDrawerTrigger
+						onClick={() => setIsFilterDrawerOpen(true)}
+						activeFilterCount={activeFilterCount}
+					/>
+					<ViewToggle value={view} onChange={handleViewChange} />
+				</div>
 			</div>
 
-			{/* フィルター */}
-			<div className="space-y-4">
+			{/* モバイル用フィルタードロワー */}
+			<FilterDrawer
+				isOpen={isFilterDrawerOpen}
+				onClose={() => setIsFilterDrawerOpen(false)}
+				title="フィルター"
+				onReset={handleFilterReset}
+			>
+				<div className="space-y-6">
+					{/* キーワード検索 */}
+					<div>
+						<span className="mb-2 block font-medium text-sm">
+							キーワード検索:
+						</span>
+						<SearchInput
+							value={searchInput}
+							onChange={handleSearchChange}
+							onCompositionStart={handleCompositionStart}
+							onCompositionEnd={handleCompositionEnd}
+							placeholder="アーティスト名で検索..."
+							size="sm"
+						/>
+					</div>
+
+					{/* 役割フィルター */}
+					<div>
+						<span className="mb-2 block font-medium text-sm">役割:</span>
+						<div className="flex flex-wrap gap-2">
+							{ROLE_TYPES.map((r) => (
+								<button
+									key={r}
+									type="button"
+									onClick={() => handleRoleChange(r)}
+									className={`btn btn-sm ${
+										roleFilter === r ? "btn-primary" : "btn-ghost"
+									}`}
+									aria-pressed={roleFilter === r}
+								>
+									{roleConfig[r].label}
+								</button>
+							))}
+						</div>
+					</div>
+
+					{/* 文字種フィルター */}
+					<div>
+						<span className="mb-2 block font-medium text-sm">文字種:</span>
+						<TwoStageScriptFilter
+							scriptCategory={scriptCategory}
+							alphabetInitial={alphabetInitial ?? null}
+							kanaRow={kanaRow ?? null}
+							onScriptCategoryChange={handleScriptCategoryChange}
+							onAlphabetInitialChange={handleAlphabetInitialChange}
+							onKanaRowChange={handleKanaRowChange}
+						/>
+					</div>
+				</div>
+			</FilterDrawer>
+
+			{/* デスクトップ用フィルター（md以上で表示） */}
+			<div className="hidden space-y-4 md:block">
 				{/* キーワード検索 */}
 				<div>
 					<span className="mb-2 block font-medium text-sm">
@@ -322,109 +408,167 @@ function ArtistsPage() {
 					title="該当するアーティストがありません"
 					description="フィルター条件を変更してお試しください"
 				/>
-			) : view === "grid" ? (
-				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-					{artists.map((artist) => (
-						<Link
-							key={artist.id}
-							to="/artists/$id"
-							params={{ id: artist.id }}
-							preload="intent"
-							className="card bg-base-100 shadow-sm transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
-						>
-							<div className="card-body p-4">
-								<div className="flex items-center gap-3">
-									<div className="flex size-12 items-center justify-center rounded-full bg-accent/10">
-										<Users className="size-6 text-accent" aria-hidden="true" />
+			) : (
+				<>
+					{/* モバイル用カードリスト */}
+					<MobileCardList
+						items={artists}
+						keyExtractor={(artist) => artist.id}
+						renderCard={(artist) => (
+							<Link
+								to="/artists/$id"
+								params={{ id: artist.id }}
+								preload="intent"
+								className="block"
+							>
+								<MobileCardItem>
+									<div className="flex items-center gap-3">
+										<div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-accent/10">
+											<Users
+												className="size-5 text-accent"
+												aria-hidden="true"
+											/>
+										</div>
+										<div className="min-w-0 flex-1">
+											<h3 className="truncate font-bold text-base">
+												{artist.name}
+											</h3>
+											{artist.name !== artist.artistName && (
+												<p className="truncate text-base-content/60 text-sm">
+													{artist.artistName}
+												</p>
+											)}
+										</div>
 									</div>
-									<div className="min-w-0 flex-1">
-										<h3 className="truncate font-bold text-base">
-											{artist.name}
-										</h3>
-										{artist.name !== artist.artistName && (
-											<p className="truncate text-base-content/60 text-sm">
-												{artist.artistName}
-											</p>
-										)}
+									{/* 役割バッジ */}
+									<div className="mt-2 flex flex-wrap gap-1">
+										{artist.roles.map((role) => (
+											<span
+												key={role.roleCode}
+												className={`badge badge-sm ${getRoleBadgeClass(role.roleCode)}`}
+											>
+												{role.label}
+											</span>
+										))}
 									</div>
-								</div>
-								{/* 役割バッジ */}
-								<div className="mt-2 flex flex-wrap gap-1">
-									{artist.roles.map((role) => (
-										<span
-											key={role.roleCode}
-											className={`badge badge-sm ${getRoleBadgeClass(role.roleCode)}`}
-										>
-											{role.label}
-										</span>
-									))}
-								</div>
-								<div className="mt-3 flex items-center gap-4 text-base-content/70 text-sm">
-									<span className="flex items-center gap-1">
+									<div className="mt-2 flex items-center gap-1 text-base-content/70 text-sm">
 										<Music className="size-4" aria-hidden="true" />
 										{formatNumber(artist.trackCount)}曲
-									</span>
-								</div>
-							</div>
-						</Link>
-					))}
-				</div>
-			) : (
-				<div className="overflow-x-auto">
-					<table className="table">
-						<thead>
-							<tr>
-								<th>アーティスト</th>
-								<th>役割</th>
-								<th>参加曲数</th>
-							</tr>
-						</thead>
-						<tbody>
+									</div>
+								</MobileCardItem>
+							</Link>
+						)}
+					/>
+
+					{/* デスクトップ用表示（sm以上で表示） */}
+					{view === "grid" ? (
+						<div className="hidden grid-cols-1 gap-4 sm:grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 							{artists.map((artist) => (
-								<tr key={artist.id} className="hover:bg-base-200/50">
-									<td>
-										<Link
-											to="/artists/$id"
-											params={{ id: artist.id }}
-											preload="intent"
-											className="flex items-center gap-3 hover:text-primary"
-										>
-											<div className="flex size-8 items-center justify-center rounded-full bg-accent/10">
+								<Link
+									key={artist.id}
+									to="/artists/$id"
+									params={{ id: artist.id }}
+									preload="intent"
+									className="card bg-base-100 shadow-sm transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
+								>
+									<div className="card-body p-4">
+										<div className="flex items-center gap-3">
+											<div className="flex size-12 items-center justify-center rounded-full bg-accent/10">
 												<Users
-													className="size-4 text-accent"
+													className="size-6 text-accent"
 													aria-hidden="true"
 												/>
 											</div>
-											<div>
-												<span className="font-medium">{artist.name}</span>
+											<div className="min-w-0 flex-1">
+												<h3 className="truncate font-bold text-base">
+													{artist.name}
+												</h3>
 												{artist.name !== artist.artistName && (
-													<div className="text-base-content/60 text-xs">
+													<p className="truncate text-base-content/60 text-sm">
 														{artist.artistName}
-													</div>
+													</p>
 												)}
 											</div>
-										</Link>
-									</td>
-									<td>
-										<div className="flex gap-1">
+										</div>
+										{/* 役割バッジ */}
+										<div className="mt-2 flex flex-wrap gap-1">
 											{artist.roles.map((role) => (
 												<span
 													key={role.roleCode}
-													className={`badge badge-sm whitespace-nowrap ${getRoleBadgeClass(role.roleCode)}`}
+													className={`badge badge-sm ${getRoleBadgeClass(role.roleCode)}`}
 												>
 													{role.label}
 												</span>
 											))}
 										</div>
-									</td>
-									<td className="text-base-content/70">
-										{formatNumber(artist.trackCount)}
-									</td>
-								</tr>
+										<div className="mt-3 flex items-center gap-4 text-base-content/70 text-sm">
+											<span className="flex items-center gap-1">
+												<Music className="size-4" aria-hidden="true" />
+												{formatNumber(artist.trackCount)}曲
+											</span>
+										</div>
+									</div>
+								</Link>
 							))}
-						</tbody>
-					</table>
-				</div>
+						</div>
+					) : (
+						<div className="hidden overflow-x-auto sm:block">
+							<table className="table">
+								<thead>
+									<tr>
+										<th>アーティスト</th>
+										<th>役割</th>
+										<th>参加曲数</th>
+									</tr>
+								</thead>
+								<tbody>
+									{artists.map((artist) => (
+										<tr key={artist.id} className="hover:bg-base-200/50">
+											<td>
+												<Link
+													to="/artists/$id"
+													params={{ id: artist.id }}
+													preload="intent"
+													className="flex items-center gap-3 hover:text-primary"
+												>
+													<div className="flex size-8 items-center justify-center rounded-full bg-accent/10">
+														<Users
+															className="size-4 text-accent"
+															aria-hidden="true"
+														/>
+													</div>
+													<div>
+														<span className="font-medium">{artist.name}</span>
+														{artist.name !== artist.artistName && (
+															<div className="text-base-content/60 text-xs">
+																{artist.artistName}
+															</div>
+														)}
+													</div>
+												</Link>
+											</td>
+											<td>
+												<div className="flex gap-1">
+													{artist.roles.map((role) => (
+														<span
+															key={role.roleCode}
+															className={`badge badge-sm whitespace-nowrap ${getRoleBadgeClass(role.roleCode)}`}
+														>
+															{role.label}
+														</span>
+													))}
+												</div>
+											</td>
+											<td className="text-base-content/70">
+												{formatNumber(artist.trackCount)}
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					)}
+				</>
 			)}
 
 			{/* 無限スクロール */}

--- a/apps/web/src/routes/_public/artists_.$id.tsx
+++ b/apps/web/src/routes/_public/artists_.$id.tsx
@@ -4,8 +4,11 @@ import { useCallback, useEffect, useState } from "react";
 import {
 	DetailTabs,
 	EmptyState,
+	EntityDetailHeader,
 	Pagination,
 	PublicBreadcrumb,
+	type StatItem,
+	StatsCardGrid,
 	TabIcons,
 	WorkStatsSection,
 	WorkStatsSkeleton,
@@ -16,7 +19,6 @@ import {
 	parseArtistDetailTab,
 	TAB_LABELS,
 } from "@/lib/detail-tab-utils";
-import { formatNumber } from "@/lib/format";
 import { createPublicArtistHead } from "@/lib/head";
 import { type PublicArtistTrack, publicApi } from "@/lib/public-api";
 import {
@@ -192,126 +194,73 @@ function ArtistDetailPage() {
 				]}
 			/>
 
-			{/* プロフィールカード */}
-			<div className="overflow-hidden rounded-2xl shadow-sm transition-shadow duration-300 hover:shadow-lg">
-				{/* グラデーションヘッダー */}
-				<div className="gradient-artist px-6 py-8">
-					<div className="flex flex-col gap-4 sm:flex-row sm:items-start">
-						{/* アバター */}
-						<div className="flex size-20 shrink-0 items-center justify-center rounded-full bg-base-100/80 shadow-lg transition-transform duration-300 hover:scale-105 sm:size-24">
-							<User className="size-10 text-primary sm:size-12" />
-						</div>
+			{/* プロフィールヘッダー */}
+			<EntityDetailHeader
+				gradientClass="gradient-artist"
+				icon={<User className="size-10 text-primary sm:size-12" />}
+				iconRingClass="ring-primary/20"
+				title={artist.name}
+				subtitle={
+					!artist.isMainName
+						? `${artist.artistName}${artist.aliasTypeCode ? ` (${aliasTypeNames[artist.aliasTypeCode] || artist.aliasTypeCode})` : ""}`
+						: undefined
+				}
+				badges={artist.roles.map((role) => (
+					<span
+						key={role.roleCode}
+						className="badge badge-primary badge-outline hover:badge-primary transition-all duration-300 hover:scale-105"
+					>
+						{role.label}
+					</span>
+				))}
+			/>
 
-						<div className="min-w-0 flex-1 space-y-3">
-							{/* 名前 */}
-							<div>
-								<h1 className="font-bold text-2xl sm:text-3xl">
-									{artist.name}
-								</h1>
-								{!artist.isMainName && (
-									<p className="mt-1 text-base-content/70">
-										{artist.artistName}
-										{artist.aliasTypeCode && (
-											<span className="badge badge-ghost badge-sm ml-2">
-												{aliasTypeNames[artist.aliasTypeCode] ||
-													artist.aliasTypeCode}
-											</span>
-										)}
-									</p>
-								)}
-							</div>
+			{/* 統計カード */}
+			<div className="rounded-2xl bg-base-100 p-6 shadow-sm transition-shadow duration-300 hover:shadow-lg">
+				<StatsCardGrid
+					items={
+						[
+							{
+								label: "トラック",
+								value: artist.stats.trackCount,
+								icon: <Music className="size-5" />,
+								iconColorClass: "text-primary",
+							},
+							{
+								label: "リリース",
+								value: artist.stats.releaseCount,
+								icon: <Disc3 className="size-5" />,
+								iconColorClass: "text-secondary",
+							},
+						] satisfies StatItem[]
+					}
+					columns={2}
+				/>
 
-							{/* 役割バッジ */}
-							<div className="flex flex-wrap gap-2">
-								{artist.roles.map((role) => (
-									<span
-										key={role.roleCode}
-										className="badge badge-primary badge-outline hover:badge-primary transition-all duration-300 hover:scale-105"
-									>
-										{role.label}
-									</span>
-								))}
-							</div>
-						</div>
-					</div>
-				</div>
-
-				{/* 統計カード */}
-				<div className="bg-base-100 p-6">
-					<div className="grid grid-cols-2 gap-4">
-						<div className="rounded-2xl bg-base-200/50 p-4 text-center transition-all duration-300 hover:bg-base-200/70 hover:ring-2 hover:ring-primary/10">
-							<div className="flex items-center justify-center gap-2 text-primary">
-								<Music className="size-5" />
-								<span className="font-bold text-2xl">
-									{formatNumber(artist.stats.trackCount)}
-								</span>
-							</div>
-							<p className="mt-1 text-base-content/70 text-sm">トラック</p>
-						</div>
-						<div className="rounded-2xl bg-base-200/50 p-4 text-center transition-all duration-300 hover:bg-base-200/70 hover:ring-2 hover:ring-secondary/10">
-							<div className="flex items-center justify-center gap-2 text-secondary">
-								<Disc3 className="size-5" />
-								<span className="font-bold text-2xl">
-									{formatNumber(artist.stats.releaseCount)}
-								</span>
-							</div>
-							<p className="mt-1 text-base-content/70 text-sm">リリース</p>
-						</div>
-					</div>
-
-					{/* 他名義セクション - モバイルで折りたたみ */}
-					{hasOtherAliases && (
-						<div className="mt-4 border-base-200 border-t pt-4">
-							{/* モバイル: 折りたたみ */}
-							<div className="sm:hidden">
-								<button
-									type="button"
-									onClick={() => setIsMetaExpanded(!isMetaExpanded)}
-									className="flex min-h-[44px] w-full items-center justify-between rounded-xl px-2 py-2 text-base-content/60 text-sm transition-colors duration-300 hover:bg-base-200/50"
-								>
-									<span>他の名義 ({artist.otherAliases.length}件)</span>
-									<ChevronDown
-										className={`size-5 transition-transform duration-300 ${isMetaExpanded ? "rotate-180" : ""}`}
-									/>
-								</button>
-								{isMetaExpanded && (
-									<div className="mt-2 flex flex-wrap gap-2">
-										{artist.otherAliases.map((alias) => (
-											<Link
-												key={alias.id}
-												to="/artists/$id"
-												params={{ id: alias.id }}
-												preload="intent"
-												className="badge badge-ghost hover:badge-primary min-h-[44px] px-3 transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
-											>
-												{alias.name}
-												{alias.aliasTypeCode && (
-													<span className="ml-1 text-xs opacity-70">
-														(
-														{aliasTypeNames[alias.aliasTypeCode] ||
-															alias.aliasTypeCode}
-														)
-													</span>
-												)}
-												<span className="ml-1 text-xs opacity-70">
-													{alias.trackCount}曲
-												</span>
-											</Link>
-										))}
-									</div>
-								)}
-							</div>
-							{/* デスクトップ: 常に表示 */}
-							<div className="hidden sm:block">
-								<p className="mb-2 text-base-content/60 text-sm">他の名義:</p>
-								<div className="flex flex-wrap gap-2">
+				{/* 他名義セクション - モバイルで折りたたみ */}
+				{hasOtherAliases && (
+					<div className="mt-4 border-base-200 border-t pt-4">
+						{/* モバイル: 折りたたみ */}
+						<div className="sm:hidden">
+							<button
+								type="button"
+								onClick={() => setIsMetaExpanded(!isMetaExpanded)}
+								className="flex min-h-[44px] w-full items-center justify-between rounded-xl px-2 py-2 text-base-content/60 text-sm transition-colors duration-300 hover:bg-base-200/50"
+							>
+								<span>他の名義 ({artist.otherAliases.length}件)</span>
+								<ChevronDown
+									className={`size-5 transition-transform duration-300 ${isMetaExpanded ? "rotate-180" : ""}`}
+								/>
+							</button>
+							{isMetaExpanded && (
+								<div className="mt-2 flex flex-wrap gap-2">
 									{artist.otherAliases.map((alias) => (
 										<Link
 											key={alias.id}
 											to="/artists/$id"
 											params={{ id: alias.id }}
 											preload="intent"
-											className="badge badge-ghost hover:badge-primary transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
+											className="badge badge-ghost hover:badge-primary min-h-[44px] px-3 transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
 										>
 											{alias.name}
 											{alias.aliasTypeCode && (
@@ -328,10 +277,38 @@ function ArtistDetailPage() {
 										</Link>
 									))}
 								</div>
+							)}
+						</div>
+						{/* デスクトップ: 常に表示 */}
+						<div className="hidden sm:block">
+							<p className="mb-2 text-base-content/60 text-sm">他の名義:</p>
+							<div className="flex flex-wrap gap-2">
+								{artist.otherAliases.map((alias) => (
+									<Link
+										key={alias.id}
+										to="/artists/$id"
+										params={{ id: alias.id }}
+										preload="intent"
+										className="badge badge-ghost hover:badge-primary transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
+									>
+										{alias.name}
+										{alias.aliasTypeCode && (
+											<span className="ml-1 text-xs opacity-70">
+												(
+												{aliasTypeNames[alias.aliasTypeCode] ||
+													alias.aliasTypeCode}
+												)
+											</span>
+										)}
+										<span className="ml-1 text-xs opacity-70">
+											{alias.trackCount}曲
+										</span>
+									</Link>
+								))}
 							</div>
 						</div>
-					)}
-				</div>
+					</div>
+				)}
 			</div>
 
 			{/* タブ */}

--- a/apps/web/src/routes/_public/circles.tsx
+++ b/apps/web/src/routes/_public/circles.tsx
@@ -1,9 +1,13 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { Disc, Music, Users } from "lucide-react";
+import { Building2, Disc, Music, Users } from "lucide-react";
 import { useRef, useState } from "react";
 import {
 	EmptyState,
+	FilterDrawer,
+	FilterDrawerTrigger,
+	MobileCardItem,
+	MobileCardList,
 	PublicBreadcrumb,
 	TwoStageScriptFilter,
 	type ViewMode,
@@ -71,6 +75,8 @@ function CirclesPage() {
 	// 検索入力のローカルステート（IME対応）
 	const [searchInput, setSearchInput] = useState(search);
 	const isComposingRef = useRef(false);
+	// モバイルフィルタードロワーの状態
+	const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false);
 
 	// 型安全なパラメータ
 	const scriptCategory = script as ScriptCategory;
@@ -176,6 +182,22 @@ function CirclesPage() {
 		});
 	};
 
+	// アクティブなフィルター数を計算
+	const activeFilterCount =
+		(search ? 1 : 0) +
+		(scriptCategory !== "all" ? 1 : 0) +
+		(alphabetInitial ? 1 : 0) +
+		(kanaRow ? 1 : 0);
+
+	// フィルターをリセット
+	const handleResetFilters = () => {
+		setSearchInput("");
+		navigate({
+			to: "/circles",
+			search: { view },
+		});
+	};
+
 	return (
 		<div className="space-y-6">
 			<PublicBreadcrumb items={[{ label: "サークル" }]} />
@@ -188,11 +210,56 @@ function CirclesPage() {
 						同人サークル · {formatNumber(total)}件
 					</p>
 				</div>
-				<ViewToggle value={view} onChange={handleViewChange} />
+				<div className="flex items-center gap-2">
+					{/* モバイル用フィルタートリガー（md未満で表示） */}
+					<FilterDrawerTrigger
+						onClick={() => setIsFilterDrawerOpen(true)}
+						activeFilterCount={activeFilterCount}
+					/>
+					<ViewToggle value={view} onChange={handleViewChange} />
+				</div>
 			</div>
 
-			{/* フィルター */}
-			<div className="space-y-4">
+			{/* モバイル用フィルタードロワー */}
+			<FilterDrawer
+				isOpen={isFilterDrawerOpen}
+				onClose={() => setIsFilterDrawerOpen(false)}
+				title="フィルター"
+				onReset={handleResetFilters}
+			>
+				<div className="space-y-6">
+					{/* キーワード検索 */}
+					<div>
+						<span className="mb-2 block font-medium text-sm">
+							キーワード検索:
+						</span>
+						<SearchInput
+							value={searchInput}
+							onChange={handleSearchChange}
+							onCompositionStart={handleCompositionStart}
+							onCompositionEnd={handleCompositionEnd}
+							placeholder="サークル名で検索..."
+							size="sm"
+						/>
+					</div>
+
+					{/* 文字種フィルター（2段階） */}
+					<div>
+						<span className="mb-2 block font-medium text-sm">文字種:</span>
+						<TwoStageScriptFilter
+							scriptCategory={scriptCategory}
+							alphabetInitial={alphabetInitial ?? null}
+							kanaRow={kanaRow ?? null}
+							onScriptCategoryChange={handleScriptCategoryChange}
+							onAlphabetInitialChange={handleAlphabetInitialChange}
+							onKanaRowChange={handleKanaRowChange}
+						/>
+					</div>
+				</div>
+			</FilterDrawer>
+
+			{/* デスクトップ用フィルター（md以上で表示） */}
+			<div className="hidden space-y-4 md:block">
 				{/* キーワード検索 */}
 				<div>
 					<span className="mb-2 block font-medium text-sm">
@@ -234,90 +301,144 @@ function CirclesPage() {
 					title="該当するサークルがありません"
 					description="フィルター条件を変更してお試しください"
 				/>
-			) : view === "grid" ? (
-				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-					{circles.map((circle) => (
-						<Link
-							key={circle.id}
-							to="/circles/$id"
-							params={{ id: circle.id }}
-							preload="intent"
-							className="card bg-base-100 shadow-sm transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
-						>
-							<div className="card-body p-4">
-								<div className="flex items-center gap-3">
-									<div className="flex size-12 items-center justify-center rounded-full bg-primary/10">
-										<Users className="size-6 text-primary" aria-hidden="true" />
-									</div>
-									<div className="min-w-0 flex-1">
-										<h3 className="truncate font-bold text-base">
-											{circle.name}
-										</h3>
-										{circle.sortName && (
-											<p className="truncate text-base-content/60 text-sm">
-												{circle.sortName}
-											</p>
-										)}
-									</div>
-								</div>
-								<div className="mt-3 flex items-center gap-4 text-base-content/70 text-sm">
-									<span className="flex items-center gap-1">
-										<Disc className="size-4" aria-hidden="true" />
-										{formatNumber(circle.releaseCount)}リリース
-									</span>
-									<span className="flex items-center gap-1">
-										<Music className="size-4" aria-hidden="true" />
-										{formatNumber(circle.trackCount)}曲
-									</span>
-								</div>
-							</div>
-						</Link>
-					))}
-				</div>
 			) : (
-				<div className="overflow-x-auto">
-					<table className="table">
-						<thead>
-							<tr>
-								<th>サークル名</th>
-								<th>読み</th>
-								<th>リリース数</th>
-								<th>曲数</th>
-							</tr>
-						</thead>
-						<tbody>
+				<>
+					{/* モバイル用カードリスト（sm未満で表示） */}
+					<MobileCardList
+						items={circles}
+						keyExtractor={(circle) => circle.id}
+						renderCard={(circle) => (
+							<Link
+								to="/circles/$id"
+								params={{ id: circle.id }}
+								preload="intent"
+								className="block"
+							>
+								<MobileCardItem>
+									<div className="flex items-center gap-3">
+										<div className="flex size-12 shrink-0 items-center justify-center rounded-full bg-primary/10">
+											<Building2
+												className="size-6 text-primary"
+												aria-hidden="true"
+											/>
+										</div>
+										<div className="min-w-0 flex-1">
+											<h3 className="truncate font-bold text-base">
+												{circle.name}
+											</h3>
+											{circle.sortName && (
+												<p className="truncate text-base-content/60 text-sm">
+													{circle.sortName}
+												</p>
+											)}
+											<div className="mt-2 flex items-center gap-4 text-base-content/70 text-sm">
+												<span className="flex items-center gap-1">
+													<Disc className="size-4" aria-hidden="true" />
+													{formatNumber(circle.releaseCount)}
+												</span>
+												<span className="flex items-center gap-1">
+													<Music className="size-4" aria-hidden="true" />
+													{formatNumber(circle.trackCount)}
+												</span>
+											</div>
+										</div>
+									</div>
+								</MobileCardItem>
+							</Link>
+						)}
+					/>
+
+					{/* デスクトップ用グリッド表示（sm以上で表示） */}
+					{view === "grid" ? (
+						<div className="hidden gap-4 sm:grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 							{circles.map((circle) => (
-								<tr key={circle.id} className="hover:bg-base-200/50">
-									<td>
-										<Link
-											to="/circles/$id"
-											params={{ id: circle.id }}
-											preload="intent"
-											className="flex items-center gap-3 hover:text-primary"
-										>
-											<div className="flex size-8 items-center justify-center rounded-full bg-primary/10">
+								<Link
+									key={circle.id}
+									to="/circles/$id"
+									params={{ id: circle.id }}
+									preload="intent"
+									className="card bg-base-100 shadow-sm transition-all duration-300 hover:shadow-lg hover:ring-2 hover:ring-primary/10"
+								>
+									<div className="card-body p-4">
+										<div className="flex items-center gap-3">
+											<div className="flex size-12 items-center justify-center rounded-full bg-primary/10">
 												<Users
-													className="size-4 text-primary"
+													className="size-6 text-primary"
 													aria-hidden="true"
 												/>
 											</div>
-											<span className="font-medium">{circle.name}</span>
-										</Link>
-									</td>
-									<td className="text-base-content/70">
-										{circle.sortName || "-"}
-									</td>
-									<td className="text-base-content/70">
-										{formatNumber(circle.releaseCount)}
-									</td>
-									<td className="text-base-content/70">
-										{formatNumber(circle.trackCount)}
-									</td>
-								</tr>
+											<div className="min-w-0 flex-1">
+												<h3 className="truncate font-bold text-base">
+													{circle.name}
+												</h3>
+												{circle.sortName && (
+													<p className="truncate text-base-content/60 text-sm">
+														{circle.sortName}
+													</p>
+												)}
+											</div>
+										</div>
+										<div className="mt-3 flex items-center gap-4 text-base-content/70 text-sm">
+											<span className="flex items-center gap-1">
+												<Disc className="size-4" aria-hidden="true" />
+												{formatNumber(circle.releaseCount)}リリース
+											</span>
+											<span className="flex items-center gap-1">
+												<Music className="size-4" aria-hidden="true" />
+												{formatNumber(circle.trackCount)}曲
+											</span>
+										</div>
+									</div>
+								</Link>
 							))}
-						</tbody>
-					</table>
-				</div>
+						</div>
+					) : (
+						/* デスクトップ用テーブル表示（sm以上で表示） */
+						<div className="hidden overflow-x-auto sm:block">
+							<table className="table">
+								<thead>
+									<tr>
+										<th>サークル名</th>
+										<th>読み</th>
+										<th>リリース数</th>
+										<th>曲数</th>
+									</tr>
+								</thead>
+								<tbody>
+									{circles.map((circle) => (
+										<tr key={circle.id} className="hover:bg-base-200/50">
+											<td>
+												<Link
+													to="/circles/$id"
+													params={{ id: circle.id }}
+													preload="intent"
+													className="flex items-center gap-3 hover:text-primary"
+												>
+													<div className="flex size-8 items-center justify-center rounded-full bg-primary/10">
+														<Users
+															className="size-4 text-primary"
+															aria-hidden="true"
+														/>
+													</div>
+													<span className="font-medium">{circle.name}</span>
+												</Link>
+											</td>
+											<td className="text-base-content/70">
+												{circle.sortName || "-"}
+											</td>
+											<td className="text-base-content/70">
+												{formatNumber(circle.releaseCount)}
+											</td>
+											<td className="text-base-content/70">
+												{formatNumber(circle.trackCount)}
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					)}
+				</>
 			)}
 
 			{/* 無限スクロール */}

--- a/apps/web/src/routes/_public/circles_.$id.tsx
+++ b/apps/web/src/routes/_public/circles_.$id.tsx
@@ -11,9 +11,12 @@ import { useCallback, useEffect, useState } from "react";
 import {
 	DetailTabs,
 	EmptyState,
+	EntityDetailHeader,
 	ExternalLink,
 	Pagination,
 	PublicBreadcrumb,
+	type StatItem,
+	StatsCardGrid,
 	TabIcons,
 	type ViewMode,
 	ViewToggle,
@@ -26,7 +29,6 @@ import {
 	parseCircleDetailTab,
 	TAB_LABELS,
 } from "@/lib/detail-tab-utils";
-import { formatNumber } from "@/lib/format";
 import { createPublicCircleHead } from "@/lib/head";
 import {
 	type PublicCircleRelease,
@@ -260,74 +262,62 @@ function CircleDetailPage() {
 				]}
 			/>
 
-			{/* ヘッダー - グラデーション背景 */}
-			<div className="gradient-circle rounded-2xl p-6 shadow-sm transition-shadow duration-300 hover:shadow-lg">
-				<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-					<div className="space-y-3">
-						<div className="flex items-center gap-4">
-							{/* アバター - Building2アイコン使用 */}
-							<div className="flex size-20 shrink-0 items-center justify-center rounded-full bg-info/15 ring-2 ring-info/20">
-								<Building2 className="size-10 text-info" />
-							</div>
-							<div className="space-y-1">
-								<h1 className="font-bold text-2xl sm:text-3xl">
-									{circle.name}
-								</h1>
-								{circle.nameJa && circle.nameJa !== circle.name && (
-									<p className="text-base-content/70">{circle.nameJa}</p>
-								)}
-								{circle.nameInitial && (
-									<span className="badge badge-ghost badge-sm">
-										{circle.nameInitial}
-									</span>
-								)}
-							</div>
-						</div>
-						{circle.notes && (
-							<p className="text-base-content/60 text-sm">{circle.notes}</p>
-						)}
-					</div>
+			{/* ヘッダー - EntityDetailHeader使用 */}
+			<EntityDetailHeader
+				gradientClass="gradient-circle"
+				icon={<Building2 className="size-10 text-info sm:size-12" />}
+				iconRingClass="ring-info/20"
+				title={circle.name}
+				subtitle={
+					circle.nameJa && circle.nameJa !== circle.name
+						? circle.nameJa
+						: undefined
+				}
+				badges={
+					circle.nameInitial
+						? [
+								<span key="initial" className="badge badge-ghost badge-sm">
+									{circle.nameInitial}
+								</span>,
+							]
+						: undefined
+				}
+			>
+				{circle.links.length > 0 &&
+					circle.links.map((link) => (
+						<ExternalLink
+							key={link.id}
+							href={link.url}
+							className="btn btn-outline btn-sm gap-1 transition-all duration-300 hover:shadow-md"
+						>
+							{platformNames[link.platformCode] ||
+								link.platformName ||
+								link.platformCode}
+						</ExternalLink>
+					))}
+			</EntityDetailHeader>
 
-					{/* 外部リンク */}
-					{circle.links.length > 0 && (
-						<div className="flex flex-wrap gap-2">
-							{circle.links.map((link) => (
-								<ExternalLink
-									key={link.id}
-									href={link.url}
-									className="btn btn-outline btn-sm gap-1 transition-all duration-300 hover:shadow-md"
-								>
-									{platformNames[link.platformCode] ||
-										link.platformName ||
-										link.platformCode}
-								</ExternalLink>
-							))}
-						</div>
-					)}
-				</div>
-
-				{/* 統計カード - glass-card-light使用 */}
-				<div className="mt-6 grid grid-cols-2 gap-4">
-					<div className="glass-card-light rounded-2xl p-4 text-center transition-all duration-300 hover:shadow-md">
-						<div className="flex items-center justify-center gap-2 text-primary">
-							<Disc3 className="size-5" />
-							<span className="font-bold text-2xl">
-								{formatNumber(circle.stats.releaseCount)}
-							</span>
-						</div>
-						<p className="mt-1 text-base-content/70 text-sm">リリース</p>
-					</div>
-					<div className="glass-card-light rounded-2xl p-4 text-center transition-all duration-300 hover:shadow-md">
-						<div className="flex items-center justify-center gap-2 text-secondary">
-							<Music className="size-5" />
-							<span className="font-bold text-2xl">
-								{formatNumber(circle.stats.trackCount)}
-							</span>
-						</div>
-						<p className="mt-1 text-base-content/70 text-sm">トラック</p>
-					</div>
-				</div>
-			</div>
+			{/* 統計カード - StatsCardGrid使用 */}
+			<StatsCardGrid
+				items={
+					[
+						{
+							label: "リリース",
+							value: circle.stats.releaseCount,
+							icon: <Disc3 className="size-5" />,
+							iconColorClass: "text-primary",
+						},
+						{
+							label: "トラック",
+							value: circle.stats.trackCount,
+							icon: <Music className="size-5" />,
+							iconColorClass: "text-secondary",
+						},
+					] satisfies StatItem[]
+				}
+				columns={2}
+				variant="default"
+			/>
 
 			{/* タブ */}
 			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/src/routes/_public/events.tsx
+++ b/apps/web/src/routes/_public/events.tsx
@@ -1,7 +1,12 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { Calendar, ChevronDown, ChevronRight, Disc } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { EmptyState, PublicBreadcrumb } from "@/components/public";
+import {
+	EmptyState,
+	MobileCardItem,
+	MobileCardList,
+	PublicBreadcrumb,
+} from "@/components/public";
 import { SearchInput } from "@/components/ui/search-input";
 import { formatNumber } from "@/lib/format";
 import { createPageHead } from "@/lib/head";
@@ -252,61 +257,110 @@ function EventsPage() {
 				(eventsBySeries.length === 0 ? (
 					<EmptyState type="empty" title="イベントがありません" />
 				) : (
-					<div className="space-y-2">
-						{eventsBySeries.map((series) => (
-							<div
-								key={series.id}
-								className="overflow-hidden rounded-lg border border-base-300 bg-base-100"
-							>
-								{/* シリーズヘッダー */}
-								<button
-									type="button"
-									className="flex w-full items-center justify-between p-4 text-left transition-colors hover:bg-base-200/50"
-									onClick={() => toggleSeries(series.id)}
-									aria-expanded={expandedSeries.has(series.id)}
+					<>
+						{/* モバイル用カードリスト */}
+						<MobileCardList
+							items={eventsBySeries.flatMap((series) => series.events)}
+							keyExtractor={(event) => event.id}
+							emptyMessage="イベントがありません"
+							renderCard={(event) => (
+								<Link
+									to="/events/$id"
+									params={{ id: event.id }}
+									preload="intent"
+									className="block"
 								>
-									<div className="flex items-center gap-3">
-										{expandedSeries.has(series.id) ? (
-											<ChevronDown className="size-5" aria-hidden="true" />
-										) : (
-											<ChevronRight className="size-5" aria-hidden="true" />
-										)}
-										<span className="font-bold text-lg">{series.name}</span>
-									</div>
-									<span className="badge badge-ghost">
-										{series.events.length}回
-									</span>
-								</button>
-
-								{/* イベントリスト */}
-								{expandedSeries.has(series.id) && (
-									<div className="border-base-300 border-t">
-										{series.events.map((event) => (
-											<Link
-												key={event.id}
-												to="/events/$id"
-												params={{ id: event.id }}
-												preload="intent"
-												className="flex items-center justify-between border-base-200 border-b px-4 py-3 pl-12 last:border-b-0 hover:bg-base-200/30"
-											>
-												<div className="flex items-center gap-4">
-													<span className="font-medium">{event.name}</span>
-													<span className="flex items-center gap-1 text-base-content/60 text-sm">
-														<Calendar className="size-4" aria-hidden="true" />
+									<MobileCardItem className="gradient-event">
+										<div className="flex items-start gap-3">
+											<div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-warning/10 ring-2 ring-warning/20">
+												<Calendar
+													className="size-5 text-warning"
+													aria-hidden="true"
+												/>
+											</div>
+											<div className="min-w-0 flex-1 space-y-1">
+												<h3 className="font-bold text-base leading-tight">
+													{event.name}
+												</h3>
+												<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-base-content/70 text-sm">
+													<span className="flex items-center gap-1">
+														<Calendar className="size-3.5" aria-hidden="true" />
 														{formatDateRange(event.startDate, event.endDate)}
 													</span>
+													{event.eventSeriesName && (
+														<span className="truncate text-base-content/50">
+															{event.eventSeriesName}
+														</span>
+													)}
 												</div>
-												<span className="flex items-center gap-1 text-base-content/70 text-sm">
-													<Disc className="size-4" aria-hidden="true" />
+												<div className="flex items-center gap-1 text-base-content/60 text-sm">
+													<Disc className="size-3.5" aria-hidden="true" />
 													{formatNumber(event.releaseCount)}リリース
-												</span>
-											</Link>
-										))}
-									</div>
-								)}
-							</div>
-						))}
-					</div>
+												</div>
+											</div>
+										</div>
+									</MobileCardItem>
+								</Link>
+							)}
+						/>
+
+						{/* デスクトップ用アコーディオン表示 */}
+						<div className="hidden space-y-2 sm:block">
+							{eventsBySeries.map((series) => (
+								<div
+									key={series.id}
+									className="overflow-hidden rounded-lg border border-base-300 bg-base-100"
+								>
+									{/* シリーズヘッダー */}
+									<button
+										type="button"
+										className="flex w-full items-center justify-between p-4 text-left transition-colors hover:bg-base-200/50"
+										onClick={() => toggleSeries(series.id)}
+										aria-expanded={expandedSeries.has(series.id)}
+									>
+										<div className="flex items-center gap-3">
+											{expandedSeries.has(series.id) ? (
+												<ChevronDown className="size-5" aria-hidden="true" />
+											) : (
+												<ChevronRight className="size-5" aria-hidden="true" />
+											)}
+											<span className="font-bold text-lg">{series.name}</span>
+										</div>
+										<span className="badge badge-ghost">
+											{series.events.length}回
+										</span>
+									</button>
+
+									{/* イベントリスト */}
+									{expandedSeries.has(series.id) && (
+										<div className="border-base-300 border-t">
+											{series.events.map((event) => (
+												<Link
+													key={event.id}
+													to="/events/$id"
+													params={{ id: event.id }}
+													preload="intent"
+													className="flex items-center justify-between border-base-200 border-b px-4 py-3 pl-12 last:border-b-0 hover:bg-base-200/30"
+												>
+													<div className="flex items-center gap-4">
+														<span className="font-medium">{event.name}</span>
+														<span className="flex items-center gap-1 text-base-content/60 text-sm">
+															<Calendar className="size-4" aria-hidden="true" />
+															{formatDateRange(event.startDate, event.endDate)}
+														</span>
+													</div>
+													<span className="flex items-center gap-1 text-base-content/70 text-sm">
+														<Disc className="size-4" aria-hidden="true" />
+														{formatNumber(event.releaseCount)}リリース
+													</span>
+												</Link>
+											))}
+										</div>
+									)}
+								</div>
+							))}
+						</div>
+					</>
 				))}
 
 			{/* 年別表示 */}
@@ -334,63 +388,140 @@ function EventsPage() {
 						{eventsByYear
 							.filter((group) => group.year === selectedYear)
 							.map((group) => (
-								<div
-									key={group.year}
-									className="overflow-hidden rounded-lg border border-base-300 bg-base-100"
-								>
-									<div className="border-base-300 border-b bg-base-200/50 px-4 py-3">
-										<h2 className="font-bold text-lg">{group.year}年</h2>
-										<p className="text-base-content/70 text-sm">
-											{group.events.length}イベント
-										</p>
+								<div key={group.year}>
+									{/* モバイル用カードリスト */}
+									<div className="sm:hidden">
+										<div className="mb-3 rounded-lg bg-base-200/50 px-4 py-3">
+											<h2 className="font-bold text-lg">{group.year}年</h2>
+											<p className="text-base-content/70 text-sm">
+												{group.events.length}イベント
+											</p>
+										</div>
+										<MobileCardList
+											items={group.events}
+											keyExtractor={(event) => event.id}
+											emptyMessage="イベントがありません"
+											renderCard={(event) => {
+												const month = event.startDate
+													? Number.parseInt(event.startDate.split("-")[1], 10)
+													: null;
+												return (
+													<Link
+														to="/events/$id"
+														params={{ id: event.id }}
+														preload="intent"
+														className="block"
+													>
+														<MobileCardItem className="gradient-event">
+															<div className="flex items-start gap-3">
+																<div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-warning/10 ring-2 ring-warning/20">
+																	<Calendar
+																		className="size-5 text-warning"
+																		aria-hidden="true"
+																	/>
+																</div>
+																<div className="min-w-0 flex-1 space-y-1">
+																	<h3 className="font-bold text-base leading-tight">
+																		{event.name}
+																	</h3>
+																	<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-base-content/70 text-sm">
+																		{month && (
+																			<span className="font-medium text-warning">
+																				{month}月
+																			</span>
+																		)}
+																		<span className="flex items-center gap-1">
+																			<Calendar
+																				className="size-3.5"
+																				aria-hidden="true"
+																			/>
+																			{formatDateRange(
+																				event.startDate,
+																				event.endDate,
+																			)}
+																		</span>
+																	</div>
+																	<div className="flex items-center gap-1 text-base-content/60 text-sm">
+																		<Disc
+																			className="size-3.5"
+																			aria-hidden="true"
+																		/>
+																		{formatNumber(event.releaseCount)}リリース
+																	</div>
+																</div>
+															</div>
+														</MobileCardItem>
+													</Link>
+												);
+											}}
+										/>
 									</div>
-									<div className="overflow-x-auto">
-										<table className="table">
-											<thead>
-												<tr>
-													<th>月</th>
-													<th>イベント名</th>
-													<th>開催日</th>
-													<th>リリース数</th>
-												</tr>
-											</thead>
-											<tbody>
-												{group.events.map((event) => {
-													const month = event.startDate
-														? Number.parseInt(event.startDate.split("-")[1], 10)
-														: null;
-													return (
-														<tr key={event.id} className="hover:bg-base-200/50">
-															<td className="text-base-content/70">
-																{month ? `${month}月` : "-"}
-															</td>
-															<td>
-																<Link
-																	to="/events/$id"
-																	params={{ id: event.id }}
-																	preload="intent"
-																	className="font-medium hover:text-primary"
-																>
-																	{event.name}
-																</Link>
-															</td>
-															<td className="text-base-content/70">
-																{formatDateRange(
-																	event.startDate,
-																	event.endDate,
-																)}
-															</td>
-															<td className="text-base-content/70">
-																<span className="flex items-center gap-1">
-																	<Disc className="size-4" aria-hidden="true" />
-																	{formatNumber(event.releaseCount)}
-																</span>
-															</td>
-														</tr>
-													);
-												})}
-											</tbody>
-										</table>
+
+									{/* デスクトップ用テーブル表示 */}
+									<div className="hidden overflow-hidden rounded-lg border border-base-300 bg-base-100 sm:block">
+										<div className="border-base-300 border-b bg-base-200/50 px-4 py-3">
+											<h2 className="font-bold text-lg">{group.year}年</h2>
+											<p className="text-base-content/70 text-sm">
+												{group.events.length}イベント
+											</p>
+										</div>
+										<div className="overflow-x-auto">
+											<table className="table">
+												<thead>
+													<tr>
+														<th>月</th>
+														<th>イベント名</th>
+														<th>開催日</th>
+														<th>リリース数</th>
+													</tr>
+												</thead>
+												<tbody>
+													{group.events.map((event) => {
+														const month = event.startDate
+															? Number.parseInt(
+																	event.startDate.split("-")[1],
+																	10,
+																)
+															: null;
+														return (
+															<tr
+																key={event.id}
+																className="hover:bg-base-200/50"
+															>
+																<td className="text-base-content/70">
+																	{month ? `${month}月` : "-"}
+																</td>
+																<td>
+																	<Link
+																		to="/events/$id"
+																		params={{ id: event.id }}
+																		preload="intent"
+																		className="font-medium hover:text-primary"
+																	>
+																		{event.name}
+																	</Link>
+																</td>
+																<td className="text-base-content/70">
+																	{formatDateRange(
+																		event.startDate,
+																		event.endDate,
+																	)}
+																</td>
+																<td className="text-base-content/70">
+																	<span className="flex items-center gap-1">
+																		<Disc
+																			className="size-4"
+																			aria-hidden="true"
+																		/>
+																		{formatNumber(event.releaseCount)}
+																	</span>
+																</td>
+															</tr>
+														);
+													})}
+												</tbody>
+											</table>
+										</div>
 									</div>
 								</div>
 							))}

--- a/apps/web/src/routes/_public/events_.$id.tsx
+++ b/apps/web/src/routes/_public/events_.$id.tsx
@@ -4,8 +4,11 @@ import { useCallback, useEffect, useState } from "react";
 import {
 	DetailTabs,
 	EmptyState,
+	EntityDetailHeader,
 	Pagination,
 	PublicBreadcrumb,
+	type StatItem,
+	StatsCardGrid,
 	TabIcons,
 	type ViewMode,
 	ViewToggle,
@@ -18,7 +21,6 @@ import {
 	parseEventDetailTab,
 	TAB_LABELS,
 } from "@/lib/detail-tab-utils";
-import { formatNumber } from "@/lib/format";
 import { createPublicEventHead } from "@/lib/head";
 import { type PublicEventRelease, publicApi } from "@/lib/public-api";
 import {
@@ -189,6 +191,73 @@ function EventDetailPage() {
 		return `${event.startDate} 〜 ${event.endDate}`;
 	};
 
+	// バッジを構築
+	const headerBadges: React.ReactNode[] = [];
+
+	// 日程バッジ
+	const dateRange = formatDateRange();
+	if (dateRange) {
+		headerBadges.push(
+			<span
+				key="date"
+				className="badge badge-warning badge-outline flex items-center gap-1"
+			>
+				<Calendar className="size-3" />
+				{dateRange}
+			</span>,
+		);
+	}
+
+	// 会場バッジ
+	if (event.venue) {
+		headerBadges.push(
+			<span key="venue" className="badge badge-ghost flex items-center gap-1">
+				<MapPin className="size-3" />
+				{event.venue}
+			</span>,
+		);
+	}
+
+	// 開催日数バッジ
+	if (event.totalDays) {
+		headerBadges.push(
+			<span key="days" className="badge badge-outline">
+				{event.totalDays}日間
+			</span>,
+		);
+	}
+
+	// イベント日バッジ
+	for (const day of event.eventDays) {
+		headerBadges.push(
+			<span key={day.id} className="badge badge-ghost">
+				{day.dayNumber}日目: {day.date}
+			</span>,
+		);
+	}
+
+	// 統計項目
+	const statsItems: StatItem[] = [
+		{
+			label: "リリース",
+			value: event.stats.releaseCount,
+			icon: <Disc3 className="size-5" />,
+			iconColorClass: "text-primary",
+		},
+		{
+			label: "サークル",
+			value: event.stats.circleCount,
+			icon: <Users className="size-5" />,
+			iconColorClass: "text-secondary",
+		},
+		{
+			label: "トラック",
+			value: event.stats.trackCount,
+			icon: <Music className="size-5" />,
+			iconColorClass: "text-accent",
+		},
+	];
+
 	return (
 		<div className="space-y-6">
 			<PublicBreadcrumb
@@ -196,77 +265,17 @@ function EventDetailPage() {
 			/>
 
 			{/* ヘッダー */}
-			<div className="rounded-2xl bg-base-100 p-6 shadow-sm">
-				<div className="space-y-3">
-					<div>
-						{event.eventSeriesName && (
-							<p className="text-base-content/60 text-sm">
-								{event.eventSeriesName}
-							</p>
-						)}
-						<h1 className="font-bold text-2xl sm:text-3xl">{event.name}</h1>
-					</div>
-					<div className="flex flex-wrap items-center gap-4 text-base-content/70">
-						{formatDateRange() && (
-							<span className="flex items-center gap-1">
-								<Calendar className="size-4" />
-								{formatDateRange()}
-							</span>
-						)}
-						{event.venue && (
-							<span className="flex items-center gap-1">
-								<MapPin className="size-4" />
-								{event.venue}
-							</span>
-						)}
-						{event.totalDays && (
-							<span className="badge badge-outline">{event.totalDays}日間</span>
-						)}
-					</div>
+			<EntityDetailHeader
+				gradientClass="gradient-event"
+				icon={<Calendar className="size-10 text-warning sm:size-12" />}
+				iconRingClass="ring-warning/20"
+				title={event.name}
+				subtitle={event.eventSeriesName ?? undefined}
+				badges={headerBadges.length > 0 ? headerBadges : undefined}
+			/>
 
-					{/* イベント日 */}
-					{event.eventDays.length > 0 && (
-						<div className="flex flex-wrap gap-2 pt-2">
-							{event.eventDays.map((day) => (
-								<span key={day.id} className="badge badge-ghost">
-									{day.dayNumber}日目: {day.date}
-								</span>
-							))}
-						</div>
-					)}
-				</div>
-
-				{/* 統計カード */}
-				<div className="mt-6 grid grid-cols-3 gap-4">
-					<div className="rounded-2xl bg-base-200/50 p-4 text-center">
-						<div className="flex items-center justify-center gap-2 text-primary">
-							<Disc3 className="size-5" />
-							<span className="font-bold text-2xl">
-								{formatNumber(event.stats.releaseCount)}
-							</span>
-						</div>
-						<p className="mt-1 text-base-content/70 text-sm">リリース</p>
-					</div>
-					<div className="rounded-2xl bg-base-200/50 p-4 text-center">
-						<div className="flex items-center justify-center gap-2 text-secondary">
-							<Users className="size-5" />
-							<span className="font-bold text-2xl">
-								{formatNumber(event.stats.circleCount)}
-							</span>
-						</div>
-						<p className="mt-1 text-base-content/70 text-sm">サークル</p>
-					</div>
-					<div className="rounded-2xl bg-base-200/50 p-4 text-center">
-						<div className="flex items-center justify-center gap-2 text-accent">
-							<Music className="size-5" />
-							<span className="font-bold text-2xl">
-								{formatNumber(event.stats.trackCount)}
-							</span>
-						</div>
-						<p className="mt-1 text-base-content/70 text-sm">トラック</p>
-					</div>
-				</div>
-			</div>
+			{/* 統計カード */}
+			<StatsCardGrid items={statsItems} columns={3} />
 
 			{/* タブ */}
 			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/src/routes/_public/original-songs.tsx
+++ b/apps/web/src/routes/_public/original-songs.tsx
@@ -1,7 +1,13 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { ChevronRight, Loader2, Music } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { PublicBreadcrumb } from "@/components/public";
+import {
+	FilterDrawer,
+	FilterDrawerTrigger,
+	MobileCardItem,
+	MobileCardList,
+	PublicBreadcrumb,
+} from "@/components/public";
 import { formatNumber } from "@/lib/format";
 import { createPageHead } from "@/lib/head";
 import {
@@ -78,6 +84,9 @@ function OriginalSongsPage() {
 	const navigate = useNavigate({ from: Route.fullPath });
 	const { type = "all", open } = Route.useSearch();
 	const { categories, works, totalSongCount } = Route.useLoaderData();
+
+	// モバイルフィルタードロワーの状態
+	const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false);
 
 	// 遅延読み込み用の状態管理
 	const [songCache, setSongCache] = useState<Map<string, PublicSongItem[]>>(
@@ -196,7 +205,13 @@ function OriginalSongsPage() {
 		navigate({
 			search: { type: newType, open: undefined },
 		});
+
+		// モバイルフィルタードロワーを閉じる
+		setIsFilterDrawerOpen(false);
 	};
+
+	// アクティブなフィルター数を計算
+	const activeFilterCount = type !== "all" ? 1 : 0;
 
 	return (
 		<div className="space-y-6">
@@ -210,19 +225,58 @@ function OriginalSongsPage() {
 						東方Project公式楽曲 · {works.length}作品 · {totalSongCount}曲
 					</p>
 				</div>
-				<Link
-					to="/official-works"
-					preload="intent"
-					className="btn btn-outline btn-sm gap-1"
-				>
-					<Music className="size-4" />
-					公式作品一覧
-					<ChevronRight className="size-4" />
-				</Link>
+				<div className="flex gap-2">
+					{/* モバイルフィルターボタン */}
+					<FilterDrawerTrigger
+						onClick={() => setIsFilterDrawerOpen(true)}
+						activeFilterCount={activeFilterCount}
+					/>
+					<Link
+						to="/official-works"
+						preload="intent"
+						className="btn btn-outline btn-sm gap-1"
+					>
+						<Music className="size-4" />
+						<span className="xs:inline hidden">公式作品一覧</span>
+						<span className="xs:hidden">公式作品</span>
+						<ChevronRight className="size-4" />
+					</Link>
+				</div>
 			</div>
 
-			{/* Step 1: カテゴリフィルター */}
-			<div className="space-y-2">
+			{/* モバイルフィルタードロワー */}
+			<FilterDrawer
+				isOpen={isFilterDrawerOpen}
+				onClose={() => setIsFilterDrawerOpen(false)}
+				title="カテゴリで絞り込み"
+			>
+				<div className="space-y-4">
+					<div className="flex flex-wrap gap-2">
+						<button
+							type="button"
+							className={`btn btn-sm ${type === "all" ? "btn-primary" : "btn-ghost"}`}
+							onClick={() => handleTypeChange("all")}
+							aria-pressed={type === "all"}
+						>
+							すべて
+						</button>
+						{categories.map((cat: PublicCategory) => (
+							<button
+								key={cat.code}
+								type="button"
+								className={`btn btn-sm ${type === cat.code ? "btn-primary" : "btn-ghost"}`}
+								onClick={() => handleTypeChange(cat.code)}
+								aria-pressed={type === cat.code}
+							>
+								{cat.name}
+							</button>
+						))}
+					</div>
+				</div>
+			</FilterDrawer>
+
+			{/* Step 1: カテゴリフィルター（デスクトップのみ） */}
+			<div className="hidden space-y-2 md:block">
 				<h2 className="font-medium text-base-content/70 text-sm">
 					カテゴリを選択
 				</h2>
@@ -249,8 +303,18 @@ function OriginalSongsPage() {
 				</div>
 			</div>
 
-			{/* Step 2: 作品アコーディオン */}
-			<div className="space-y-2">
+			{/* モバイル: 選択中のカテゴリ表示 */}
+			{type !== "all" && (
+				<div className="md:hidden">
+					<span className="badge badge-primary gap-1">
+						{categories.find((c: PublicCategory) => c.code === type)?.name ||
+							type}
+					</span>
+				</div>
+			)}
+
+			{/* Step 2: 作品アコーディオン（デスクトップ） */}
+			<div className="hidden space-y-2 sm:block">
 				<h2 className="font-medium text-base-content/70 text-sm">
 					作品を選択して楽曲を表示
 				</h2>
@@ -274,6 +338,44 @@ function OriginalSongsPage() {
 					</div>
 				)}
 			</div>
+
+			{/* Step 2: 作品カードリスト（モバイル） */}
+			<MobileCardList
+				items={works}
+				keyExtractor={(work: PublicWorkItem) => work.id}
+				emptyMessage="選択したカテゴリに作品がありません"
+				renderCard={(work: PublicWorkItem) => (
+					<Link
+						to="/official-works/$id"
+						params={{ id: work.id }}
+						preload="intent"
+						className="block"
+					>
+						<MobileCardItem className="gradient-song">
+							<div className="flex items-center gap-3">
+								<div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-success/20">
+									<Music className="size-5 text-success" aria-hidden="true" />
+								</div>
+								<div className="min-w-0 flex-1">
+									<h3 className="truncate font-bold text-base">
+										{work.nameJa}
+									</h3>
+									{work.nameEn && work.nameEn !== work.nameJa && (
+										<p className="truncate text-base-content/60 text-sm">
+											{work.nameEn}
+										</p>
+									)}
+								</div>
+								<div className="shrink-0 text-right">
+									<span className="badge badge-success badge-sm">
+										{work.songCount ?? 0}曲
+									</span>
+								</div>
+							</div>
+						</MobileCardItem>
+					</Link>
+				)}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/routes/_public/releases_.$id.tsx
+++ b/apps/web/src/routes/_public/releases_.$id.tsx
@@ -3,8 +3,11 @@ import { Calendar, Disc, Disc3, Music, Users } from "lucide-react";
 import { useMemo } from "react";
 import {
 	EmptyState,
+	EntityDetailHeader,
 	PublicationLinks,
 	PublicBreadcrumb,
+	type StatItem,
+	StatsCardGrid,
 } from "@/components/public";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPublicReleaseHead } from "@/lib/head";
@@ -109,94 +112,81 @@ function ReleaseDetailPage() {
 				]}
 			/>
 
-			{/* ヘッダー - グラデーション背景 */}
-			<div className="gradient-release overflow-hidden rounded-2xl shadow-sm transition-shadow duration-300 hover:shadow-lg">
-				<div className="glass-card-light rounded-2xl p-6">
-					<div className="flex flex-col gap-6 sm:flex-row">
-						{/* ジャケット画像エリア（プレースホルダー） */}
-						<div className="group relative mx-auto flex size-40 shrink-0 items-center justify-center rounded-2xl bg-base-200/70 transition-all duration-300 hover:ring-2 hover:ring-primary/10 sm:mx-0 sm:size-48">
-							<Disc className="size-16 text-primary/60 transition-transform duration-300 group-hover:scale-110 sm:size-20" />
-							{/* オーバーレイ効果 */}
-							<div className="absolute inset-0 rounded-2xl bg-gradient-to-t from-base-content/5 to-transparent" />
-						</div>
-
-						{/* リリース情報 */}
-						<div className="flex flex-1 flex-col justify-center space-y-4">
-							{/* リリースタイプバッジとタイトル */}
-							<div className="space-y-2">
-								{release.releaseType && (
-									<span
-										className={`badge ${releaseTypeBadgeColors[release.releaseType] ?? "badge-ghost"}`}
-									>
-										{releaseTypeNames[release.releaseType] ??
-											release.releaseType}
-									</span>
-								)}
-								<h1 className="font-bold text-2xl sm:text-3xl">
-									{release.name}
-								</h1>
-							</div>
-
-							{/* サークル一覧 */}
-							{release.circles.length > 0 && (
-								<div className="flex flex-wrap items-center gap-2">
-									{release.circles
-										.sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
-										.map((circle, idx) => (
-											<CircleBadge
-												key={`${circle.circleId}-${idx}`}
-												circle={circle}
-											/>
-										))}
-								</div>
-							)}
-
-							{/* イベント・発売日 */}
-							<div className="flex flex-wrap items-center gap-4 text-base-content/60 text-sm">
-								{release.event && (
-									<Link
-										to="/events/$id"
-										params={{ id: release.event.id }}
-										preload="intent"
-										className="flex min-h-11 items-center gap-1 rounded-lg px-2 py-2 transition-colors duration-300 hover:bg-base-200/50 hover:text-primary"
-									>
-										<Calendar className="size-4" />
-										{release.event.name}
-									</Link>
-								)}
-								{release.releaseDate && (
-									<span className="flex items-center gap-1">
-										<Calendar className="size-4" />
-										{release.releaseDate}
-									</span>
-								)}
-							</div>
-						</div>
+			{/* ヘッダー - EntityDetailHeader + StatsCardGrid */}
+			<EntityDetailHeader
+				gradientClass="gradient-release"
+				icon={<Disc className="size-10 text-primary/80 sm:size-12" />}
+				iconRingClass="ring-primary/20"
+				title={release.name}
+				badges={
+					release.releaseType
+						? [
+								<span
+									key="releaseType"
+									className={`badge ${releaseTypeBadgeColors[release.releaseType] ?? "badge-ghost"}`}
+								>
+									{releaseTypeNames[release.releaseType] ?? release.releaseType}
+								</span>,
+							]
+						: undefined
+				}
+			>
+				{/* サークル一覧 */}
+				{release.circles.length > 0 && (
+					<div className="flex flex-wrap items-center gap-2">
+						{release.circles
+							.sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+							.map((circle, idx) => (
+								<CircleBadge
+									key={`${circle.circleId}-${idx}`}
+									circle={circle}
+								/>
+							))}
 					</div>
+				)}
 
-					{/* 統計カード */}
-					<div className="mt-6 grid grid-cols-2 gap-4">
-						<div className="rounded-2xl bg-base-100/70 p-4 text-center transition-all duration-300 hover:bg-base-100 hover:shadow-md">
-							<div className="flex items-center justify-center gap-2 text-primary">
-								<Music className="size-5" />
-								<span className="font-bold text-2xl">{release.trackCount}</span>
-							</div>
-							<p className="mt-1 text-base-content/70 text-sm">トラック数</p>
-						</div>
-						<div className="rounded-2xl bg-base-100/70 p-4 text-center transition-all duration-300 hover:bg-base-100 hover:shadow-md">
-							<div className="flex items-center justify-center gap-2 text-secondary">
-								<Users className="size-5" />
-								<span className="font-bold text-2xl">
-									{release.artistCount}
-								</span>
-							</div>
-							<p className="mt-1 text-base-content/70 text-sm">
-								参加アーティスト
-							</p>
-						</div>
-					</div>
+				{/* イベント・発売日 */}
+				<div className="flex flex-wrap items-center gap-4 text-base-content/60 text-sm">
+					{release.event && (
+						<Link
+							to="/events/$id"
+							params={{ id: release.event.id }}
+							preload="intent"
+							className="flex min-h-11 items-center gap-1 rounded-lg px-2 py-2 transition-colors duration-300 hover:bg-base-200/50 hover:text-primary"
+						>
+							<Calendar className="size-4" />
+							{release.event.name}
+						</Link>
+					)}
+					{release.releaseDate && (
+						<span className="flex items-center gap-1">
+							<Calendar className="size-4" />
+							{release.releaseDate}
+						</span>
+					)}
 				</div>
-			</div>
+			</EntityDetailHeader>
+
+			{/* 統計カード */}
+			<StatsCardGrid
+				items={
+					[
+						{
+							label: "トラック数",
+							value: release.trackCount,
+							icon: <Music className="size-5" />,
+							iconColorClass: "text-primary",
+						},
+						{
+							label: "参加アーティスト",
+							value: release.artistCount,
+							icon: <Users className="size-5" />,
+							iconColorClass: "text-secondary",
+						},
+					] satisfies StatItem[]
+				}
+				columns={2}
+			/>
 
 			{/* トラックリスト */}
 			<div className="space-y-4">

--- a/apps/web/src/routes/_public/tracks_.$id.tsx
+++ b/apps/web/src/routes/_public/tracks_.$id.tsx
@@ -8,7 +8,11 @@ import {
 	Music,
 } from "lucide-react";
 import { useMemo } from "react";
-import { PublicationLinks, PublicBreadcrumb } from "@/components/public";
+import {
+	EntityDetailHeader,
+	PublicationLinks,
+	PublicBreadcrumb,
+} from "@/components/public";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPublicTrackHead } from "@/lib/head";
 import { type PublicTrackDetail, publicApi } from "@/lib/public-api";
@@ -112,49 +116,54 @@ function TrackDetailPage() {
 			/>
 
 			{/* ヘッダー */}
-			<div className="rounded-2xl bg-base-100 p-6 shadow-sm">
-				<div className="space-y-3">
-					{/* トラック番号とタイトル */}
-					<div className="flex flex-wrap items-center gap-2">
-						<span className="badge badge-outline badge-lg">
-							Track {track.trackNumber.toString().padStart(2, "0")}
-						</span>
-						<h1 className="font-bold text-2xl sm:text-3xl">{track.name}</h1>
-					</div>
-
-					{/* リリース情報 */}
-					<div className="flex flex-wrap items-center gap-4 text-base-content/60 text-sm">
-						{track.release && (
-							<Link
-								to="/releases/$id"
-								params={{ id: track.release.id }}
-								preload="intent"
-								className="flex items-center gap-1 hover:text-primary"
-							>
-								<Disc3 className="size-4" />
-								{track.release.name}
-							</Link>
-						)}
-						{track.disc && (
-							<span className="flex items-center gap-1">
-								<Disc3 className="size-4" />
-								Disc {track.disc.discNumber}
-								{track.disc.discName && ` - ${track.disc.discName}`}
-							</span>
-						)}
-						{track.event && (
-							<Link
-								to="/events/$id"
-								params={{ id: track.event.id }}
-								preload="intent"
-								className="flex items-center gap-1 hover:text-primary"
-							>
-								{track.event.name}
-							</Link>
-						)}
-					</div>
+			<EntityDetailHeader
+				gradientClass="gradient-track"
+				icon={<Music className="size-10 text-accent sm:size-12" />}
+				iconRingClass="ring-accent/20"
+				title={track.name}
+				badges={[
+					<span
+						key="track-number"
+						className="badge badge-accent badge-outline badge-lg"
+					>
+						Track {track.trackNumber.toString().padStart(2, "0")}
+					</span>,
+					...(track.disc
+						? [
+								<span key="disc" className="badge badge-ghost badge-sm gap-1">
+									<Disc3 className="size-3" />
+									Disc {track.disc.discNumber}
+									{track.disc.discName && ` - ${track.disc.discName}`}
+								</span>,
+							]
+						: []),
+				]}
+			>
+				{/* リリース・イベントへのリンク */}
+				<div className="flex flex-wrap gap-2">
+					{track.release && (
+						<Link
+							to="/releases/$id"
+							params={{ id: track.release.id }}
+							preload="intent"
+							className="btn btn-ghost btn-sm gap-1"
+						>
+							<Disc3 className="size-4" />
+							{track.release.name}
+						</Link>
+					)}
+					{track.event && (
+						<Link
+							to="/events/$id"
+							params={{ id: track.event.id }}
+							preload="intent"
+							className="btn btn-ghost btn-sm"
+						>
+							{track.event.name}
+						</Link>
+					)}
 				</div>
-			</div>
+			</EntityDetailHeader>
 
 			{/* クレジット */}
 			{track.credits.length > 0 && (


### PR DESCRIPTION
## 概要

公開画面全体のUI/UXを改善し、モバイル対応強化とデザイン統一を実施。

## 変更内容

### 新規コンポーネント
* `EntityDetailHeader` - 詳細ページヘッダーの統一コンポーネント
* `StatsCardGrid` - 統計カードのグリッド表示コンポーネント
* `MobileCardList` - モバイル用カードリストコンポーネント
* `FilterDrawer` - モバイル用フィルタードロワーコンポーネント

### CSS追加
* `gradient-event` - イベント用暖色グラデーション（オレンジ/アンバー系）
* `gradient-song` - 原曲用落ち着いたグラデーション（グリーン/ティール系）
* `slideInFromBottom` アニメーション

### 詳細ページ改善
* `artists_.$id.tsx` - EntityDetailHeader, StatsCardGrid適用
* `circles_.$id.tsx` - EntityDetailHeader, StatsCardGrid適用
* `events_.$id.tsx` - gradient-event適用, EntityDetailHeader適用
* `releases_.$id.tsx` - EntityDetailHeader, StatsCardGrid適用
* `tracks_.$id.tsx` - EntityDetailHeader適用

### 一覧ページモバイル対応
* `artists.tsx` - MobileCardList, FilterDrawer導入
* `circles.tsx` - MobileCardList, FilterDrawer導入
* `events.tsx` - MobileCardList追加
* `original-songs.tsx` - MobileCardList, FilterDrawer導入

## 影響範囲

* 公開画面の全詳細ページ（5ページ）
* 公開画面の一覧ページ（4ページ）
* 共有コンポーネント（4コンポーネント新規追加）

## 補足事項

* WCAG 2.1 AA準拠（コントラスト比4.5:1以上、タップ領域44px以上）
* レスポンシブブレークポイント: sm (640px), md (768px)
* 既存のURL構造、localStorageキー、キャッシュ戦略は維持