### PR TITLE
feat: 統計ダッシュボードに役割別アーティスト数とトラック数を追加

### DIFF
--- a/apps/server/src/routes/public/stats.ts
+++ b/apps/server/src/routes/public/stats.ts
@@ -8,6 +8,7 @@ import {
 	db,
 	desc,
 	eq,
+	eventSeries,
 	events,
 	isNotNull,
 	ne,
@@ -16,8 +17,10 @@ import {
 	releaseCircles,
 	releases,
 	sql,
+	trackCreditRoles,
 	trackCredits,
 	trackOfficialSongs,
+	tracks,
 } from "@thac/db";
 import { Hono } from "hono";
 import { handleDbError } from "../../utils/api-error";
@@ -45,6 +48,13 @@ statsRouter.get("/", async (c) => {
 			return c.json(cached);
 		}
 
+		// 名義単位のユニーク識別子を生成するSQL式
+		const artistAliasIdentifier = sql`CASE
+			WHEN ${trackCredits.artistAliasId} IS NULL
+			THEN ${trackCredits.artistId} || '__main__'
+			ELSE ${trackCredits.artistAliasId}
+		END`;
+
 		const [
 			eventsResult,
 			circlesResult,
@@ -52,6 +62,11 @@ statsRouter.get("/", async (c) => {
 			tracksResult,
 			originalSongsResult,
 			releasesResult,
+			eventSeriesResult,
+			totalTracksResult,
+			vocalistsResult,
+			arrangersResult,
+			lyricistsResult,
 		] = await Promise.all([
 			db.select({ count: count() }).from(events),
 			db.select({ count: count() }).from(circles),
@@ -81,6 +96,41 @@ statsRouter.get("/", async (c) => {
 				.select({ count: count() })
 				.from(officialSongs),
 			db.select({ count: count() }).from(releases),
+			// イベントシリーズ数を取得
+			db
+				.select({ count: count() })
+				.from(eventSeries),
+			// 全トラック数を取得
+			db
+				.select({ count: count() })
+				.from(tracks),
+			// ボーカリスト数を取得（名義単位でユニークカウント）
+			db
+				.select({ count: countDistinct(artistAliasIdentifier) })
+				.from(trackCredits)
+				.innerJoin(
+					trackCreditRoles,
+					eq(trackCredits.id, trackCreditRoles.trackCreditId),
+				)
+				.where(eq(trackCreditRoles.roleCode, "vocalist")),
+			// アレンジャー数を取得（名義単位でユニークカウント）
+			db
+				.select({ count: countDistinct(artistAliasIdentifier) })
+				.from(trackCredits)
+				.innerJoin(
+					trackCreditRoles,
+					eq(trackCredits.id, trackCreditRoles.trackCreditId),
+				)
+				.where(eq(trackCreditRoles.roleCode, "arranger")),
+			// 作詞者数を取得（名義単位でユニークカウント）
+			db
+				.select({ count: countDistinct(artistAliasIdentifier) })
+				.from(trackCredits)
+				.innerJoin(
+					trackCreditRoles,
+					eq(trackCredits.id, trackCreditRoles.trackCreditId),
+				)
+				.where(eq(trackCreditRoles.roleCode, "lyricist")),
 		]);
 
 		const response = {
@@ -90,6 +140,11 @@ statsRouter.get("/", async (c) => {
 			tracks: tracksResult[0]?.count ?? 0,
 			originalSongs: originalSongsResult[0]?.count ?? 0,
 			releases: releasesResult[0]?.count ?? 0,
+			eventSeries: eventSeriesResult[0]?.count ?? 0,
+			totalTracks: totalTracksResult[0]?.count ?? 0,
+			vocalists: vocalistsResult[0]?.count ?? 0,
+			arrangers: arrangersResult[0]?.count ?? 0,
+			lyricists: lyricistsResult[0]?.count ?? 0,
 		};
 
 		setCache(cacheKey, response, CACHE_TTL.PUBLIC_STATS);

--- a/apps/web/src/components/public/hero-section.tsx
+++ b/apps/web/src/components/public/hero-section.tsx
@@ -48,6 +48,11 @@ export function HeroSection({ stats }: HeroSectionProps) {
 		tracks: stats?.tracks ?? 0,
 		originalSongs: stats?.originalSongs ?? 0,
 		releases: stats?.releases ?? 0,
+		eventSeries: stats?.eventSeries ?? 0,
+		totalTracks: stats?.totalTracks ?? 0,
+		vocalists: stats?.vocalists ?? 0,
+		arrangers: stats?.arrangers ?? 0,
+		lyricists: stats?.lyricists ?? 0,
 	};
 
 	return (

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -41,6 +41,11 @@ export interface PublicStats {
 	tracks: number;
 	originalSongs: number;
 	releases: number;
+	eventSeries: number;
+	totalTracks: number;
+	vocalists: number;
+	arrangers: number;
+	lyricists: number;
 }
 
 /** ランキング項目 */

--- a/apps/web/src/routes/_public/events.tsx
+++ b/apps/web/src/routes/_public/events.tsx
@@ -32,6 +32,7 @@ const STORAGE_KEY_EXPANDED = "events-expanded-series";
 
 interface EventsSearchParams {
 	search?: string;
+	view?: EventsViewMode;
 }
 
 export const Route = createFileRoute("/_public/events")({
@@ -57,8 +58,10 @@ export const Route = createFileRoute("/_public/events")({
 	},
 	component: EventsPage,
 	validateSearch: (search: Record<string, unknown>): EventsSearchParams => {
+		const view = search.view;
 		return {
 			search: typeof search.search === "string" ? search.search : undefined,
+			view: view === "series" || view === "year" ? view : undefined,
 		};
 	},
 });
@@ -82,7 +85,7 @@ function getYear(dateStr: string | null): number | null {
 
 function EventsPage() {
 	const navigate = useNavigate();
-	const { search = "" } = Route.useSearch();
+	const { search = "", view: urlView } = Route.useSearch();
 	const { events, total } = Route.useLoaderData();
 
 	// 検索入力のローカルステート（IME対応）
@@ -124,8 +127,15 @@ function EventsPage() {
 	};
 
 	useEffect(() => {
-		const savedView = localStorage.getItem(STORAGE_KEY_VIEW) as EventsViewMode;
-		if (savedView) setViewModeState(savedView);
+		// URLパラメータを優先、なければlocalStorageから復元
+		if (urlView) {
+			setViewModeState(urlView);
+		} else {
+			const savedView = localStorage.getItem(
+				STORAGE_KEY_VIEW,
+			) as EventsViewMode;
+			if (savedView) setViewModeState(savedView);
+		}
 		const savedYear = localStorage.getItem(STORAGE_KEY_YEAR);
 		if (savedYear) setSelectedYearState(Number(savedYear));
 		const savedExpanded = localStorage.getItem(STORAGE_KEY_EXPANDED);
@@ -136,7 +146,7 @@ function EventsPage() {
 				// Keep default
 			}
 		}
-	}, []);
+	}, [urlView]);
 
 	// 初期選択年を設定
 	useEffect(() => {
@@ -155,6 +165,10 @@ function EventsPage() {
 	const setViewMode = (view: EventsViewMode) => {
 		setViewModeState(view);
 		localStorage.setItem(STORAGE_KEY_VIEW, view);
+		navigate({
+			to: "/events",
+			search: (prev) => ({ ...prev, view }),
+		});
 	};
 
 	const setSelectedYear = (year: number) => {

--- a/apps/web/src/routes/_public/stats.tsx
+++ b/apps/web/src/routes/_public/stats.tsx
@@ -1,13 +1,19 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
+	ArrowRight,
 	BarChart3,
 	Calendar,
+	CalendarRange,
 	Crown,
 	Disc3,
+	ListMusic,
 	type LucideIcon,
+	Mic2,
 	Music,
 	PenLine,
+	PenTool,
+	Sliders,
 	Sparkles,
 	TrendingUp,
 	Trophy,
@@ -77,6 +83,12 @@ function StatCard({
 						<TrendingUp className="size-3" aria-hidden="true" />
 						<span>+{trend}%</span>
 					</div>
+				)}
+				{href && (
+					<ArrowRight
+						className="size-5 text-base-content/30 transition-all duration-300 group-hover:translate-x-1 group-hover:text-primary"
+						aria-hidden="true"
+					/>
 				)}
 			</div>
 			<div>
@@ -358,14 +370,18 @@ function StatsPage() {
 	const { stats } = Route.useLoaderData();
 
 	// プロパティレベルでフォールバックを適用
-	const displayStats = {
-		events: stats?.events ?? 0,
-		circles: stats?.circles ?? 0,
-		artists: stats?.artists ?? 0,
-		tracks: stats?.tracks ?? 0,
-		originalSongs: stats?.originalSongs ?? 0,
-		releases: stats?.releases ?? 0,
-	};
+	const {
+		events = 0,
+		circles = 0,
+		artists = 0,
+		releases = 0,
+		tracks: arranges = 0,
+		eventSeries = 0,
+		totalTracks = 0,
+		vocalists = 0,
+		arrangers = 0,
+		lyricists = 0,
+	} = stats ?? {};
 
 	return (
 		<div className="space-y-8">
@@ -389,51 +405,102 @@ function StatsPage() {
 				</div>
 			</div>
 
-			{/* Stats cards */}
-			<section>
-				<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
-					<StatCard
-						icon={Music}
-						count={displayStats.originalSongs}
-						label="原曲"
-						href="/original-songs"
-						color="text-secondary"
-					/>
-					<StatCard
-						icon={Calendar}
-						count={displayStats.events}
-						label="イベント"
-						href="/events"
-						color="text-info"
-					/>
-					<StatCard
-						icon={Users}
-						count={displayStats.circles}
-						label="サークル"
-						href="/circles"
-						color="text-primary"
-					/>
-					<StatCard
-						icon={UserRound}
-						count={displayStats.artists}
-						label="アーティスト"
-						href="/artists"
-						color="text-accent"
-					/>
-					<StatCard
-						icon={Disc3}
-						count={displayStats.releases}
-						label="作品"
-						color="text-warning"
-					/>
-					<StatCard
-						icon={Music}
-						count={displayStats.tracks}
-						label="アレンジ"
-						color="text-success"
-					/>
-				</div>
-			</section>
+			{/* Stats cards - Category sections */}
+			<div className="space-y-8">
+				{/* 楽曲データ */}
+				<section>
+					<h2 className="mb-3 font-medium text-base-content/60 text-sm">
+						楽曲データ
+					</h2>
+					<div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+						<StatCard
+							icon={Disc3}
+							count={releases}
+							label="作品"
+							color="text-warning"
+						/>
+						<StatCard
+							icon={ListMusic}
+							count={totalTracks}
+							label="トラック"
+							color="text-secondary"
+						/>
+						<StatCard
+							icon={Music}
+							count={arranges}
+							label="アレンジ"
+							color="text-success"
+						/>
+					</div>
+				</section>
+
+				{/* サークル・イベント */}
+				<section>
+					<h2 className="mb-3 font-medium text-base-content/60 text-sm">
+						サークル・イベント
+					</h2>
+					<div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+						<StatCard
+							icon={Users}
+							count={circles}
+							label="サークル"
+							href="/circles"
+							color="text-primary"
+						/>
+						<StatCard
+							icon={Calendar}
+							count={events}
+							label="イベント"
+							href="/events?view=year"
+							color="text-info"
+						/>
+						<StatCard
+							icon={CalendarRange}
+							count={eventSeries}
+							label="イベントシリーズ"
+							href="/events?view=series"
+							color="text-info"
+						/>
+					</div>
+				</section>
+
+				{/* アーティスト（役割別） */}
+				<section>
+					<h2 className="mb-3 font-medium text-base-content/60 text-sm">
+						アーティスト（役割別）
+					</h2>
+					<div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+						<StatCard
+							icon={UserRound}
+							count={artists}
+							label="アーティスト"
+							href="/artists"
+							color="text-accent"
+						/>
+						<StatCard
+							icon={Mic2}
+							count={vocalists}
+							label="ボーカリスト"
+							href="/artists?role=vocalist"
+							color="text-error"
+						/>
+						<StatCard
+							icon={Sliders}
+							count={arrangers}
+							label="編曲者"
+							href="/artists?role=arranger"
+							color="text-purple-500"
+						/>
+						<StatCard
+							icon={PenTool}
+							count={lyricists}
+							label="作詞者"
+							href="/artists?role=lyricist"
+							color="text-orange-500"
+						/>
+					</div>
+				</section>
+			</div>
 
 			{/* Ranking sections with Suspense */}
 			<Suspense fallback={<RankingsSkeleton />}>


### PR DESCRIPTION
## 概要

統計ダッシュボード（/stats）に役割別アーティスト数、トラック数、イベントシリーズ数を追加し、カテゴリ別レイアウトに改善。

## 変更内容

### バックエンド (apps/server)
* イベントシリーズ数、トラック数のカウントクエリを追加
* 役割別アーティスト数（ボーカリスト、編曲者、作詞者）のクエリを追加
  * メイン名義と別名義を区別してユニークカウント

### フロントエンド (apps/web)

#### 統計ダッシュボード (stats.tsx)
* カテゴリ別レイアウトに変更
  * 楽曲データ: 作品、トラック、アレンジ
  * サークル・イベント: サークル、イベント、イベントシリーズ
  * アーティスト（役割別）: アーティスト、ボーカリスト、編曲者、作詞者
* リンク付きカードに矢印アイコンを追加
* 役割別カードからアーティスト一覧へのフィルター付きリンク
  * `/artists?role=vocalist` 等

#### イベントページ (events.tsx)
* URLパラメータ `view` を追加（series | year）
* 表示モード切り替えボタンでURLも更新されるように改善
* 統計ダッシュボードからのリンク対応
  * イベント → `/events?view=year`
  * イベントシリーズ → `/events?view=series`

## 影響範囲

* 統計ダッシュボード（/stats）の表示が変更
* イベント一覧（/events）のURL構造に `view` パラメータを追加