### PR TITLE
feat: 統計ページに原曲2曲組み合わせランキングを追加

### DIFF
--- a/apps/server/src/routes/public/stats.ts
+++ b/apps/server/src/routes/public/stats.ts
@@ -502,6 +502,176 @@ statsRouter.get("/rankings/artists", async (c) => {
 });
 
 /**
+ * GET /api/public/stats/rankings/song-pairs
+ * 原曲2曲組み合わせランキング（ページネーション対応）
+ * ちょうど2曲の原曲を持つトラックのペアをカウント
+ */
+statsRouter.get("/rankings/song-pairs", async (c) => {
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Number(c.req.query("limit")) || 20;
+		const offset = (page - 1) * limit;
+
+		const cacheKey = cacheKeys.songPairsRanking({ page, limit });
+
+		const cached = getCache<unknown>(cacheKey);
+		if (cached) {
+			setCacheHeaders(c, { maxAge: CACHE_TTL.STATS_RANKINGS });
+			return c.json(cached);
+		}
+
+		// ちょうど2曲の原曲を持つトラックIDを取得するサブクエリ
+		const twoSongTracksSubquery = db
+			.select({ trackId: trackOfficialSongs.trackId })
+			.from(trackOfficialSongs)
+			.innerJoin(
+				officialSongs,
+				eq(trackOfficialSongs.officialSongId, officialSongs.id),
+			)
+			.innerJoin(
+				officialWorks,
+				eq(officialSongs.officialWorkId, officialWorks.id),
+			)
+			.where(
+				and(
+					isNotNull(trackOfficialSongs.officialSongId),
+					ne(officialWorks.id, "0799"),
+				),
+			)
+			.groupBy(trackOfficialSongs.trackId)
+			.having(sql`COUNT(DISTINCT ${trackOfficialSongs.officialSongId}) = 2`)
+			.as("two_song_tracks");
+
+		// 総ペア数を取得（ユニークペアの数）
+		// 「その他」(0799)を両方の曲で除外
+		const totalPairsResult = await db
+			.select({
+				count: countDistinct(
+					sql`MIN(${trackOfficialSongs.officialSongId}, t2.official_song_id) || '|' || MAX(${trackOfficialSongs.officialSongId}, t2.official_song_id)`,
+				),
+			})
+			.from(trackOfficialSongs)
+			.innerJoin(
+				officialSongs,
+				eq(trackOfficialSongs.officialSongId, officialSongs.id),
+			)
+			.innerJoin(
+				officialWorks,
+				eq(officialSongs.officialWorkId, officialWorks.id),
+			)
+			.innerJoin(
+				sql`${trackOfficialSongs} AS t2`,
+				sql`${trackOfficialSongs.trackId} = t2.track_id AND ${trackOfficialSongs.officialSongId} < t2.official_song_id`,
+			)
+			.innerJoin(
+				sql`${officialSongs} AS os2`,
+				sql`t2.official_song_id = os2.id`,
+			)
+			.innerJoin(
+				sql`${officialWorks} AS ow2`,
+				sql`os2.official_work_id = ow2.id`,
+			)
+			.innerJoin(
+				twoSongTracksSubquery,
+				eq(trackOfficialSongs.trackId, twoSongTracksSubquery.trackId),
+			)
+			.where(and(ne(officialWorks.id, "0799"), sql`ow2.id != '0799'`));
+
+		const total = totalPairsResult[0]?.count ?? 0;
+
+		// ペアごとのカウントを取得してランキング
+		// 「その他」(0799)を両方の曲で除外
+		const rankingResult = await db
+			.select({
+				song1Id: sql<string>`MIN(${trackOfficialSongs.officialSongId}, t2.official_song_id)`,
+				song2Id: sql<string>`MAX(${trackOfficialSongs.officialSongId}, t2.official_song_id)`,
+				count: count(),
+			})
+			.from(trackOfficialSongs)
+			.innerJoin(
+				officialSongs,
+				eq(trackOfficialSongs.officialSongId, officialSongs.id),
+			)
+			.innerJoin(
+				officialWorks,
+				eq(officialSongs.officialWorkId, officialWorks.id),
+			)
+			.innerJoin(
+				sql`${trackOfficialSongs} AS t2`,
+				sql`${trackOfficialSongs.trackId} = t2.track_id AND ${trackOfficialSongs.officialSongId} < t2.official_song_id`,
+			)
+			.innerJoin(
+				sql`${officialSongs} AS os2`,
+				sql`t2.official_song_id = os2.id`,
+			)
+			.innerJoin(
+				sql`${officialWorks} AS ow2`,
+				sql`os2.official_work_id = ow2.id`,
+			)
+			.innerJoin(
+				twoSongTracksSubquery,
+				eq(trackOfficialSongs.trackId, twoSongTracksSubquery.trackId),
+			)
+			.where(and(ne(officialWorks.id, "0799"), sql`ow2.id != '0799'`))
+			.groupBy(
+				sql`MIN(${trackOfficialSongs.officialSongId}, t2.official_song_id)`,
+				sql`MAX(${trackOfficialSongs.officialSongId}, t2.official_song_id)`,
+			)
+			.orderBy(desc(count()))
+			.limit(limit)
+			.offset(offset);
+
+		// 原曲名を取得するために、必要なIDを収集
+		const songIds = new Set<string>();
+		for (const row of rankingResult) {
+			songIds.add(row.song1Id);
+			songIds.add(row.song2Id);
+		}
+
+		// 原曲名を一括取得
+		const songNames = new Map<string, string>();
+		if (songIds.size > 0) {
+			const songsResult = await db
+				.select({
+					id: officialSongs.id,
+					name: officialSongs.name,
+				})
+				.from(officialSongs)
+				.where(
+					sql`${officialSongs.id} IN (${sql.join(
+						[...songIds].map((id) => sql`${id}`),
+						sql`, `,
+					)})`,
+				);
+
+			for (const song of songsResult) {
+				songNames.set(song.id, song.name);
+			}
+		}
+
+		const response = {
+			data: rankingResult.map((row) => ({
+				song1Id: row.song1Id,
+				song1Name: songNames.get(row.song1Id) ?? "",
+				song2Id: row.song2Id,
+				song2Name: songNames.get(row.song2Id) ?? "",
+				count: row.count,
+			})),
+			total,
+			page,
+			limit,
+		};
+
+		setCache(cacheKey, response, CACHE_TTL.STATS_RANKINGS);
+		setCacheHeaders(c, { maxAge: CACHE_TTL.STATS_RANKINGS });
+
+		return c.json(response);
+	} catch (error) {
+		return handleDbError(c, error, "GET /api/public/stats/rankings/song-pairs");
+	}
+});
+
+/**
  * GET /api/public/stats/recent-updates
  * 最近の更新情報を取得
  */

