### PR TITLE
feat: 統計ランキングページを追加

### DIFF
--- a/apps/server/src/routes/public/stats.ts
+++ b/apps/server/src/routes/public/stats.ts
@@ -217,6 +217,233 @@ statsRouter.get("/rankings", async (c) => {
 });
 
 /**
+ * GET /api/public/stats/rankings/original-songs
+ * 原曲アレンジ数ランキング（ページネーション対応）
+ */
+statsRouter.get("/rankings/original-songs", async (c) => {
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Number(c.req.query("limit")) || 20;
+		const offset = (page - 1) * limit;
+
+		const cacheKey = cacheKeys.originalSongsRanking({ page, limit });
+
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.STATS_RANKINGS });
+			return c.json(cached);
+		}
+
+		// 総件数を取得（「その他」を除外）
+		const totalResult = await db
+			.select({ count: count() })
+			.from(officialSongs)
+			.innerJoin(
+				officialWorks,
+				eq(officialSongs.officialWorkId, officialWorks.id),
+			)
+			.where(ne(officialWorks.id, "0799"));
+
+		const total = totalResult[0]?.count ?? 0;
+
+		// アレンジ数でソートしたランキングを取得
+		const rankingResult = await db
+			.select({
+				id: officialSongs.id,
+				name: officialSongs.name,
+				workId: officialSongs.officialWorkId,
+				workName: officialWorks.name,
+				count: count(trackOfficialSongs.trackId),
+			})
+			.from(officialSongs)
+			.innerJoin(
+				officialWorks,
+				eq(officialSongs.officialWorkId, officialWorks.id),
+			)
+			.leftJoin(
+				trackOfficialSongs,
+				eq(officialSongs.id, trackOfficialSongs.officialSongId),
+			)
+			.where(ne(officialWorks.id, "0799"))
+			.groupBy(officialSongs.id, officialWorks.id)
+			.orderBy(desc(count(trackOfficialSongs.trackId)))
+			.limit(limit)
+			.offset(offset);
+
+		const response = {
+			data: rankingResult.map((row) => ({
+				id: row.id,
+				name: row.name,
+				workId: row.workId,
+				workName: row.workName,
+				count: row.count,
+			})),
+			total,
+			page,
+			limit,
+		};
+
+		setCache(cacheKey, response, CACHE_TTL.STATS_RANKINGS);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.STATS_RANKINGS });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"GET /api/public/stats/rankings/original-songs",
+		);
+	}
+});
+
+/**
+ * GET /api/public/stats/rankings/circles
+ * サークルリリース数ランキング（ページネーション対応）
+ */
+statsRouter.get("/rankings/circles", async (c) => {
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Number(c.req.query("limit")) || 20;
+		const offset = (page - 1) * limit;
+
+		const cacheKey = cacheKeys.circlesRanking({ page, limit });
+
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.STATS_RANKINGS });
+			return c.json(cached);
+		}
+
+		// 総件数を取得
+		const totalResult = await db.select({ count: count() }).from(circles);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		// リリース数でソートしたランキングを取得
+		const rankingResult = await db
+			.select({
+				id: circles.id,
+				name: circles.name,
+				count: countDistinct(releaseCircles.releaseId),
+			})
+			.from(circles)
+			.leftJoin(releaseCircles, eq(circles.id, releaseCircles.circleId))
+			.groupBy(circles.id)
+			.orderBy(desc(countDistinct(releaseCircles.releaseId)))
+			.limit(limit)
+			.offset(offset);
+
+		const response = {
+			data: rankingResult.map((row) => ({
+				id: row.id,
+				name: row.name,
+				count: row.count,
+			})),
+			total,
+			page,
+			limit,
+		};
+
+		setCache(cacheKey, response, CACHE_TTL.STATS_RANKINGS);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.STATS_RANKINGS });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/stats/rankings/circles");
+	}
+});
+
+/**
+ * GET /api/public/stats/rankings/artists
+ * アーティスト楽曲数ランキング（ページネーション対応）
+ */
+statsRouter.get("/rankings/artists", async (c) => {
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Number(c.req.query("limit")) || 20;
+		const offset = (page - 1) * limit;
+
+		const cacheKey = cacheKeys.artistsRanking({ page, limit });
+
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.STATS_RANKINGS });
+			return c.json(cached);
+		}
+
+		// 総件数を取得（名義単位でカウント）
+		const totalResult = await db
+			.select({
+				count: countDistinct(
+					sql`CASE
+						WHEN ${trackCredits.artistAliasId} IS NULL
+						THEN ${trackCredits.artistId} || '__main__'
+						ELSE ${trackCredits.artistAliasId}
+					END`,
+				),
+			})
+			.from(trackCredits);
+
+		const total = totalResult[0]?.count ?? 0;
+
+		// 楽曲数でソートしたランキングを取得（名義単位）
+		const rankingResult = await db
+			.select({
+				id: sql<string>`CASE
+					WHEN ${trackCredits.artistAliasId} IS NULL
+					THEN ${trackCredits.artistId} || '__main__'
+					ELSE ${trackCredits.artistAliasId}
+				END`,
+				name: sql<string>`CASE
+					WHEN ${trackCredits.artistAliasId} IS NULL
+					THEN ${artists.name}
+					ELSE ${artistAliases.name}
+				END`,
+				artistId: trackCredits.artistId,
+				count: countDistinct(trackCredits.trackId),
+			})
+			.from(trackCredits)
+			.innerJoin(artists, eq(trackCredits.artistId, artists.id))
+			.leftJoin(artistAliases, eq(trackCredits.artistAliasId, artistAliases.id))
+			.groupBy(
+				sql`CASE
+					WHEN ${trackCredits.artistAliasId} IS NULL
+					THEN ${trackCredits.artistId} || '__main__'
+					ELSE ${trackCredits.artistAliasId}
+				END`,
+				sql`CASE
+					WHEN ${trackCredits.artistAliasId} IS NULL
+					THEN ${artists.name}
+					ELSE ${artistAliases.name}
+				END`,
+				trackCredits.artistId,
+			)
+			.orderBy(desc(countDistinct(trackCredits.trackId)))
+			.limit(limit)
+			.offset(offset);
+
+		const response = {
+			data: rankingResult.map((row) => ({
+				id: row.id,
+				name: row.name,
+				artistId: row.artistId,
+				count: row.count,
+			})),
+			total,
+			page,
+			limit,
+		};
+
+		setCache(cacheKey, response, CACHE_TTL.STATS_RANKINGS);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.STATS_RANKINGS });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/stats/rankings/artists");
+	}
+});
+
+/**
  * GET /api/public/stats/recent-updates
  * 最近の更新情報を取得
  */

