### PR TITLE
fix: stats プロパティの undefined 参照エラーを修正

### DIFF
--- a/apps/web/src/components/public/hero-section.tsx
+++ b/apps/web/src/components/public/hero-section.tsx
@@ -3,16 +3,6 @@ import { Calendar, Disc, Disc3, Search, Sparkles, Users } from "lucide-react";
 import type { PublicStats } from "@/lib/public-api";
 import { Badge } from "../ui/badge";
 
-// フォールバック用のデフォルト値
-const defaultStats: PublicStats = {
-	events: 0,
-	circles: 0,
-	artists: 0,
-	tracks: 0,
-	originalSongs: 0,
-	releases: 0,
-};
-
 interface HeroSectionProps {
 	stats: PublicStats | null;
 }
@@ -43,7 +33,14 @@ function StatLink({ href, count, label, icon }: StatLinkProps) {
 }
 
 export function HeroSection({ stats }: HeroSectionProps) {
-	const displayStats = stats ?? defaultStats;
+	const displayStats: PublicStats = {
+		events: stats?.events ?? 0,
+		circles: stats?.circles ?? 0,
+		artists: stats?.artists ?? 0,
+		tracks: stats?.tracks ?? 0,
+		originalSongs: stats?.originalSongs ?? 0,
+		releases: stats?.releases ?? 0,
+	};
 
 	return (
 		<section className="relative flex h-[calc(100vh-4rem)] flex-col justify-center overflow-hidden px-4 py-12">

--- a/apps/web/src/routes/_public/stats.tsx
+++ b/apps/web/src/routes/_public/stats.tsx
@@ -357,6 +357,16 @@ function RecentUpdatesSection() {
 function StatsPage() {
 	const { stats } = Route.useLoaderData();
 
+	// プロパティレベルでフォールバックを適用
+	const displayStats = {
+		events: stats?.events ?? 0,
+		circles: stats?.circles ?? 0,
+		artists: stats?.artists ?? 0,
+		tracks: stats?.tracks ?? 0,
+		originalSongs: stats?.originalSongs ?? 0,
+		releases: stats?.releases ?? 0,
+	};
+
 	return (
 		<div className="space-y-8">
 			<PublicBreadcrumb items={[{ label: "統計" }]} />
@@ -384,41 +394,41 @@ function StatsPage() {
 				<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
 					<StatCard
 						icon={Music}
-						count={stats.originalSongs}
+						count={displayStats.originalSongs}
 						label="原曲"
 						href="/original-songs"
 						color="text-secondary"
 					/>
 					<StatCard
 						icon={Calendar}
-						count={stats.events}
+						count={displayStats.events}
 						label="イベント"
 						href="/events"
 						color="text-info"
 					/>
 					<StatCard
 						icon={Users}
-						count={stats.circles}
+						count={displayStats.circles}
 						label="サークル"
 						href="/circles"
 						color="text-primary"
 					/>
 					<StatCard
 						icon={Users}
-						count={stats.artists}
+						count={displayStats.artists}
 						label="アーティスト"
 						href="/artists"
 						color="text-accent"
 					/>
 					<StatCard
 						icon={Disc}
-						count={stats.releases}
+						count={displayStats.releases}
 						label="作品"
 						color="text-warning"
 					/>
 					<StatCard
 						icon={Disc3}
-						count={stats.tracks}
+						count={displayStats.tracks}
 						label="アレンジ"
 						color="text-success"
 					/>


### PR DESCRIPTION
## 概要

HeroSection と StatsPage で stats オブジェクトの個別プロパティが undefined の場合に toLocaleString/formatNumber が失敗するエラーを修正。

## 問題の原因

`hero-section.tsx` で `const displayStats = stats ?? defaultStats;` としていたが、`stats` オブジェクト自体は存在するものの個別プロパティ（`releases`、`tracks`等）が `undefined` の場合にフォールバックが機能せず、`toLocaleString()` が undefined に対して呼び出されエラーが発生していた。

```
TypeError: Cannot read properties of undefined (reading 'toLocaleString')
    at HeroSection (hero-section.tsx:149:32)
```

## 変更内容

* `hero-section.tsx`: `displayStats` 初期化をオブジェクトレベルからプロパティレベルでのフォールバックに変更
* `stats.tsx`: 同様にプロパティレベルでフォールバックを適用（予防的修正）
* 未使用になった `defaultStats` 定数を削除

## 影響範囲

* トップページ（`/`）の HeroSection
* 統計ページ（`/stats`）の StatCard 表示

## 補足事項

なし