### PR TITLE
fix: ジャンルバッジのテキスト色をdaisyUIテーマ変数に変更

### DIFF
--- a/apps/web/src/components/public/genre-badge.tsx
+++ b/apps/web/src/components/public/genre-badge.tsx
@@ -12,64 +12,12 @@ interface GenreBadgeProps {
 }
 
 /**
- * Hex color からRGB値を取得
- */
-function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
-	const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-	return result
-		? {
-				r: Number.parseInt(result[1], 16),
-				g: Number.parseInt(result[2], 16),
-				b: Number.parseInt(result[3], 16),
-			}
-		: null;
-}
-
-/**
- * 色を白とブレンドして実際の表示色を計算
- * @param rgb 元の色
- * @param alpha 透過度（0-1）
- * @returns 白背景とブレンドした色
- */
-function blendWithWhite(
-	rgb: { r: number; g: number; b: number },
-	alpha: number,
-): { r: number; g: number; b: number } {
-	return {
-		r: Math.round(rgb.r * alpha + 255 * (1 - alpha)),
-		g: Math.round(rgb.g * alpha + 255 * (1 - alpha)),
-		b: Math.round(rgb.b * alpha + 255 * (1 - alpha)),
-	};
-}
-
-/**
- * 背景色の明るさを判定し、テキスト色を決定
- * 20%透過の実際の表示色を考慮してWCAGコントラスト比を計算
- */
-function getContrastColor(hexColor: string): string {
-	const rgb = hexToRgb(hexColor);
-	if (!rgb) return "inherit";
-
-	// 20%透過で白背景とブレンドした実際の表示色を計算
-	const blendedRgb = blendWithWhite(rgb, 0.2);
-
-	// 相対輝度を計算（WCAG方式）
-	const luminance =
-		(0.299 * blendedRgb.r + 0.587 * blendedRgb.g + 0.114 * blendedRgb.b) / 255;
-
-	// 白背景とのブレンドで明るくなるため、閾値を高めに設定
-	return luminance > 0.75 ? "#1f2937" : "#374151";
-}
-
-/**
  * 値がReactコンポーネントかどうかを判定
- * forwardRefコンポーネントも含めて判定する
  */
 function isReactComponent(
 	value: unknown,
 ): value is React.ComponentType<{ className?: string }> {
 	if (typeof value === "function") return true;
-	// forwardRefコンポーネントはオブジェクトで$$typeofを持つ
 	if (value && typeof value === "object" && "$$typeof" in value) return true;
 	return false;
 }
