### PR TITLE
fix: 公開統計APIの件数を正確なCOUNT(*)に修正

### DIFF
--- a/.claude/rules/db-queries.md
+++ b/.claude/rules/db-queries.md
@@ -37,22 +37,22 @@ const [credits, tags, genres] = await Promise.all([
 
 ## COUNT最適化
 
-### 概算カウント（統計・ダッシュボード用）
+### 統計・ダッシュボード用カウント
 
-`COUNT(*)`のシーケンシャルスキャンを回避。`pg_class.reltuples`で近似値を使用。
+テーブルサイズが小規模（数千行以下）の場合は`COUNT(*)`を使用し、キャッシュと併用:
 
 ```typescript
-const result = await db.execute<{ relname: string; reltuples: string }>(
-  sql`SELECT relname, reltuples::bigint AS reltuples
-      FROM pg_class WHERE relname = ANY(${tableNames})`,
-);
-// reltuplesが負（未ANALYZE）の場合は0にフォールバック
-counts.set(row.relname, Math.max(0, Number(row.reltuples)));
+const [releasesResult, tracksResult] = await Promise.all([
+  db.select({ count: count() }).from(releases),
+  db.select({ count: count() }).from(tracks),
+]);
+// PostgreSQLのbigintはstringで返るためNumber()でラップ
+const releases = Number(releasesResult[0]?.count ?? 0);
 ```
 
-- VACUUM/ANALYZEで更新される統計値
-- ダッシュボード等の正確性が不要な場面で使用
-- キャッシュと併用で高速化
+- `COUNT(*)`はインデックスオンリースキャンが効くためサブミリ秒で完了（数千行規模）
+- キャッシュ（5分TTL等）と併用でDB負荷を最小化
+- `pg_class.reltuples`はVACUUM/ANALYZE未実行で不正確になるため使用しない
 
 ### 正確なCOUNT
 

--- a/apps/server/src/routes/public/stats.ts
+++ b/apps/server/src/routes/public/stats.ts
@@ -8,6 +8,8 @@ import {
 	db,
 	desc,
 	eq,
+	eventSeries,
+	events,
 	inArray,
 	isNotNull,
 	officialSongs,
@@ -18,6 +20,7 @@ import {
 	trackCreditRoles,
 	trackCredits,
 	trackOfficialSongs,
+	tracks,
 } from "@thac/db";
 import { Hono } from "hono";
 import { handleDbError } from "../../utils/api-error";
@@ -28,28 +31,6 @@ import {
 	setCache,
 	setCacheHeaders,
 } from "../../utils/cache";
-
-/**
- * pg_class.reltuplesを使用した近似行数の取得
- * VACUUM/ANALYZEで更新される統計値を利用し、COUNT(*)のシーケンシャルスキャンを回避
- * キャッシュと併用するため、近似値で十分な精度を提供
- */
-async function getApproximateCounts(
-	tableNames: string[],
-): Promise<Map<string, number>> {
-	const result = await db.execute<{ relname: string; reltuples: string }>(
-		sql`SELECT relname, reltuples::bigint AS reltuples FROM pg_class WHERE relname IN (${sql.join(
-			tableNames.map((name) => sql`${name}`),
-			sql`, `,
-		)})`,
-	);
-	const counts = new Map<string, number>();
-	for (const row of result) {
-		// reltuplesが負の場合（未ANALYZE）は0にフォールバック
-		counts.set(row.relname, Math.max(0, Number(row.reltuples)));
-	}
-	return counts;
-}
 
 const statsRouter = new Hono();
 
@@ -74,25 +55,26 @@ statsRouter.get("/", async (c) => {
 			ELSE ${trackCredits.artistAliasId}
 		END`;
 
-		// 近似カウント: pg_class.reltuplesでシーケンシャルスキャンを回避
-		const approximateCountsPromise = getApproximateCounts([
-			"events",
-			"circles",
-			"artist_aliases",
-			"official_songs",
-			"releases",
-			"event_series",
-			"tracks",
-		]);
-
 		const [
-			approximateCounts,
+			releasesResult,
+			totalTracksResult,
+			circlesResult,
+			eventsResult,
+			eventSeriesResult,
+			artistsResult,
+			originalSongsResult,
 			tracksResult,
 			vocalistsResult,
 			arrangersResult,
 			lyricistsResult,
 		] = await Promise.all([
-			approximateCountsPromise,
+			db.select({ count: count() }).from(releases),
+			db.select({ count: count() }).from(tracks),
+			db.select({ count: count() }).from(circles),
+			db.select({ count: count() }).from(events),
+			db.select({ count: count() }).from(eventSeries),
+			db.select({ count: count() }).from(artistAliases),
+			db.select({ count: count() }).from(officialSongs),
 			// 東方原曲に紐付くトラックのみをカウント
 			// - officialSongIdがNOT NULL
 			// - officialWorks.idが「0799」（その他）でない
@@ -143,14 +125,14 @@ statsRouter.get("/", async (c) => {
 		]);
 
 		const response = {
-			events: approximateCounts.get("events") ?? 0,
-			circles: approximateCounts.get("circles") ?? 0,
-			artists: approximateCounts.get("artist_aliases") ?? 0,
+			events: Number(eventsResult[0]?.count ?? 0),
+			circles: Number(circlesResult[0]?.count ?? 0),
+			artists: Number(artistsResult[0]?.count ?? 0),
 			tracks: Number(tracksResult[0]?.count ?? 0),
-			originalSongs: approximateCounts.get("official_songs") ?? 0,
-			releases: approximateCounts.get("releases") ?? 0,
-			eventSeries: approximateCounts.get("event_series") ?? 0,
-			totalTracks: approximateCounts.get("tracks") ?? 0,
+			originalSongs: Number(originalSongsResult[0]?.count ?? 0),
+			releases: Number(releasesResult[0]?.count ?? 0),
+			eventSeries: Number(eventSeriesResult[0]?.count ?? 0),
+			totalTracks: Number(totalTracksResult[0]?.count ?? 0),
 			vocalists: Number(vocalistsResult[0]?.count ?? 0),
 			arrangers: Number(arrangersResult[0]?.count ?? 0),
 			lyricists: Number(lyricistsResult[0]?.count ?? 0),


### PR DESCRIPTION
## 概要

公開統計API (`/api/public/stats`) で `pg_class.reltuples` による近似カウントを正確な `COUNT(*)` に置換し、統計ページの件数表示を修正。

## 問題の原因

`pg_class.reltuples` はVACUUM/ANALYZEが未実行の場合、古い値や負値（-1）を返す。
これにより、リリース数・サークル数・イベント数等が実際の値と大幅に乖離していた。

| テーブル | reltuples | 実際のCOUNT(*) | 差分 |
|---------|-----------|---------------|------|
| releases | 525 | 604 | -79 |
| circles | 235 | 290 | -55 |
| events | 0 (-1) | 5 | -5 |
| event_series | 0 (-1) | 3 | -3 |
| artist_aliases | 919 | 1,023 | -104 |

## 変更内容

* `getApproximateCounts()` 関数（`pg_class.reltuples` 使用）を削除
* 7つの `COUNT(*)` クエリ + 4つの既存 `countDistinct` クエリを全て `Promise.all()` で並列実行に変更
* import に `events`, `eventSeries`, `tracks` を追加
* `.claude/rules/db-queries.md` のCOUNT最適化ドキュメントを新方針に更新

## 影響範囲

* `/api/public/stats` エンドポイントのレスポンス値が正確になる
* テーブルサイズは全て5,000行以下で、既存の5分キャッシュと併用するためパフォーマンス影響なし
* 他のエンドポイント（ランキング、管理画面等）は全て既に正確な `COUNT(*)` を使用しており影響なし