--- a/apps/server/src/utils/cache.ts
+++ b/apps/server/src/utils/cache.ts
@@ -261,4 +261,11 @@ export const cacheKeys = {
 	publicStats: () => "public:stats",
 	publicStatsRankings: () => "public:stats:rankings",
 	publicStatsRecentUpdates: () => "public:stats:recent-updates",
+
+	originalSongsRanking: (params: { page: number; limit: number }) =>
+		`public:stats:rankings:original-songs:page=${params.page}:limit=${params.limit}`,
+	circlesRanking: (params: { page: number; limit: number }) =>
+		`public:stats:rankings:circles:page=${params.page}:limit=${params.limit}`,
+	artistsRanking: (params: { page: number; limit: number }) =>
+		`public:stats:rankings:artists:page=${params.page}:limit=${params.limit}`,
 };

--- a/apps/web/src/components/public/index.ts
+++ b/apps/web/src/components/public/index.ts
@@ -59,6 +59,14 @@ export {
 export { PublicFooter } from "./public-footer";
 export { PublicHeader } from "./public-header";
 export { PublicationLinks } from "./publication-links";
+export {
+	calculateRanks,
+	getMedalOrRank,
+	RankBadge,
+	type RankBadgeProps,
+	RankingList,
+	type RankingListProps,
+} from "./ranking-list";
 export { RecentReleases } from "./recent-releases";
 export { RelatedLinks } from "./related-links";
 export {

--- a/apps/web/src/components/public/ranking-list.tsx
+++ b/apps/web/src/components/public/ranking-list.tsx
@@ -1,0 +1,173 @@
+import type { ReactNode } from "react";
+import { InfiniteScroll } from "@/components/ui/infinite-scroll";
+import { cn } from "@/lib/utils";
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+interface RankingListProps<T> {
+	/** ランキングアイテム配列 */
+	items: T[];
+	/** カウント値を取得する関数 */
+	getCount: (item: T) => number;
+	/** アイテムをレンダリング */
+	renderItem: (item: T, rank: number, medal: string) => ReactNode;
+	/** 次ページ取得中フラグ */
+	isFetchingNextPage: boolean;
+	/** 次ページがあるか */
+	hasNextPage: boolean;
+	/** 次ページ取得関数 */
+	fetchNextPage: () => void;
+	/** 総アイテム数（無限スクロールの進捗表示用） */
+	totalCount?: number;
+	/** スケルトンローディングの行数 */
+	skeletonRows?: number;
+	/** コンテナに適用するクラス名 */
+	className?: string;
+	/** アイテムリストに適用するクラス名 */
+	listClassName?: string;
+}
+
+// =============================================================================
+// ユーティリティ関数
+// =============================================================================
+
+/**
+ * 同点順位を計算する
+ * 同じカウント数のアイテムは同じ順位になる
+ * 例: 1, 1, 3, 4, 4, 6...
+ */
+function calculateRanks(counts: number[]): number[] {
+	const ranks: number[] = [];
+
+	for (let i = 0; i < counts.length; i++) {
+		if (i === 0) {
+			ranks.push(1);
+		} else if (counts[i] === counts[i - 1]) {
+			// 前のアイテムと同じカウント → 同じ順位
+			ranks.push(ranks[i - 1]);
+		} else {
+			// 異なるカウント → 現在のインデックス + 1
+			ranks.push(i + 1);
+		}
+	}
+
+	return ranks;
+}
+
+/**
+ * 順位に対応するメダル絵文字または数字を取得
+ */
+function getMedalOrRank(rank: number): string {
+	switch (rank) {
+		case 1:
+			return "🥇";
+		case 2:
+			return "🥈";
+		case 3:
+			return "🥉";
+		default:
+			return String(rank);
+	}
+}
+
+// =============================================================================
+// サブコンポーネント
+// =============================================================================
+
+interface RankBadgeProps {
+	rank: number;
+	medal: string;
+}
+
+/**
+ * 順位バッジコンポーネント
+ */
+function RankBadge({ rank, medal }: RankBadgeProps) {
+	const isMedal = rank <= 3;
+
+	return (
+		<span
+			className={cn(
+				"flex size-8 shrink-0 items-center justify-center rounded-lg font-bold text-sm",
+				isMedal ? "" : "bg-base-content/10 text-base-content/70",
+			)}
+		>
+			{medal}
+		</span>
+	);
+}
+
+// =============================================================================
+// メインコンポーネント
+// =============================================================================
+
+/**
+ * 無限スクロール対応のランキングリストコンポーネント
+ *
+ * @example
+ * ```tsx
+ * <RankingList
+ *   items={songs}
+ *   getCount={(song) => song.arrangeCount}
+ *   renderItem={(song, rank, medal) => (
+ *     <Link to={`/original-songs/${song.id}`}>
+ *       <span>{medal}</span>
+ *       <span>{song.name}</span>
+ *       <span>{song.arrangeCount}曲</span>
+ *     </Link>
+ *   )}
+ *   isFetchingNextPage={isFetchingNextPage}
+ *   hasNextPage={hasNextPage}
+ *   fetchNextPage={fetchNextPage}
+ *   totalCount={total}
+ * />
+ * ```
+ */
+function RankingList<T>({
+	items,
+	getCount,
+	renderItem,
+	isFetchingNextPage,
+	hasNextPage,
+	fetchNextPage,
+	totalCount,
+	skeletonRows = 3,
+	className,
+	listClassName,
+}: RankingListProps<T>) {
+	// カウント配列を抽出して順位を計算
+	const counts = items.map(getCount);
+	const ranks = calculateRanks(counts);
+
+	return (
+		<div className={className}>
+			{/* ランキングリスト */}
+			<div className={cn("divide-y divide-base-content/5", listClassName)}>
+				{items.map((item, index) => {
+					const rank = ranks[index];
+					const medal = getMedalOrRank(rank);
+					return renderItem(item, rank, medal);
+				})}
+			</div>
+
+			{/* 無限スクロール */}
+			<InfiniteScroll
+				onLoadMore={fetchNextPage}
+				isLoading={isFetchingNextPage}
+				hasMore={hasNextPage}
+				loadedCount={items.length}
+				totalCount={totalCount ?? items.length}
+				skeletonRows={skeletonRows}
+			/>
+		</div>
+	);
+}
+
+// =============================================================================
+// エクスポート
+// =============================================================================
+
+export { RankingList, RankBadge, calculateRanks, getMedalOrRank };
+export type { RankingListProps, RankBadgeProps };

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -452,6 +452,34 @@ export interface PublicReleaseDetail {
 }
 
 // =============================================================================
+// ランキングAPI型定義
+// =============================================================================
+
+/** 原曲アレンジ数ランキング項目 */
+export interface OriginalSongRankingItem {
+	id: string;
+	name: string;
+	workId: string | null;
+	workName: string | null;
+	count: number;
+}
+
+/** サークルリリース数ランキング項目 */
+export interface CircleRankingItem {
+	id: string;
+	name: string;
+	count: number;
+}
+
+/** アーティスト楽曲数ランキング項目 */
+export interface ArtistRankingItem {
+	id: string;
+	name: string;
+	artistId: string;
+	count: number;
+}
+
+// =============================================================================
 // 統計API型定義
 // =============================================================================
 
@@ -561,6 +589,36 @@ export const publicApi = {
 		/** 最近の更新 */
 		recentUpdates: () =>
 			publicFetch<PublicStatsRecentUpdates>("/api/public/stats/recent-updates"),
+		/** 原曲アレンジ数ランキング（ページネーション対応） */
+		originalSongsRanking: (params?: { page?: number; limit?: number }) => {
+			const sp = new URLSearchParams();
+			if (params?.page) sp.set("page", String(params.page));
+			if (params?.limit) sp.set("limit", String(params.limit));
+			const query = sp.toString();
+			return publicFetch<PaginatedResponse<OriginalSongRankingItem>>(
+				`/api/public/stats/rankings/original-songs${query ? `?${query}` : ""}`,
+			);
+		},
+		/** サークルリリース数ランキング（ページネーション対応） */
+		circlesRanking: (params?: { page?: number; limit?: number }) => {
+			const sp = new URLSearchParams();
+			if (params?.page) sp.set("page", String(params.page));
+			if (params?.limit) sp.set("limit", String(params.limit));
+			const query = sp.toString();
+			return publicFetch<PaginatedResponse<CircleRankingItem>>(
+				`/api/public/stats/rankings/circles${query ? `?${query}` : ""}`,
+			);
+		},
+		/** アーティスト楽曲数ランキング（ページネーション対応） */
+		artistsRanking: (params?: { page?: number; limit?: number }) => {
+			const sp = new URLSearchParams();
+			if (params?.page) sp.set("page", String(params.page));
+			if (params?.limit) sp.set("limit", String(params.limit));
+			const query = sp.toString();
+			return publicFetch<PaginatedResponse<ArtistRankingItem>>(
+				`/api/public/stats/rankings/artists${query ? `?${query}` : ""}`,
+			);
+		},
 	}),
 
 	/** カテゴリマスタ一覧を取得 */

--- a/apps/web/src/lib/public-query-options.ts
+++ b/apps/web/src/lib/public-query-options.ts
@@ -4,6 +4,9 @@
  */
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import {
+	type ArtistRankingItem,
+	type CircleRankingItem,
+	type OriginalSongRankingItem,
 	type PaginatedResponse,
 	type PublicArtistItem,
 	type PublicCircleItem,
@@ -318,3 +321,60 @@ export const publicRecentUpdatesQueryOptions = () =>
 		queryFn: () => publicApi.stats.recentUpdates(),
 		staleTime: STALE_TIME_PUBLIC.RECENT_UPDATES,
 	});
