### PR TITLE
feat: トップページと統計ページに作品数を表示

### DIFF
--- a/apps/server/src/routes/public/stats.ts
+++ b/apps/server/src/routes/public/stats.ts
@@ -51,6 +51,7 @@ statsRouter.get("/", async (c) => {
 			artistsResult,
 			tracksResult,
 			originalSongsResult,
+			releasesResult,
 		] = await Promise.all([
 			db.select({ count: count() }).from(events),
 			db.select({ count: count() }).from(circles),
@@ -79,6 +80,7 @@ statsRouter.get("/", async (c) => {
 			db
 				.select({ count: count() })
 				.from(officialSongs),
+			db.select({ count: count() }).from(releases),
 		]);
 
 		const response = {
@@ -87,6 +89,7 @@ statsRouter.get("/", async (c) => {
 			artists: artistsResult[0]?.count ?? 0,
 			tracks: tracksResult[0]?.count ?? 0,
 			originalSongs: originalSongsResult[0]?.count ?? 0,
+			releases: releasesResult[0]?.count ?? 0,
 		};
 
 		setCache(cacheKey, response, CACHE_TTL.PUBLIC_STATS);

--- a/apps/web/src/components/public/hero-section.tsx
+++ b/apps/web/src/components/public/hero-section.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Calendar, Disc3, Search, Sparkles, Users } from "lucide-react";
+import { Calendar, Disc, Disc3, Search, Sparkles, Users } from "lucide-react";
 import type { PublicStats } from "@/lib/public-api";
 import { Badge } from "../ui/badge";
 
@@ -10,6 +10,7 @@ const defaultStats: PublicStats = {
 	artists: 0,
 	tracks: 0,
 	originalSongs: 0,
+	releases: 0,
 };
 
 interface HeroSectionProps {
@@ -140,17 +141,27 @@ export function HeroSection({ stats }: HeroSectionProps) {
 						}
 					/>
 					<div className="h-4 w-px bg-base-content/20" aria-hidden="true" />
-					<StatLink
-						href="/stats"
-						count={displayStats.tracks}
-						label="トラック"
-						icon={
-							<Disc3
-								className="size-4 text-primary group-hover:text-primary"
-								aria-hidden="true"
-							/>
-						}
-					/>
+					{/* 作品（リンクなし） */}
+					<div className="flex items-center gap-2">
+						<Disc className="size-4 text-primary" aria-hidden="true" />
+						<span>
+							<span className="font-semibold text-base-content">
+								{displayStats.releases.toLocaleString()}
+							</span>{" "}
+							作品
+						</span>
+					</div>
+					<div className="h-4 w-px bg-base-content/20" aria-hidden="true" />
+					{/* アレンジ（リンクなし） */}
+					<div className="flex items-center gap-2">
+						<Disc3 className="size-4 text-primary" aria-hidden="true" />
+						<span>
+							<span className="font-semibold text-base-content">
+								{displayStats.tracks.toLocaleString()}
+							</span>{" "}
+							アレンジ
+						</span>
+					</div>
 				</div>
 			</div>
 		</section>

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -40,6 +40,7 @@ export interface PublicStats {
 	artists: number;
 	tracks: number;
 	originalSongs: number;
+	releases: number;
 }
 
 /** ランキング項目 */

--- a/apps/web/src/routes/_public/stats.tsx
+++ b/apps/web/src/routes/_public/stats.tsx
@@ -4,6 +4,7 @@ import {
 	BarChart3,
 	Calendar,
 	Crown,
+	Disc,
 	Disc3,
 	type LucideIcon,
 	Music,
@@ -380,7 +381,7 @@ function StatsPage() {
 
 			{/* Stats cards */}
 			<section>
-				<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+				<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
 					<StatCard
 						icon={Music}
 						count={stats.originalSongs}
@@ -389,7 +390,14 @@ function StatsPage() {
 						color="text-secondary"
 					/>
 					<StatCard
-						icon={Disc3}
+						icon={Calendar}
+						count={stats.events}
+						label="イベント"
+						href="/events"
+						color="text-info"
+					/>
+					<StatCard
+						icon={Users}
 						count={stats.circles}
 						label="サークル"
 						href="/circles"
@@ -403,16 +411,15 @@ function StatsPage() {
 						color="text-accent"
 					/>
 					<StatCard
-						icon={Calendar}
-						count={stats.events}
-						label="イベント"
-						href="/events"
-						color="text-info"
+						icon={Disc}
+						count={stats.releases}
+						label="作品"
+						color="text-warning"
 					/>
 					<StatCard
-						icon={Music}
+						icon={Disc3}
 						count={stats.tracks}
-						label="トラック"
+						label="アレンジ"
 						color="text-success"
 					/>
 				</div>


### PR DESCRIPTION
## 概要

トップページと統計ページに「作品」数を表示し、「トラック」を「アレンジ」に名称変更する。

## 変更内容

* サーバーAPI: `/api/public/stats` のレスポンスに `releases` カウントを追加
* 型定義: `PublicStats` インターフェースに `releases` フィールドを追加
* トップページ HeroSection:
  - 作品数の表示を追加（リンクなし）
  - 「トラック」を「アレンジ」に名称変更（リンクなし）
  - 表示順: イベント → サークル → アーティスト → 作品 → アレンジ
* 統計ページ:
  - 作品カードを追加（Disc アイコン、text-warning）
  - グリッドを5カラムから6カラムに変更
  - 「トラック」を「アレンジ」に名称変更
  - 表示順: 原曲 → イベント → サークル → アーティスト → 作品 → アレンジ

## 影響範囲

* トップページ（HeroSection）の統計表示
* 統計ページの統計カード表示
* 公開統計APIのレスポンス形式