### PR TITLE
fix: パンくずリストのラベル抜けと無効リンクを修正

### DIFF
--- a/apps/web/src/components/public/public-breadcrumb.tsx
+++ b/apps/web/src/components/public/public-breadcrumb.tsx
@@ -104,47 +104,50 @@ export function PublicBreadcrumb({
 		...items,
 	];
 
-	// モバイル省略表示の計算
+	// モバイル省略表示の判定
 	const shouldCollapse = collapsible && allItems.length > maxVisibleItems;
-	const visibleItems = shouldCollapse
-		? [
-				allItems[0], // 最初（ホーム）
-				{ label: "...", href: undefined } as BreadcrumbItemData, // 省略マーカー
-				...allItems.slice(-2), // 最後2つ
-			]
-		: allItems;
 
 	return (
 		<Breadcrumb className="mb-4">
 			<BreadcrumbList>
-				{visibleItems.map((item, index) => {
-					const isLast = index === visibleItems.length - 1;
+				{allItems.map((item, index) => {
 					const isHome = index === 0;
-					const isEllipsis = item.label === "...";
+					const isLast = index === allItems.length - 1;
+					// 最後の2項目かどうか（モバイルでも表示する）
+					const isLastTwo = index >= allItems.length - 2;
 
-					const icon = isEllipsis ? null : getItemIcon(item, isHome);
+					// 中間項目かどうか（モバイルで非表示にする対象）
+					// ホームと最後の2項目以外が中間項目
+					const isMiddleItem = shouldCollapse && !isHome && !isLastTwo;
+
+					const icon = getItemIcon(item, isHome);
+
+					// モバイルでの表示順序を制御
+					// ホーム: order-1, 最後の2項目: order-3, 中間項目: hidden
+					const orderClass = shouldCollapse
+						? isHome
+							? "order-1 sm:order-none"
+							: isLastTwo
+								? "order-3 sm:order-none"
+								: ""
+						: "";
 
 					return (
 						<BreadcrumbItem
 							key={`${item.label}-${index}`}
-							className={
-								shouldCollapse && !isHome && !isLast ? "hidden sm:flex" : ""
-							}
+							className={`${isMiddleItem ? "hidden sm:flex" : ""} ${orderClass}`.trim()}
 						>
+							{/* セパレータ */}
 							{index > 0 && (
 								<BreadcrumbSeparator
-									className={
-										shouldCollapse && !isHome && !isLast ? "hidden sm:flex" : ""
-									}
+									className={isMiddleItem ? "hidden sm:flex" : ""}
 								>
 									<ChevronRight className="size-4 text-base-content/50" />
 								</BreadcrumbSeparator>
 							)}
-							{isEllipsis ? (
-								<span className="flex items-center px-1 text-base-content/50 sm:hidden">
-									<MoreHorizontal className="size-4" />
-								</span>
-							) : isLast || !item.href ? (
+
+							{/* アイテム本体 */}
+							{isLast || !item.href ? (
 								<BreadcrumbPage className="flex items-center gap-1.5 font-medium text-base-content">
 									{icon}
 									<span className="line-clamp-1">{item.label}</span>
@@ -161,6 +164,18 @@ export function PublicBreadcrumb({
 						</BreadcrumbItem>
 					);
 				})}
+
+				{/* モバイル用省略マーカー（ホームと最後の2項目の間に表示） */}
+				{shouldCollapse && (
+					<BreadcrumbItem className="order-2 sm:hidden">
+						<BreadcrumbSeparator>
+							<ChevronRight className="size-4 text-base-content/50" />
+						</BreadcrumbSeparator>
+						<span className="flex items-center px-1 text-base-content/50">
+							<MoreHorizontal className="size-4" />
+						</span>
+					</BreadcrumbItem>
+				)}
 			</BreadcrumbList>
 		</Breadcrumb>
 	);

--- a/apps/web/src/routes/_public/releases_.$id.tsx
+++ b/apps/web/src/routes/_public/releases_.$id.tsx
@@ -90,9 +90,7 @@ function ReleaseDetailPage() {
 	if (!release) {
 		return (
 			<div className="space-y-6">
-				<PublicBreadcrumb
-					items={[{ label: "作品", href: "/releases" }, { label: id }]}
-				/>
+				<PublicBreadcrumb items={[{ label: "作品" }, { label: id }]} />
 				<div className="rounded-2xl bg-base-100 p-8 text-center shadow-sm">
 					<h1 className="font-bold text-2xl">作品が見つかりません</h1>
 					<p className="mt-2 text-base-content/70">
@@ -105,9 +103,7 @@ function ReleaseDetailPage() {
 
 	return (
 		<div className="space-y-6">
-			<PublicBreadcrumb
-				items={[{ label: "作品", href: "/releases" }, { label: release.name }]}
-			/>
+			<PublicBreadcrumb items={[{ label: "作品" }, { label: release.name }]} />
 
 			{/* ヘッダー - EntityDetailHeader + StatsCardGrid */}
 			<EntityDetailHeader

--- a/apps/web/src/routes/_public/tracks_.$id.tsx
+++ b/apps/web/src/routes/_public/tracks_.$id.tsx
@@ -85,9 +85,7 @@ function TrackDetailPage() {
 	if (!track) {
 		return (
 			<div className="space-y-6">
-				<PublicBreadcrumb
-					items={[{ label: "作品", href: "/releases" }, { label: id }]}
-				/>
+				<PublicBreadcrumb items={[{ label: "作品" }, { label: id }]} />
 				<div className="rounded-2xl bg-base-100 p-8 text-center shadow-sm">
 					<h1 className="font-bold text-2xl">トラックが見つかりません</h1>
 					<p className="mt-2 text-base-content/70">
@@ -102,7 +100,7 @@ function TrackDetailPage() {
 		<div className="space-y-6">
 			<PublicBreadcrumb
 				items={[
-					{ label: "作品", href: "/releases" },
+					{ label: "作品" },
 					...(track.release
 						? [
 								{


### PR DESCRIPTION
## 概要

パンくずリストのモバイル省略ロジックのバグと無効リンクを修正

## 問題の原因

1. **ラベル抜け**: モバイル省略ロジックで中間項目を配列から削除していたため、デスクトップでも中間項目が表示されなかった
2. **無効リンク**: `/releases` ページが存在しないのに「作品」ラベルにリンクが設定されていた

## 変更内容

* `PublicBreadcrumb` コンポーネントのモバイル省略ロジックを修正
  * 中間項目を配列から削除せず、CSSで表示/非表示を制御
  * CSS `order` プロパティで省略マーカーの位置を制御
  * 「最後の2項目」を正しく判定するように変更
* `releases_.$id.tsx` の「作品」ラベルから無効な `href="/releases"` を削除
* `tracks_.$id.tsx` の「作品」ラベルから無効な `href="/releases"` を削除

## 影響範囲

* 公開ページのパンくずリスト表示
  * `/original-songs/$id`
  * `/tracks/$id`
  * `/releases/$id`
  * `/official-works/$id`