+
+// =============================================================================
+// ランキング無限スクロール用クエリオプション
+// =============================================================================
+
+/**
+ * 原曲アレンジ数ランキングの無限スクロールクエリオプション
+ */
+export const originalSongsRankingInfiniteQueryOptions = (limit = 20) => {
+	return infiniteQueryOptions({
+		queryKey: ["public", "stats", "rankings", "original-songs", limit],
+		queryFn: ({ pageParam }) =>
+			publicApi.stats.originalSongsRanking({ page: pageParam, limit }),
+		initialPageParam: 1,
+		getNextPageParam: (
+			lastPage: PaginatedResponse<OriginalSongRankingItem>,
+		) => {
+			const hasMore = lastPage.page * lastPage.limit < lastPage.total;
+			return hasMore ? lastPage.page + 1 : undefined;
+		},
+		staleTime: STALE_TIME_PUBLIC.RANKINGS,
+	});
+};
+
+/**
+ * サークルリリース数ランキングの無限スクロールクエリオプション
+ */
+export const circlesRankingInfiniteQueryOptions = (limit = 20) => {
+	return infiniteQueryOptions({
+		queryKey: ["public", "stats", "rankings", "circles", limit],
+		queryFn: ({ pageParam }) =>
+			publicApi.stats.circlesRanking({ page: pageParam, limit }),
+		initialPageParam: 1,
+		getNextPageParam: (lastPage: PaginatedResponse<CircleRankingItem>) => {
+			const hasMore = lastPage.page * lastPage.limit < lastPage.total;
+			return hasMore ? lastPage.page + 1 : undefined;
+		},
+		staleTime: STALE_TIME_PUBLIC.RANKINGS,
+	});
+};
+
+/**
+ * アーティスト楽曲数ランキングの無限スクロールクエリオプション
+ */
+export const artistsRankingInfiniteQueryOptions = (limit = 20) => {
+	return infiniteQueryOptions({
+		queryKey: ["public", "stats", "rankings", "artists", limit],
+		queryFn: ({ pageParam }) =>
+			publicApi.stats.artistsRanking({ page: pageParam, limit }),
+		initialPageParam: 1,
+		getNextPageParam: (lastPage: PaginatedResponse<ArtistRankingItem>) => {
+			const hasMore = lastPage.page * lastPage.limit < lastPage.total;
+			return hasMore ? lastPage.page + 1 : undefined;
+		},
+		staleTime: STALE_TIME_PUBLIC.RANKINGS,
+	});
+};

