### PR TITLE
feat: 一覧ページのタイトルにアイコン付きスタイルを適用

### DIFF
--- a/apps/web/src/routes/_public/artists.tsx
+++ b/apps/web/src/routes/_public/artists.tsx
@@ -270,20 +270,30 @@ function ArtistsPage() {
 			<PublicBreadcrumb items={[{ label: "アーティスト" }]} />
 
 			{/* ヘッダー */}
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div>
-					<h1 className="font-bold text-3xl">アーティスト一覧</h1>
-					<p className="mt-1 text-base-content/70">
-						アーティスト · {formatNumber(total)}件
-					</p>
-				</div>
-				<div className="flex items-center gap-2">
-					{/* モバイル用フィルタートリガー */}
-					<FilterDrawerTrigger
-						onClick={() => setIsFilterDrawerOpen(true)}
-						activeFilterCount={activeFilterCount}
-					/>
-					<ViewToggle value={view} onChange={handleViewChange} />
+			<div className="glass-card relative overflow-hidden rounded-2xl p-6 md:p-8">
+				<div className="gradient-mesh absolute inset-0" />
+				<div className="relative flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+					<div className="flex items-center gap-4">
+						<div className="flex size-14 items-center justify-center rounded-2xl bg-primary text-primary-content">
+							<UserRound className="size-7" aria-hidden="true" />
+						</div>
+						<div>
+							<h1 className="font-bold text-2xl md:text-3xl">
+								アーティスト一覧
+							</h1>
+							<p className="mt-1 text-base-content/60">
+								東方アレンジを制作するアーティスト · {formatNumber(total)}件
+							</p>
+						</div>
+					</div>
+					<div className="flex items-center gap-2">
+						{/* モバイル用フィルタートリガー */}
+						<FilterDrawerTrigger
+							onClick={() => setIsFilterDrawerOpen(true)}
+							activeFilterCount={activeFilterCount}
+						/>
+						<ViewToggle value={view} onChange={handleViewChange} />
+					</div>
 				</div>
 			</div>
 

--- a/apps/web/src/routes/_public/circles.tsx
+++ b/apps/web/src/routes/_public/circles.tsx
@@ -203,20 +203,28 @@ function CirclesPage() {
 			<PublicBreadcrumb items={[{ label: "サークル" }]} />
 
 			{/* ヘッダー */}
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div>
-					<h1 className="font-bold text-3xl">サークル一覧</h1>
-					<p className="mt-1 text-base-content/70">
-						同人サークル · {formatNumber(total)}件
-					</p>
-				</div>
-				<div className="flex items-center gap-2">
-					{/* モバイル用フィルタートリガー（md未満で表示） */}
-					<FilterDrawerTrigger
-						onClick={() => setIsFilterDrawerOpen(true)}
-						activeFilterCount={activeFilterCount}
-					/>
-					<ViewToggle value={view} onChange={handleViewChange} />
+			<div className="glass-card relative overflow-hidden rounded-2xl p-6 md:p-8">
+				<div className="gradient-mesh absolute inset-0" />
+				<div className="relative flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+					<div className="flex items-center gap-4">
+						<div className="flex size-14 items-center justify-center rounded-2xl bg-primary text-primary-content">
+							<Users className="size-7" aria-hidden="true" />
+						</div>
+						<div>
+							<h1 className="font-bold text-2xl md:text-3xl">サークル一覧</h1>
+							<p className="mt-1 text-base-content/60">
+								東方アレンジを制作するサークル · {formatNumber(total)}件
+							</p>
+						</div>
+					</div>
+					<div className="flex items-center gap-2">
+						{/* モバイル用フィルタートリガー（md未満で表示） */}
+						<FilterDrawerTrigger
+							onClick={() => setIsFilterDrawerOpen(true)}
+							activeFilterCount={activeFilterCount}
+						/>
+						<ViewToggle value={view} onChange={handleViewChange} />
+					</div>
 				</div>
 			</div>
 

--- a/apps/web/src/routes/_public/events.tsx
+++ b/apps/web/src/routes/_public/events.tsx
@@ -209,32 +209,40 @@ function EventsPage() {
 			<PublicBreadcrumb items={[{ label: "イベント" }]} />
 
 			{/* ヘッダー */}
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div>
-					<h1 className="font-bold text-3xl">イベント一覧</h1>
-					<p className="mt-1 text-base-content/70">
-						同人即売会 · {formatNumber(total)}件
-					</p>
-				</div>
+			<div className="glass-card relative overflow-hidden rounded-2xl p-6 md:p-8">
+				<div className="gradient-mesh absolute inset-0" />
+				<div className="relative flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+					<div className="flex items-center gap-4">
+						<div className="flex size-14 items-center justify-center rounded-2xl bg-primary text-primary-content">
+							<Calendar className="size-7" aria-hidden="true" />
+						</div>
+						<div>
+							<h1 className="font-bold text-2xl md:text-3xl">イベント一覧</h1>
+							<p className="mt-1 text-base-content/60">
+								東方同人即売会イベント · {formatNumber(total)}件
+							</p>
+						</div>
+					</div>
 
-				{/* 表示モード切替 */}
-				<div className="flex gap-1 rounded-lg bg-base-200 p-1">
-					<button
-						type="button"
-						className={`btn btn-sm ${viewMode === "series" ? "btn-primary" : "btn-ghost"}`}
-						onClick={() => setViewMode("series")}
-						aria-pressed={viewMode === "series"}
-					>
-						シリーズ別
-					</button>
-					<button
-						type="button"
-						className={`btn btn-sm ${viewMode === "year" ? "btn-primary" : "btn-ghost"}`}
-						onClick={() => setViewMode("year")}
-						aria-pressed={viewMode === "year"}
-					>
-						年別
-					</button>
+					{/* 表示モード切替 */}
+					<div className="flex gap-1 rounded-lg bg-base-200 p-1">
+						<button
+							type="button"
+							className={`btn btn-sm ${viewMode === "series" ? "btn-primary" : "btn-ghost"}`}
+							onClick={() => setViewMode("series")}
+							aria-pressed={viewMode === "series"}
+						>
+							シリーズ別
+						</button>
+						<button
+							type="button"
+							className={`btn btn-sm ${viewMode === "year" ? "btn-primary" : "btn-ghost"}`}
+							onClick={() => setViewMode("year")}
+							aria-pressed={viewMode === "year"}
+						>
+							年別
+						</button>
+					</div>
 				</div>
 			</div>
 

--- a/apps/web/src/routes/_public/official-works.tsx
+++ b/apps/web/src/routes/_public/official-works.tsx
@@ -177,14 +177,22 @@ function OfficialWorksPage() {
 			<PublicBreadcrumb items={[{ label: "公式作品" }]} />
 
 			{/* ヘッダー */}
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div>
-					<h1 className="font-bold text-3xl">公式作品一覧</h1>
-					<p className="mt-1 text-base-content/70">
-						東方Project公式作品 · {total}件
-					</p>
+			<div className="glass-card relative overflow-hidden rounded-2xl p-6 md:p-8">
+				<div className="gradient-mesh absolute inset-0" />
+				<div className="relative flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+					<div className="flex items-center gap-4">
+						<div className="flex size-14 items-center justify-center rounded-2xl bg-primary text-primary-content">
+							<Disc3 className="size-7" aria-hidden="true" />
+						</div>
+						<div>
+							<h1 className="font-bold text-2xl md:text-3xl">公式作品一覧</h1>
+							<p className="mt-1 text-base-content/60">
+								東方Project公式作品 · {total}件
+							</p>
+						</div>
+					</div>
+					<ViewToggle value={view} onChange={handleViewChange} />
 				</div>
-				<ViewToggle value={view} onChange={handleViewChange} />
 			</div>
 
 			{/* カテゴリフィルター */}

--- a/apps/web/src/routes/_public/original-songs.tsx
+++ b/apps/web/src/routes/_public/original-songs.tsx
@@ -250,29 +250,37 @@ function OriginalSongsPage() {
 			<PublicBreadcrumb items={[{ label: "原曲" }]} />
 
 			{/* ヘッダー */}
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div>
-					<h1 className="font-bold text-3xl">原曲一覧</h1>
-					<p className="mt-1 text-base-content/70">
-						東方Project公式楽曲 · {works.length}作品 · {totalSongCount}曲
-					</p>
-				</div>
-				<div className="flex gap-2">
-					{/* モバイルフィルターボタン */}
-					<FilterDrawerTrigger
-						onClick={() => setIsFilterDrawerOpen(true)}
-						activeFilterCount={activeFilterCount}
-					/>
-					<Link
-						to="/official-works"
-						preload="intent"
-						className="btn btn-outline btn-sm gap-1"
-					>
-						<Music className="size-4" />
-						<span className="xs:inline hidden">公式作品一覧</span>
-						<span className="xs:hidden">公式作品</span>
-						<ChevronRight className="size-4" />
-					</Link>
+			<div className="glass-card relative overflow-hidden rounded-2xl p-6 md:p-8">
+				<div className="gradient-mesh absolute inset-0" />
+				<div className="relative flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+					<div className="flex items-center gap-4">
+						<div className="flex size-14 items-center justify-center rounded-2xl bg-primary text-primary-content">
+							<Music className="size-7" aria-hidden="true" />
+						</div>
+						<div>
+							<h1 className="font-bold text-2xl md:text-3xl">原曲一覧</h1>
+							<p className="mt-1 text-base-content/60">
+								東方Project公式楽曲 · {works.length}作品 · {totalSongCount}曲
+							</p>
+						</div>
+					</div>
+					<div className="flex gap-2">
+						{/* モバイルフィルターボタン */}
+						<FilterDrawerTrigger
+							onClick={() => setIsFilterDrawerOpen(true)}
+							activeFilterCount={activeFilterCount}
+						/>
+						<Link
+							to="/official-works"
+							preload="intent"
+							className="btn btn-outline btn-sm gap-1"
+						>
+							<Music className="size-4" />
+							<span className="xs:inline hidden">公式作品一覧</span>
+							<span className="xs:hidden">公式作品</span>
+							<ChevronRight className="size-4" />
+						</Link>
+					</div>
 				</div>
 			</div>
 


### PR DESCRIPTION
## 概要

統計ダッシュボードで使用されているアイコン付きページタイトルスタイル（glass-card）を各一覧ページに適用し、UIの一貫性を向上させる。

## 変更内容

- 原曲一覧ページ（Music アイコン）
- 公式作品一覧ページ（Disc3 アイコン）
- サークル一覧ページ（Users アイコン）
- アーティスト一覧ページ（UserRound アイコン）
- イベント一覧ページ（Calendar アイコン）

各ページで以下の変更を実施:
- `glass-card` クラスを使用したガラスモーフィズムカード
- `gradient-mesh` 背景グラデーション効果
- アイコン付きのヘッダーデザイン（各エンティティに対応するアイコンを使用）
- 既存のアクションボタン（フィルター、表示切替）の配置を維持

## 影響範囲

- 原曲一覧: `/original-songs`
- 公式作品一覧: `/official-works`
- サークル一覧: `/circles`
- アーティスト一覧: `/artists`
- イベント一覧: `/events`

## 補足事項

アイコンは既存の `public-breadcrumb.tsx` の `ENTITY_ICONS` マッピングに準拠。