### PR TITLE
fix: 原作詳細ページの原曲アレンジ数が0と表示される問題を修正

### DIFF
--- a/apps/server/src/routes/public/official-works.ts
+++ b/apps/server/src/routes/public/official-works.ts
@@ -193,6 +193,16 @@ officialWorksRouter.get("/:id", async (c) => {
 
 		const work = workResult[0];
 
+		// 原曲ごとのアレンジ数をサブクエリで計算（LEFT JOIN方式）
+		const arrangeCountSq = db
+			.select({
+				songId: trackOfficialSongs.officialSongId,
+				count: countDistinct(trackOfficialSongs.trackId).as("arrangeCount"),
+			})
+			.from(trackOfficialSongs)
+			.groupBy(trackOfficialSongs.officialSongId)
+			.as("arrangeCountSq");
+
 		// 楽曲、リンク、統計を並列取得
 		const [songsData, linksData, statsData] = await Promise.all([
 			// 楽曲一覧（arrangeCount含む）
@@ -204,13 +214,10 @@ officialWorksRouter.get("/:id", async (c) => {
 					nameJa: officialSongs.nameJa,
 					nameEn: officialSongs.nameEn,
 					composerName: officialSongs.composerName,
-					arrangeCount: sql<number>`(
-						SELECT COUNT(DISTINCT ${trackOfficialSongs.trackId})
-						FROM ${trackOfficialSongs}
-						WHERE ${trackOfficialSongs.officialSongId} = ${officialSongs.id}
-					)`,
+					arrangeCount: sql<number>`COALESCE(${arrangeCountSq.count}, 0)`,
 				})
 				.from(officialSongs)
+				.leftJoin(arrangeCountSq, eq(officialSongs.id, arrangeCountSq.songId))
 				.where(eq(officialSongs.officialWorkId, id))
 				.orderBy(asc(officialSongs.trackNumber)),
 


### PR DESCRIPTION
## 概要

原作詳細ページ（例：東方紅魔郷）の収録曲一覧で、各原曲のアレンジ数がすべて0と表示されていた問題を修正。

## 問題の原因

`apps/server/src/routes/public/official-works.ts`の原作詳細エンドポイントで、相関サブクエリを使用してarrangeCountを取得していたが、Drizzle ORMの`sql`テンプレートリテラル内で外部テーブルの列参照が正しく解決されていなかった。

## 変更内容

* 同ファイル内の原作一覧エンドポイントで採用されている「サブクエリをLEFT JOINする方式」に統一
* 相関サブクエリからLEFT JOIN方式に変更することで、Drizzle ORMの列参照問題を回避

## 影響範囲

* 原作詳細ページ（`/original-work/:id`）の収録曲一覧表示

## 補足事項

なし