### PR TITLE
feat: プロフィールページの名前をインライン編集に変更

### DIFF
--- a/apps/web/src/routes/user/_user/profile.tsx
+++ b/apps/web/src/routes/user/_user/profile.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { Check, Pencil, X } from "lucide-react";
 import { useState } from "react";
 import { Banner } from "@/components/ui/banner";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -9,7 +9,7 @@ import { authClient } from "@/lib/auth-client";
 import { createPageHead } from "@/lib/head";
 
 export const Route = createFileRoute("/user/_user/profile")({
-	head: () => createPageHead("プロフィール編集"),
+	head: () => createPageHead("プロフィール"),
 	component: ProfilePage,
 });
 
@@ -19,19 +19,34 @@ function ProfilePage() {
 
 	const currentUser = session?.user ?? user;
 
-	const [name, setName] = useState(currentUser.name ?? "");
+	const [isEditing, setIsEditing] = useState(false);
+	const [editName, setEditName] = useState("");
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState<string | null>(null);
 
-	const handleSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
+	const handleStartEdit = () => {
+		setEditName(currentUser.name ?? "");
+		setIsEditing(true);
 		setError(null);
 		setSuccess(null);
+	};
 
-		// 文字数チェック
-		if (name.trim().length > 20) {
+	const handleCancelEdit = () => {
+		setIsEditing(false);
+		setEditName("");
+	};
+
+	const handleSave = async () => {
+		if (isSubmitting) return;
+
+		if (editName.trim().length > 20) {
 			setError("名前は20文字以内で入力してください");
+			return;
+		}
+
+		if (editName.trim() === (currentUser.name ?? "")) {
+			handleCancelEdit();
 			return;
 		}
 
@@ -39,14 +54,16 @@ function ProfilePage() {
 
 		try {
 			const result = await authClient.updateUser({
-				name: name.trim() || undefined,
+				name: editName.trim() || undefined,
 			});
 
 			if (result.error) {
 				setError(result.error.message ?? "更新に失敗しました");
 			} else {
-				setSuccess("プロフィールを更新しました");
 				refetch();
+				setIsEditing(false);
+				setEditName("");
+				setSuccess("プロフィールを更新しました");
 			}
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "更新に失敗しました");
@@ -55,10 +72,19 @@ function ProfilePage() {
 		}
 	};
 
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			handleSave();
+		} else if (e.key === "Escape") {
+			handleCancelEdit();
+		}
+	};
+
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>プロフィール編集</CardTitle>
+				<CardTitle>プロフィール</CardTitle>
 			</CardHeader>
 			<CardContent>
 				{error && (
@@ -81,7 +107,7 @@ function ProfilePage() {
 					</Banner>
 				)}
 
-				<form onSubmit={handleSubmit} className="space-y-6">
+				<div className="space-y-6">
 					{/* 現在のアバター */}
 					<div className="space-y-2">
 						<Label>アバター</Label>
@@ -104,37 +130,69 @@ function ProfilePage() {
 					</div>
 
 					{/* Name */}
-					<div className="space-y-2">
-						<Label htmlFor="name">名前</Label>
-						<Input
-							id="name"
-							type="text"
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-							placeholder="表示名を入力"
-							maxLength={20}
-							autoComplete="off"
-							data-1p-ignore
-							data-lpignore="true"
-							data-form-type="other"
-						/>
-						<p className="text-base-content/60 text-xs">
-							他のユーザーに表示される名前です
-						</p>
-					</div>
-
-					{/* Submit */}
-					<div className="pt-4">
-						<Button
-							type="submit"
-							variant="primary"
-							disabled={isSubmitting}
-							className="w-full sm:w-auto"
-						>
-							{isSubmitting ? "保存中..." : "保存"}
-						</Button>
-					</div>
-				</form>
+					{!isEditing ? (
+						<div className="space-y-2">
+							<Label>名前</Label>
+							<div className="flex items-center gap-2">
+								{currentUser.name ? (
+									<p className="text-base-content">{currentUser.name}</p>
+								) : (
+									<p className="text-base-content/40">未設定</p>
+								)}
+								<button
+									type="button"
+									className="btn btn-ghost btn-sm btn-square"
+									onClick={handleStartEdit}
+								>
+									<Pencil className="h-4 w-4" />
+								</button>
+							</div>
+							<p className="text-base-content/60 text-xs">
+								他のユーザーに表示される名前です
+							</p>
+						</div>
+					) : (
+						<div className="space-y-2">
+							<Label htmlFor="name">名前</Label>
+							<div className="flex items-center gap-2">
+								<Input
+									id="name"
+									type="text"
+									value={editName}
+									onChange={(e) => setEditName(e.target.value)}
+									onKeyDown={handleKeyDown}
+									placeholder="表示名を入力"
+									maxLength={20}
+									autoComplete="off"
+									data-1p-ignore
+									data-lpignore="true"
+									data-form-type="other"
+									disabled={isSubmitting}
+								/>
+								<button
+									type="button"
+									className="btn btn-primary btn-sm btn-square"
+									onClick={handleSave}
+									disabled={isSubmitting}
+								>
+									{isSubmitting ? (
+										<span className="loading loading-spinner loading-xs" />
+									) : (
+										<Check className="h-4 w-4" />
+									)}
+								</button>
+								<button
+									type="button"
+									className="btn btn-ghost btn-sm btn-square"
+									onClick={handleCancelEdit}
+									disabled={isSubmitting}
+								>
+									<X className="h-4 w-4" />
+								</button>
+							</div>
+						</div>
+					)}
+				</div>
 			</CardContent>
 		</Card>
 	);


### PR DESCRIPTION
## 概要

プロフィールページの名前フィールドを、常時入力可能なフォームからインライン編集パターンに変更する。

## 変更内容

* 名前フィールドを表示モード（テキスト + 編集ボタン）と編集モード（入力 + 保存/キャンセルボタン）の切り替え式に変更
* ページタイトルを「プロフィール編集」から「プロフィール」に変更
* Pencil/Check/X アイコンによる直感的な操作UI
* Enter/Escape キーボードショートカット対応
* 名前未設定時は「未設定」をグレーテキストで表示
* 保存中はloading spinner表示
* 変更がない場合はAPI呼び出しをスキップ

## 影響範囲

* `apps/web/src/routes/user/_user/profile.tsx` のみ（1ファイル）
* プロフィールページの表示・操作が変わるが、API呼び出しのロジックに変更なし