@@ -80,7 +28,6 @@ function isReactComponent(
 function getLucideIcon(
 	iconName: string,
 ): React.ComponentType<{ className?: string }> | null {
-	// kebab-case を PascalCase に変換
 	const pascalCase = iconName
 		.split("-")
 		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
@@ -88,7 +35,6 @@ function getLucideIcon(
 
 	// biome-ignore lint/performance/noDynamicNamespaceImportAccess: Dynamic icon loading is intentional
 	const IconComponent = LucideIcons[pascalCase as keyof typeof LucideIcons];
-	// Reactコンポーネント（関数またはforwardRef）かどうかをチェック
 	if (isReactComponent(IconComponent)) {
 		return IconComponent;
 	}
@@ -97,11 +43,9 @@ function getLucideIcon(
 
 /**
  * 公開画面用ジャンルバッジコンポーネント
- * 読み取り専用（削除ボタンなし）、smサイズのみ
  */
 function GenreBadge({ code, name, color, icon, className }: GenreBadgeProps) {
 	const IconComponent = icon ? getLucideIcon(icon) : null;
-	const textColor = getContrastColor(color);
 
 	return (
 		<span
@@ -112,9 +56,9 @@ function GenreBadge({ code, name, color, icon, className }: GenreBadgeProps) {
 				className,
 			)}
 			style={{
-				backgroundColor: `${color}33`, // 20% opacity
-				borderColor: `${color}66`, // 40% opacity for border
-				color: textColor,
+				backgroundColor: `${color}33`,
+				borderColor: `${color}66`,
+				color: "var(--bc)",
 			}}
 		>
 			{IconComponent && <IconComponent className="size-3" />}

--- a/apps/web/src/components/ui/genre-badge.tsx
+++ b/apps/web/src/components/ui/genre-badge.tsx
@@ -15,64 +15,12 @@ interface GenreBadgeProps {
 }
 
 /**
- * Hex color からRGB値を取得
- */
-function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
-	const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-	return result
-		? {
-				r: Number.parseInt(result[1], 16),
-				g: Number.parseInt(result[2], 16),
-				b: Number.parseInt(result[3], 16),
-			}
-		: null;
-}
-
-/**
- * 色を白とブレンドして実際の表示色を計算
- * @param rgb 元の色
- * @param alpha 透過度（0-1）
- * @returns 白背景とブレンドした色
- */
-function blendWithWhite(
-	rgb: { r: number; g: number; b: number },
-	alpha: number,
-): { r: number; g: number; b: number } {
-	return {
-		r: Math.round(rgb.r * alpha + 255 * (1 - alpha)),
-		g: Math.round(rgb.g * alpha + 255 * (1 - alpha)),
-		b: Math.round(rgb.b * alpha + 255 * (1 - alpha)),
-	};
-}
-
-/**
- * 背景色の明るさを判定し、テキスト色を決定
- * 25%透過の実際の表示色を考慮してWCAGコントラスト比を計算
- */
-function getContrastColor(hexColor: string): string {
-	const rgb = hexToRgb(hexColor);
-	if (!rgb) return "inherit";
-
-	// 25%透過で白背景とブレンドした実際の表示色を計算
-	const blendedRgb = blendWithWhite(rgb, 0.25);
-
-	// 相対輝度を計算（WCAG方式）
-	const luminance =
-		(0.299 * blendedRgb.r + 0.587 * blendedRgb.g + 0.114 * blendedRgb.b) / 255;
-
-	// 白背景とのブレンドで明るくなるため、閾値を高めに設定
-	return luminance > 0.75 ? "#1f2937" : "#374151";
-}
-
-/**
  * 値がReactコンポーネントかどうかを判定
- * forwardRefコンポーネントも含めて判定する
  */
 function isReactComponent(
 	value: unknown,
 ): value is React.ComponentType<{ className?: string }> {
 	if (typeof value === "function") return true;
-	// forwardRefコンポーネントはオブジェクトで$$typeofを持つ
 	if (value && typeof value === "object" && "$$typeof" in value) return true;
 	return false;
 }
@@ -83,7 +31,6 @@ function isReactComponent(
 function getLucideIcon(
 	iconName: string,
 ): React.ComponentType<{ className?: string }> | null {
-	// kebab-case を PascalCase に変換
 	const pascalCase = iconName
 		.split("-")
 		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
@@ -91,7 +38,6 @@ function getLucideIcon(
 
 	// biome-ignore lint/performance/noDynamicNamespaceImportAccess: Dynamic icon loading is intentional
 	const IconComponent = LucideIcons[pascalCase as keyof typeof LucideIcons];
-	// Reactコンポーネント（関数またはforwardRef）かどうかをチェック
 	if (isReactComponent(IconComponent)) {
 		return IconComponent;
 	}
@@ -108,7 +54,6 @@ function GenreBadge({
 	className,
 }: GenreBadgeProps) {
 	const IconComponent = icon ? getLucideIcon(icon) : null;
-	const textColor = getContrastColor(color);
 
 	const sizeClasses = {
 		sm: "badge-sm gap-1 text-xs",
@@ -130,9 +75,9 @@ function GenreBadge({
 				className,
 			)}
 			style={{
-				backgroundColor: `${color}40`, // 25% opacity
-				borderColor: `${color}80`, // 50% opacity for border
-				color: textColor,
+				backgroundColor: `${color}40`,
+				borderColor: `${color}80`,
+				color: "var(--bc)",
 			}}
 		>
 			{IconComponent && <IconComponent className={iconSizeClasses[size]} />}


### PR DESCRIPTION
## 概要

ジャンルバッジのテキスト色がライト/ダークテーマで見づらい問題を修正

## 問題の原因

daisyUIの`badge`クラスがTailwindのテキスト色クラス（`!text-gray-900 dark:!text-gray-100`）を上書きしていたため、意図したテキスト色が適用されなかった

## 変更内容

* Tailwindテキスト色クラスを削除
* daisyUIのCSS変数 `--bc` (base-content) を使用してテーマ連動のテキスト色を実装
* 不要になったコントラスト計算関数（hexToRgb, blendWithWhite, getContrastColor）を削除

## 影響範囲

* `apps/web/src/components/public/genre-badge.tsx` - 公開画面用バッジ
* `apps/web/src/components/ui/genre-badge.tsx` - 管理画面用バッジ