--- a/apps/web/src/routes/_public/stats.tsx
+++ b/apps/web/src/routes/_public/stats.tsx
@@ -186,7 +186,7 @@ function RankingsSection() {
 						<h2 className="font-bold">原曲アレンジ数</h2>
 					</div>
 					<Link
-						to="/original-songs"
+						to="/stats/original-songs"
 						preload="intent"
 						className="group flex items-center gap-1 text-primary text-sm transition-colors hover:text-primary"
 					>
@@ -218,7 +218,7 @@ function RankingsSection() {
 						<h2 className="font-bold">サークルリリース数</h2>
 					</div>
 					<Link
-						to="/circles"
+						to="/stats/circles"
 						preload="intent"
 						className="group flex items-center gap-1 text-primary text-sm transition-colors hover:text-primary"
 					>
@@ -250,7 +250,7 @@ function RankingsSection() {
 						<h2 className="font-bold">アーティスト楽曲数</h2>
 					</div>
 					<Link
-						to="/artists"
+						to="/stats/artists"
 						preload="intent"
 						className="group flex items-center gap-1 text-primary text-sm transition-colors hover:text-primary"
 					>

--- a/apps/web/src/routes/_public/stats_.artists.tsx
+++ b/apps/web/src/routes/_public/stats_.artists.tsx
@@ -1,0 +1,103 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Sparkles, User } from "lucide-react";
+import {
+	EmptyState,
+	PublicBreadcrumb,
+	RankBadge,
+	RankingList,
+} from "@/components/public";
+import { formatNumber } from "@/lib/format";
+import { createPageHead } from "@/lib/head";
+import { artistsRankingInfiniteQueryOptions } from "@/lib/public-query-options";
+
+const PAGE_SIZE = 20;
+
+export const Route = createFileRoute("/_public/stats_/artists")({
+	head: () => createPageHead("アーティスト楽曲数ランキング"),
+	component: ArtistsRankingPage,
+});
+
+function ArtistsRankingPage() {
+	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+		useInfiniteQuery(artistsRankingInfiniteQueryOptions(PAGE_SIZE));
+
+	// ページデータをフラット化
+	const artists = data?.pages.flatMap((page) => page.data) ?? [];
+	const total = data?.pages[0]?.total ?? 0;
+
+	return (
+		<div className="space-y-6">
+			<PublicBreadcrumb
+				items={[
+					{ label: "統計", href: "/stats" },
+					{ label: "アーティスト楽曲数ランキング" },
+				]}
+			/>
+
+			{/* ヘッダー */}
+			<div className="glass-card relative overflow-hidden rounded-2xl p-6 md:p-8">
+				<div className="gradient-mesh absolute inset-0" />
+				<div className="relative flex items-center gap-4">
+					<div className="flex size-14 items-center justify-center rounded-2xl bg-accent/10 text-accent">
+						<Sparkles className="size-7" aria-hidden="true" />
+					</div>
+					<div>
+						<h1 className="font-bold text-2xl md:text-3xl">
+							アーティスト楽曲数ランキング
+						</h1>
+						<p className="mt-1 text-base-content/60">
+							楽曲数が多いアーティスト · {formatNumber(total)}件
+						</p>
+					</div>
+				</div>
+			</div>
+
+			{/* コンテンツ */}
+			{isLoading ? (
+				<div className="flex items-center justify-center py-12">
+					<span className="loading loading-spinner loading-lg" />
+				</div>
+			) : artists.length === 0 ? (
+				<EmptyState
+					type="search"
+					title="ランキングデータがありません"
+					description="データが存在しません"
+				/>
+			) : (
+				<div className="glass-card overflow-hidden rounded-2xl">
+					<RankingList
+						items={artists}
+						getCount={(artist) => artist.count}
+						renderItem={(artist, rank, medal) => (
+							<Link
+								key={artist.id}
+								to="/artists/$id"
+								params={{ id: artist.id }}
+								preload="intent"
+								className="group flex items-center gap-3 px-4 py-3 transition-all duration-300 hover:bg-base-content/5"
+							>
+								<RankBadge rank={rank} medal={medal} />
+								<div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent/10">
+									<User className="size-5 text-accent" aria-hidden="true" />
+								</div>
+								<div className="min-w-0 flex-1">
+									<span className="block truncate font-medium transition-colors group-hover:text-primary">
+										{artist.name}
+									</span>
+								</div>
+								<span className="whitespace-nowrap rounded-full bg-base-content/5 px-2.5 py-1 text-base-content/60 text-xs">
+									{formatNumber(artist.count)} 曲
+								</span>
+							</Link>
+						)}
+						isFetchingNextPage={isFetchingNextPage}
+						hasNextPage={hasNextPage ?? false}
+						fetchNextPage={fetchNextPage}
+						totalCount={total}
+					/>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/routes/_public/stats_.circles.tsx
+++ b/apps/web/src/routes/_public/stats_.circles.tsx
@@ -1,0 +1,103 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Crown, Users } from "lucide-react";
+import {
+	EmptyState,
+	PublicBreadcrumb,
+	RankBadge,
+	RankingList,
+} from "@/components/public";
+import { formatNumber } from "@/lib/format";
+import { createPageHead } from "@/lib/head";
+import { circlesRankingInfiniteQueryOptions } from "@/lib/public-query-options";
+
+const PAGE_SIZE = 20;
+
+export const Route = createFileRoute("/_public/stats_/circles")({
+	head: () => createPageHead("サークルリリース数ランキング"),
+	component: CirclesRankingPage,
+});
+
+function CirclesRankingPage() {
+	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+		useInfiniteQuery(circlesRankingInfiniteQueryOptions(PAGE_SIZE));
+
+	// ページデータをフラット化
+	const circles = data?.pages.flatMap((page) => page.data) ?? [];
+	const total = data?.pages[0]?.total ?? 0;
+
+	return (
+		<div className="space-y-6">
+			<PublicBreadcrumb
+				items={[
+					{ label: "統計", href: "/stats" },
+					{ label: "サークルリリース数ランキング" },
+				]}
+			/>
+
+			{/* ヘッダー */}
+			<div className="glass-card relative overflow-hidden rounded-2xl p-6 md:p-8">
+				<div className="gradient-mesh absolute inset-0" />
+				<div className="relative flex items-center gap-4">
+					<div className="flex size-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+						<Crown className="size-7" aria-hidden="true" />
+					</div>
+					<div>
+						<h1 className="font-bold text-2xl md:text-3xl">
+							サークルリリース数ランキング
+						</h1>
+						<p className="mt-1 text-base-content/60">
+							リリース数が多いサークル · {formatNumber(total)}件
+						</p>
+					</div>
+				</div>
+			</div>
+
+			{/* コンテンツ */}
+			{isLoading ? (
+				<div className="flex items-center justify-center py-12">
+					<span className="loading loading-spinner loading-lg" />
+				</div>
+			) : circles.length === 0 ? (
+				<EmptyState
+					type="search"
+					title="ランキングデータがありません"
+					description="データが存在しません"
+				/>
+			) : (
+				<div className="glass-card overflow-hidden rounded-2xl">
+					<RankingList
+						items={circles}
+						getCount={(circle) => circle.count}
+						renderItem={(circle, rank, medal) => (
+							<Link
+								key={circle.id}
+								to="/circles/$id"
+								params={{ id: circle.id }}
+								preload="intent"
+								className="group flex items-center gap-3 px-4 py-3 transition-all duration-300 hover:bg-base-content/5"
+							>
+								<RankBadge rank={rank} medal={medal} />
+								<div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+									<Users className="size-5 text-primary" aria-hidden="true" />
+								</div>
+								<div className="min-w-0 flex-1">
+									<span className="block truncate font-medium transition-colors group-hover:text-primary">
+										{circle.name}
+									</span>
+								</div>
+								<span className="whitespace-nowrap rounded-full bg-base-content/5 px-2.5 py-1 text-base-content/60 text-xs">
+									{formatNumber(circle.count)} リリース
+								</span>
+							</Link>
+						)}
+						isFetchingNextPage={isFetchingNextPage}
+						hasNextPage={hasNextPage ?? false}
+						fetchNextPage={fetchNextPage}
+						totalCount={total}
+					/>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/routes/_public/stats_.original-songs.tsx
+++ b/apps/web/src/routes/_public/stats_.original-songs.tsx
@@ -1,0 +1,108 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Music, Trophy } from "lucide-react";
+import {
+	EmptyState,
+	PublicBreadcrumb,
+	RankBadge,
+	RankingList,
+} from "@/components/public";
+import { formatNumber } from "@/lib/format";
+import { createPageHead } from "@/lib/head";
+import { originalSongsRankingInfiniteQueryOptions } from "@/lib/public-query-options";
+
+const PAGE_SIZE = 20;
+
+export const Route = createFileRoute("/_public/stats_/original-songs")({
+	head: () => createPageHead("原曲アレンジ数ランキング"),
+	component: OriginalSongsRankingPage,
+});
+
+function OriginalSongsRankingPage() {
+	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+		useInfiniteQuery(originalSongsRankingInfiniteQueryOptions(PAGE_SIZE));
+
+	// ページデータをフラット化
+	const songs = data?.pages.flatMap((page) => page.data) ?? [];
+	const total = data?.pages[0]?.total ?? 0;
+
+	return (
+		<div className="space-y-6">
+			<PublicBreadcrumb
+				items={[
+					{ label: "統計", href: "/stats" },
+					{ label: "原曲アレンジ数ランキング" },
+				]}
+			/>
+
+			{/* ヘッダー */}
+			<div className="glass-card relative overflow-hidden rounded-2xl p-6 md:p-8">
+				<div className="gradient-mesh absolute inset-0" />
+				<div className="relative flex items-center gap-4">
+					<div className="flex size-14 items-center justify-center rounded-2xl bg-yellow-500/10 text-yellow-500">
+						<Trophy className="size-7" aria-hidden="true" />
+					</div>
+					<div>
+						<h1 className="font-bold text-2xl md:text-3xl">
+							原曲アレンジ数ランキング
+						</h1>
+						<p className="mt-1 text-base-content/60">
+							アレンジ楽曲が多い原曲 · {formatNumber(total)}件
+						</p>
+					</div>
+				</div>
+			</div>
+
+			{/* コンテンツ */}
+			{isLoading ? (
+				<div className="flex items-center justify-center py-12">
+					<span className="loading loading-spinner loading-lg" />
+				</div>
+			) : songs.length === 0 ? (
+				<EmptyState
+					type="search"
+					title="ランキングデータがありません"
+					description="データが存在しません"
+				/>
+			) : (
+				<div className="glass-card overflow-hidden rounded-2xl">
+					<RankingList
+						items={songs}
+						getCount={(song) => song.count}
+						renderItem={(song, rank, medal) => (
+							<Link
+								key={song.id}
+								to="/original-songs/$id"
+								params={{ id: song.id }}
+								preload="intent"
+								className="group flex items-center gap-3 px-4 py-3 transition-all duration-300 hover:bg-base-content/5"
+							>
+								<RankBadge rank={rank} medal={medal} />
+								<div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-secondary/10">
+									<Music className="size-5 text-secondary" aria-hidden="true" />
+								</div>
+								<div className="min-w-0 flex-1">
+									<span className="block truncate font-medium transition-colors group-hover:text-primary">
+										{song.name}
+									</span>
+									{song.workName && (
+										<span className="block truncate text-base-content/60 text-sm">
+											{song.workName}
+										</span>
+									)}
+								</div>
+								<span className="whitespace-nowrap rounded-full bg-base-content/5 px-2.5 py-1 text-base-content/60 text-xs">
+									{formatNumber(song.count)} アレンジ
+								</span>
+							</Link>
+						)}
+						isFetchingNextPage={isFetchingNextPage}
+						hasNextPage={hasNextPage ?? false}
+						fetchNextPage={fetchNextPage}
+						totalCount={total}
+					/>
+				</div>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## 概要

統計ページの「すべて見る」リンクから遷移するランキング専用ページを実装

## 変更内容

### サーバー側
* ページネーション対応のランキングAPI（3エンドポイント）を追加
  - `GET /api/public/stats/rankings/original-songs` - 原曲アレンジ数ランキング
  - `GET /api/public/stats/rankings/circles` - サークルリリース数ランキング
  - `GET /api/public/stats/rankings/artists` - アーティスト楽曲数ランキング
* キャッシュキー（`originalSongsRanking`, `circlesRanking`, `artistsRanking`）を追加

### クライアント側
* API関数・型定義を追加（`public-api.ts`）
* 無限スクロール用InfiniteQueryOptionsを追加（`public-query-options.ts`）
* 共通ランキングリストコンポーネントを新規作成（`ranking-list.tsx`）
  - 同点順位計算（1, 1, 3, 4...）
  - メダル表示（🥇🥈🥉）
  - 無限スクロール対応
* 3つのランキングページを新規作成
  - `/stats/original-songs` - 原曲アレンジ数ランキング
  - `/stats/circles` - サークルリリース数ランキング
  - `/stats/artists` - アーティスト楽曲数ランキング
* 統計ページの「すべて見る」リンク先を更新

## 影響範囲

* 統計ページ（`/stats`）の「すべて見る」リンクの遷移先が変更
  - 旧: `/original-songs`, `/circles`, `/artists`（一覧ページ）
  - 新: `/stats/original-songs`, `/stats/circles`, `/stats/artists`（ランキングページ）