--- a/apps/server/src/utils/cache.ts
+++ b/apps/server/src/utils/cache.ts
@@ -275,4 +275,6 @@ export const cacheKeys = {
 		`public:stats:rankings:circles:page=${params.page}:limit=${params.limit}`,
 	artistsRanking: (params: { page: number; limit: number }) =>
 		`public:stats:rankings:artists:page=${params.page}:limit=${params.limit}`,
+	songPairsRanking: (params: { page: number; limit: number }) =>
+		`public:stats:rankings:song-pairs:page=${params.page}:limit=${params.limit}`,
 };

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -486,6 +486,15 @@ export interface ArtistRankingItem {
 	count: number;
 }
 
+/** 原曲2曲組み合わせランキング項目 */
+export interface SongPairRankingItem {
+	song1Id: string;
+	song1Name: string;
+	song2Id: string;
+	song2Name: string;
+	count: number;
+}
+
 // =============================================================================
 // 統計API型定義
 // =============================================================================
@@ -624,6 +633,16 @@ export const publicApi = {
 			const query = sp.toString();
 			return publicFetch<PaginatedResponse<ArtistRankingItem>>(
 				`/api/public/stats/rankings/artists${query ? `?${query}` : ""}`,
+			);
+		},
+		/** 原曲2曲組み合わせランキング（ページネーション対応） */
+		songPairsRanking: (params?: { page?: number; limit?: number }) => {
+			const sp = new URLSearchParams();
+			if (params?.page) sp.set("page", String(params.page));
+			if (params?.limit) sp.set("limit", String(params.limit));
+			const query = sp.toString();
+			return publicFetch<PaginatedResponse<SongPairRankingItem>>(
+				`/api/public/stats/rankings/song-pairs${query ? `?${query}` : ""}`,
 			);
 		},
 	}),

--- a/apps/web/src/lib/public-query-options.ts
+++ b/apps/web/src/lib/public-query-options.ts
@@ -12,6 +12,7 @@ import {
 	type PublicCircleItem,
 	type PublicEventRelease,
 	publicApi,
+	type SongPairRankingItem,
 	type SongStatsResponse,
 	type StackedWorkStatsResponse,
 	type WorkStatsResponse,
@@ -373,6 +374,23 @@ export const artistsRankingInfiniteQueryOptions = (limit = 20) => {
 			publicApi.stats.artistsRanking({ page: pageParam, limit }),
 		initialPageParam: 1,
 		getNextPageParam: (lastPage: PaginatedResponse<ArtistRankingItem>) => {
+			const hasMore = lastPage.page * lastPage.limit < lastPage.total;
+			return hasMore ? lastPage.page + 1 : undefined;
+		},
+		staleTime: STALE_TIME_PUBLIC.RANKINGS,
+	});
+};
+
+/**
+ * 原曲2曲組み合わせランキングの無限スクロールクエリオプション
+ */
+export const songPairsRankingInfiniteQueryOptions = (limit = 20) => {
+	return infiniteQueryOptions({
+		queryKey: ["public", "stats", "rankings", "song-pairs", limit],
+		queryFn: ({ pageParam }) =>
+			publicApi.stats.songPairsRanking({ page: pageParam, limit }),
+		initialPageParam: 1,
+		getNextPageParam: (lastPage: PaginatedResponse<SongPairRankingItem>) => {
 			const hasMore = lastPage.page * lastPage.limit < lastPage.total;
 			return hasMore ? lastPage.page + 1 : undefined;
 		},

--- a/apps/web/src/routes/_public/stats.tsx
+++ b/apps/web/src/routes/_public/stats.tsx
@@ -5,6 +5,7 @@ import {
 	BarChart3,
 	Calendar,
 	CalendarRange,
+	Combine,
 	Crown,
 	Disc3,
 	ListMusic,
@@ -285,6 +286,33 @@ function RankingsSection() {
 						/>
 					))}
 				</div>
+			</section>
+
+			{/* Song pairs ranking - placeholder card linking to full ranking */}
+			<section className="glass-card overflow-hidden rounded-2xl lg:col-span-3">
+				<Link
+					to="/stats/song-pairs"
+					preload="intent"
+					className="group flex items-center justify-between p-5 transition-all duration-300 hover:bg-base-content/5"
+				>
+					<div className="flex items-center gap-3">
+						<div className="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-pink-500/10 to-purple-500/10 text-pink-500">
+							<Combine className="size-5" aria-hidden="true" />
+						</div>
+						<div>
+							<h2 className="font-bold">原曲2曲組み合わせランキング</h2>
+							<p className="text-base-content/60 text-sm">
+								2曲の原曲を組み合わせたアレンジの統計
+							</p>
+						</div>
+					</div>
+					<span className="flex items-center gap-1 text-primary text-sm transition-colors">
+						すべて見る
+						<span className="transition-transform group-hover:translate-x-0.5">
+							→
+						</span>
+					</span>
+				</Link>
 			</section>
 		</div>
 	);

--- a/apps/web/src/routes/_public/stats_.song-pairs.tsx
+++ b/apps/web/src/routes/_public/stats_.song-pairs.tsx
@@ -1,0 +1,116 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Combine } from "lucide-react";
+import {
+	EmptyState,
+	PublicBreadcrumb,
+	RankBadge,
+	RankingList,
+} from "@/components/public";
+import { formatNumber } from "@/lib/format";
+import { createPageHead } from "@/lib/head";
+import { songPairsRankingInfiniteQueryOptions } from "@/lib/public-query-options";
+
+const PAGE_SIZE = 20;
+
+export const Route = createFileRoute("/_public/stats_/song-pairs")({
+	head: () => createPageHead("原曲2曲組み合わせランキング"),
+	component: SongPairsRankingPage,
+});
+
+function SongPairsRankingPage() {
+	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+		useInfiniteQuery(songPairsRankingInfiniteQueryOptions(PAGE_SIZE));
+
+	// ページデータをフラット化
+	const pairs = data?.pages.flatMap((page) => page.data) ?? [];
+	const total = data?.pages[0]?.total ?? 0;
+
+	return (
+		<div className="space-y-6">
+			<PublicBreadcrumb
+				items={[
+					{ label: "統計", href: "/stats" },
+					{ label: "原曲2曲組み合わせランキング" },
+				]}
+			/>
+
+			{/* ヘッダー */}
+			<div className="glass-card relative overflow-hidden rounded-2xl p-6 md:p-8">
+				<div className="gradient-mesh absolute inset-0" />
+				<div className="relative flex items-center gap-4">
+					<div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-pink-500/10 to-purple-500/10 text-pink-500">
+						<Combine className="size-7" aria-hidden="true" />
+					</div>
+					<div>
+						<h1 className="font-bold text-2xl md:text-3xl">
+							原曲2曲組み合わせランキング
+						</h1>
+						<p className="mt-1 text-base-content/60">
+							2曲の原曲を組み合わせたアレンジ · {formatNumber(total)}件
+						</p>
+					</div>
+				</div>
+			</div>
+
+			{/* コンテンツ */}
+			{isLoading ? (
+				<div className="flex items-center justify-center py-12">
+					<span className="loading loading-spinner loading-lg" />
+				</div>
+			) : pairs.length === 0 ? (
+				<EmptyState
+					type="search"
+					title="ランキングデータがありません"
+					description="データが存在しません"
+				/>
+			) : (
+				<div className="glass-card overflow-hidden rounded-2xl">
+					<RankingList
+						items={pairs}
+						getCount={(pair) => pair.count}
+						renderItem={(pair, rank, medal) => (
+							<div
+								key={`${pair.song1Id}-${pair.song2Id}`}
+								className="group flex items-center gap-3 px-4 py-3 transition-all duration-300 hover:bg-base-content/5"
+							>
+								<RankBadge rank={rank} medal={medal} />
+								<div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-pink-500 to-purple-500 text-white">
+									<Combine className="size-5" aria-hidden="true" />
+								</div>
+								<div className="min-w-0 flex-1">
+									<div className="flex flex-wrap items-center gap-1">
+										<Link
+											to="/original-songs/$id"
+											params={{ id: pair.song1Id }}
+											preload="intent"
+											className="truncate font-medium transition-colors hover:text-primary"
+										>
+											{pair.song1Name}
+										</Link>
+										<span className="text-base-content/40">×</span>
+										<Link
+											to="/original-songs/$id"
+											params={{ id: pair.song2Id }}
+											preload="intent"
+											className="truncate font-medium transition-colors hover:text-primary"
+										>
+											{pair.song2Name}
+										</Link>
+									</div>
+								</div>
+								<span className="whitespace-nowrap rounded-full bg-base-content/5 px-2.5 py-1 text-base-content/60 text-xs">
+									{formatNumber(pair.count)} アレンジ
+								</span>
+							</div>
+						)}
+						isFetchingNextPage={isFetchingNextPage}
+						hasNextPage={hasNextPage ?? false}
+						fetchNextPage={fetchNextPage}
+						totalCount={total}
+					/>
+				</div>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## 概要

統計ページに「原曲2曲組み合わせランキング」機能を追加。2つの異なる原曲を組み合わせてアレンジした楽曲数をランキング表示する。

## 変更内容

* APIエンドポイント追加: `GET /api/public/stats/rankings/song-pairs`
  - ちょうど2曲の原曲を持つトラックのペアをカウント
  - ページネーション対応（page, limit パラメータ）
  - 5分間のキャッシュ
* ランキング詳細ページ追加: `/stats/song-pairs`
  - 無限スクロールによるページネーション
  - 各曲名から原曲詳細ページへのリンク
  - ピンク〜パープルのグラデーションテーマ
* 統計ダッシュボード (`/stats`) にリンクカード追加

## 影響範囲

* バックエンド: `apps/server/src/routes/public/stats.ts`
* フロントエンド: `apps/web/src/routes/_public/stats.tsx`, 新規ページ追加

## 補足事項

* 「その他」（`official_work_id = '0799'`）に属する原曲は除外
* 原曲の紐付き順（part_position）は問わない（A×B と B×A は同一ペアとしてカウント）