### PR TITLE
refactor: update-meilisearchスキルをProgressive Disclosure構造にリファクタリング

### DIFF
--- a/.claude/skills/update-meilisearch/SKILL.md
+++ b/.claude/skills/update-meilisearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-meilisearch
-description: "Meilisearchアップデートスキル。devbox（メイン開発環境）とDocker（本番/代替環境）の両方でバージョン確認・バックアップ・アップグレードを行う。"
+description: "Meilisearchアップデートスキル。devbox（メイン開発環境）とDocker（本番/代替環境）の両方でバージョン確認・バックアップ・アップグレードを行う。「Meilisearchをアップデートして」「最新版を確認して」「/update-meilisearch」などのリクエストで起動。"
 ---
 
 # Meilisearch Update Skill
@@ -24,13 +24,6 @@ Meilisearchのバージョン確認・アップグレードを自動化するス
 │  (ローカルデータ)  │  (永続化データ)            │
 └────────────────────┴────────────────────────────┘
 ```
-
-## 実行トリガー
-
-以下のようなリクエストで起動:
-- "Meilisearchをアップデートして"
-- "Meilisearchの最新版を確認して"
-- "/update-meilisearch"
 
 ## オーケストレーション方針
 
@@ -136,45 +129,10 @@ Task 3: 破壊的変更の影響調査
 
 ### Step 4: バックアップ作成
 
-#### devbox環境
+devbox環境: `data/meilisearch/` コピー + API経由でDump作成
+Docker環境: API経由でDump作成 + ホストにコピー
 
-```
-Task 4-devbox: devbox環境のバックアップ
-- subagent_type: Bash
-- prompt: |
-    devbox環境のMeilisearchデータをバックアップしてください。
-
-    1. データディレクトリのコピー:
-       cp -r data/meilisearch data/meilisearch.bak
-
-    2. Meilisearchが起動中の場合、API経由でDump作成:
-       a. ヘルスチェック: curl -s http://localhost:7700/health
-       b. Dump作成: curl -X POST -H "Authorization: Bearer development_master_key" http://localhost:7700/dumps
-       c. タスク完了確認: curl -H "Authorization: Bearer development_master_key" "http://localhost:7700/tasks?types=dumpCreation&limit=1"
-       d. Dumpファイル確認: ls data/meilisearch/dumps/
-```
-
-#### Docker環境
-
-```
-Task 4-docker: Docker環境のバックアップ
-- subagent_type: Bash
-- prompt: |
-    Docker環境のMeilisearchデータをバックアップしてください。
-
-    1. Meilisearch起動確認・起動:
-       curl -s http://localhost:7700/health
-       起動していない場合: docker compose up -d meilisearch
-       ヘルスチェックが通るまで待機（最大60秒）
-
-    2. Dump作成:
-       curl -X POST -H "Authorization: Bearer development_master_key" http://localhost:7700/dumps
-       タスク完了確認: curl -H "Authorization: Bearer development_master_key" "http://localhost:7700/tasks?types=dumpCreation&limit=1"
-
-    3. Dumpファイルをホストにコピー:
-       mkdir -p .meilisearch/dumps
-       docker compose cp meilisearch:/meili_data/dumps/<dump_file> .meilisearch/dumps/
-```
+詳細な手順は [backup-restore.md](references/backup-restore.md) を参照。
 
 ### Step 5: アップグレード実行
 
@@ -216,37 +174,7 @@ Task 5-devbox-normal: devbox標準アップグレード
 ```
 
 **回避策フロー（devbox search に未反映の場合）:**
-
-```
-Task 5-devbox-workaround: nixpkgs直接参照でアップグレード
-- subagent_type: Bash
-- prompt: |
-    devbox search に目的バージョンがない場合、nixpkgs を直接参照して更新してください。
-
-    1. nixpkgs で該当バージョンの PR を検索:
-       gh search prs --repo NixOS/nixpkgs "meilisearch <version>"
-
-    2. マージ済み PR のコミットハッシュを取得:
-       gh pr view <PR番号> --repo NixOS/nixpkgs --json mergeCommit
-
-    3. バージョン確認:
-       nix eval "github:NixOS/nixpkgs/<commit>#meilisearch.version"
-
-    4. store パス取得:
-       nix eval --raw "github:NixOS/nixpkgs/<commit>#meilisearch.outPath"
-
-    5. devbox.lock を手動更新:
-       - resolved: "github:NixOS/nixpkgs/<commit>#meilisearch" に変更
-       - version: 新バージョンに変更
-       - store_path: 取得した store パスに変更
-
-    6. devbox install でインストール
-
-    7. devbox run -- meilisearch --version で確認
-```
-
-**参考: nixpkgs のパッケージ管理場所**
-- `pkgs/by-name/me/meilisearch/package.nix` in NixOS/nixpkgs
+詳細は [upgrade-workarounds.md](references/upgrade-workarounds.md) を参照。
 
 #### Docker環境のアップグレード
 
@@ -283,57 +211,10 @@ Task 5-migration: データ移行（Docker環境）
     ※ 一時コンテナなので停止してもデータは永続化されています
 ```
 
-### Step 6: 検証（バージョン + データ移行確認）
+### Step 6: 検証
 
-```
-Task 6: 検証
-- subagent_type: Bash
-- prompt: |
-    Meilisearchのアップグレードを検証してください。
-    バージョン確認だけでなく、データが正しく移行されているかも必ず確認すること。
-
-    devbox環境:
-      1. バージョン確認:
-         devbox run -- meilisearch --version
-
-      2. サービス起動中なら以下を全て確認:
-         a. ヘルスチェック:
-            curl -s http://localhost:7700/health
-            → {"status":"available"} を確認
-
-         b. バージョン確認:
-            curl -s -H "Authorization: Bearer development_master_key" http://localhost:7700/version
-            → 目的のバージョンを確認
-
-         c. インデックス一覧とドキュメント数:
-            curl -s -H "Authorization: Bearer development_master_key" http://localhost:7700/indexes
-            → インデックスが存在し、ドキュメント数がアップグレード前と同等であることを確認
-
-         d. 検索動作確認（tracks インデックスが存在する場合）:
-            curl -s -H "Authorization: Bearer development_master_key" \
-              "http://localhost:7700/indexes/tracks/search" \
-              -H 'Content-Type: application/json' \
-              -d '{"q": "test", "limit": 3}'
-            → 検索結果が返ってくることを確認（データが読み取り可能であること）
-
-         e. インデックス設定の確認:
-            curl -s -H "Authorization: Bearer development_master_key" \
-              http://localhost:7700/indexes/tracks/settings
-            → searchableAttributes, filterableAttributes 等が保持されていることを確認
-
-    Docker環境:
-      1. docker compose up -d meilisearch
-      2. ヘルスチェック待機（最大60秒）
-      3. 上記 a〜e と同様の検証を実施
-
-    検証結果を以下の形式で報告:
-      - バージョン: OK/NG (実際のバージョン)
-      - ヘルスチェック: OK/NG
-      - インデックス数: <数> (アップグレード前: <数>)
-      - ドキュメント数: <数> (アップグレード前: <数>)
-      - 検索動作: OK/NG
-      - インデックス設定: OK/NG (保持されている設定一覧)
-```
+バージョン確認・ヘルスチェック・データ移行確認を実施する。
+詳細な検証手順は [verification.md](references/verification.md) を参照。
 
 ### Step 7: ドキュメント更新
 
@@ -349,75 +230,9 @@ Task 6: 検証
 
 **判断基準**: リリースノートの "Breaking Changes" セクションで DB format の変更有無を確認する。
 
-## ロールバック手順
+## ロールバック・障害復旧
 
-### devbox環境
-
-```
-Task: devboxロールバック
-- subagent_type: Bash
-- prompt: |
-    devbox環境のMeilisearchをロールバックしてください。
-    1. devbox.lock を元のバージョンに戻す（git checkout devbox.lock）
-    2. devbox install
-    3. 必要なら data/meilisearch をバックアップから復元:
-       rm -rf data/meilisearch
-       mv data/meilisearch.bak data/meilisearch
-    4. devbox run -- meilisearch --version で確認
-```
-
-### Docker環境
-
-```
-Task: Dockerロールバック
-- subagent_type: Bash
-- prompt: |
-    Docker環境のMeilisearchをロールバックしてください。
-    1. docker compose stop meilisearch
-    2. docker-compose.yml を元のバージョンに戻す
-    3. スナップショットから復元（必要な場合）
-    4. docker compose up -d meilisearch
-    5. ヘルスチェック確認: curl -s http://localhost:7700/health
-```
-
-## 障害復旧
-
-### 起動失敗（os error 11 - Resource temporarily unavailable）
-
-バージョンアップグレード後にサービスが起動しない場合の対処法:
-
-```
-Task: データ復旧
-- subagent_type: Bash
-- prompt: |
-    Meilisearchの起動障害を復旧してください。
-
-    devbox環境:
-      1. data/meilisearch を削除して Dump から再構築
-      2. data/meilisearch.bak があればそこから復元
-      3. devbox services restart
-
-    Docker環境:
-      1. docker compose stop meilisearch && docker compose rm -f meilisearch
-      2. ボリュームを使用中のコンテナがあれば削除:
-         docker ps -a --filter volume=thac_meilisearch_data -q | xargs -r docker rm -f
-      3. docker volume rm thac_meilisearch_data
-      4. docker volume create thac_meilisearch_data
-      5. docker run --rm \
-           -v thac_meilisearch_data:/meili_data \
-           -v $(pwd)/.meilisearch/dumps:/dumps:ro \
-           -e MEILI_MASTER_KEY=development_master_key \
-           getmeili/meilisearch:v<現バージョン> \
-           meilisearch --import-dump /dumps/meilisearch-dump.dump
-      6. インポート完了確認後 Ctrl+C で停止
-      7. docker compose up -d meilisearch
-      8. ヘルスチェック確認: curl -s http://localhost:7700/health
-```
-
-この問題は以下の原因で発生します:
-- バージョン間のデータベースフォーマット非互換
-- 一時コンテナがボリュームをロックしたまま残存（Docker環境）
-- dump経由の移行が正常に完了していない
+問題発生時は [troubleshooting.md](references/troubleshooting.md) を参照。
 
 ## 環境変数
 
@@ -442,3 +257,10 @@ Task: データ復旧
 - [Meilisearch Releases](https://github.com/meilisearch/meilisearch/releases)
 - [Meilisearch Update Guide](https://www.meilisearch.com/docs/learn/update_and_migration/updating)
 - nixpkgs の Meilisearch パッケージ管理場所: `pkgs/by-name/me/meilisearch/package.nix` in NixOS/nixpkgs
+
+### リファレンス
+
+- [バックアップ・リストア手順](references/backup-restore.md)
+- [アップグレード回避策](references/upgrade-workarounds.md)
+- [検証手順](references/verification.md)
+- [トラブルシューティング・ロールバック](references/troubleshooting.md)

--- a/.claude/skills/update-meilisearch/references/backup-restore.md
+++ b/.claude/skills/update-meilisearch/references/backup-restore.md
@@ -1,0 +1,72 @@
+# バックアップ・リストア手順
+
+## devbox環境のバックアップ
+
+```
+Task 4-devbox: devbox環境のバックアップ
+- subagent_type: Bash
+- prompt: |
+    devbox環境のMeilisearchデータをバックアップしてください。
+
+    1. データディレクトリのコピー:
+       cp -r data/meilisearch data/meilisearch.bak
+
+    2. Meilisearchが起動中の場合、API経由でDump作成:
+       a. ヘルスチェック: curl -s http://localhost:7700/health
+       b. Dump作成: curl -X POST -H "Authorization: Bearer development_master_key" http://localhost:7700/dumps
+       c. タスク完了確認: curl -H "Authorization: Bearer development_master_key" "http://localhost:7700/tasks?types=dumpCreation&limit=1"
+       d. Dumpファイル確認: ls data/meilisearch/dumps/
+```
+
+## Docker環境のバックアップ
+
+```
+Task 4-docker: Docker環境のバックアップ
+- subagent_type: Bash
+- prompt: |
+    Docker環境のMeilisearchデータをバックアップしてください。
+
+    1. Meilisearch起動確認・起動:
+       curl -s http://localhost:7700/health
+       起動していない場合: docker compose up -d meilisearch
+       ヘルスチェックが通るまで待機（最大60秒）
+
+    2. Dump作成:
+       curl -X POST -H "Authorization: Bearer development_master_key" http://localhost:7700/dumps
+       タスク完了確認: curl -H "Authorization: Bearer development_master_key" "http://localhost:7700/tasks?types=dumpCreation&limit=1"
+
+    3. Dumpファイルをホストにコピー:
+       mkdir -p .meilisearch/dumps
+       docker compose cp meilisearch:/meili_data/dumps/<dump_file> .meilisearch/dumps/
+```
+
+## Dumpからのリストア
+
+### devbox環境
+
+```bash
+# バックアップからデータディレクトリを復元
+rm -rf data/meilisearch
+mv data/meilisearch.bak data/meilisearch
+```
+
+### Docker環境
+
+```bash
+# 1. 既存データを削除
+docker compose stop meilisearch && docker compose rm -f meilisearch
+docker volume rm thac_meilisearch_data
+docker volume create thac_meilisearch_data
+
+# 2. Dumpからインポート
+docker run --rm \
+  -v thac_meilisearch_data:/meili_data \
+  -v $(pwd)/.meilisearch/dumps:/dumps:ro \
+  -e MEILI_MASTER_KEY=development_master_key \
+  getmeili/meilisearch:v<バージョン> \
+  meilisearch --import-dump /dumps/<dump_file>
+
+# 3. インポート完了確認後 Ctrl+C で停止
+# 4. 通常起動
+docker compose up -d meilisearch
+```

--- a/.claude/skills/update-meilisearch/references/troubleshooting.md
+++ b/.claude/skills/update-meilisearch/references/troubleshooting.md
@@ -1,0 +1,101 @@
+# トラブルシューティング・ロールバック
+
+## ロールバック手順
+
+### devbox環境
+
+```
+Task: devboxロールバック
+- subagent_type: Bash
+- prompt: |
+    devbox環境のMeilisearchをロールバックしてください。
+    1. devbox.lock を元のバージョンに戻す（git checkout devbox.lock）
+    2. devbox install
+    3. 必要なら data/meilisearch をバックアップから復元:
+       rm -rf data/meilisearch
+       mv data/meilisearch.bak data/meilisearch
+    4. devbox run -- meilisearch --version で確認
+```
+
+### Docker環境
+
+```
+Task: Dockerロールバック
+- subagent_type: Bash
+- prompt: |
+    Docker環境のMeilisearchをロールバックしてください。
+    1. docker compose stop meilisearch
+    2. docker-compose.yml を元のバージョンに戻す
+    3. スナップショットから復元（必要な場合）
+    4. docker compose up -d meilisearch
+    5. ヘルスチェック確認: curl -s http://localhost:7700/health
+```
+
+## 障害復旧
+
+### 起動失敗（os error 11 - Resource temporarily unavailable）
+
+バージョンアップグレード後にサービスが起動しない場合の対処法:
+
+```
+Task: データ復旧
+- subagent_type: Bash
+- prompt: |
+    Meilisearchの起動障害を復旧してください。
+
+    devbox環境:
+      1. data/meilisearch を削除して Dump から再構築
+      2. data/meilisearch.bak があればそこから復元
+      3. devbox services restart
+
+    Docker環境:
+      1. docker compose stop meilisearch && docker compose rm -f meilisearch
+      2. ボリュームを使用中のコンテナがあれば削除:
+         docker ps -a --filter volume=thac_meilisearch_data -q | xargs -r docker rm -f
+      3. docker volume rm thac_meilisearch_data
+      4. docker volume create thac_meilisearch_data
+      5. docker run --rm \
+           -v thac_meilisearch_data:/meili_data \
+           -v $(pwd)/.meilisearch/dumps:/dumps:ro \
+           -e MEILI_MASTER_KEY=development_master_key \
+           getmeili/meilisearch:v<現バージョン> \
+           meilisearch --import-dump /dumps/meilisearch-dump.dump
+      6. インポート完了確認後 Ctrl+C で停止
+      7. docker compose up -d meilisearch
+      8. ヘルスチェック確認: curl -s http://localhost:7700/health
+```
+
+この問題は以下の原因で発生します:
+- バージョン間のデータベースフォーマット非互換
+- 一時コンテナがボリュームをロックしたまま残存（Docker環境）
+- dump経由の移行が正常に完了していない
+
+### Docker ボリューム競合
+
+ボリュームが使用中で削除できない場合:
+
+```bash
+# 使用中のコンテナを確認・削除
+docker ps -a --filter volume=thac_meilisearch_data -q | xargs -r docker rm -f
+# ボリューム削除・再作成
+docker volume rm thac_meilisearch_data
+docker volume create thac_meilisearch_data
+```
+
+### devbox install 失敗
+
+```bash
+# キャッシュクリアして再試行
+devbox install --refresh
+# それでも失敗する場合、devbox.lock を確認
+# resolved, version, store_path の整合性をチェック
+```
+
+### API認証エラー
+
+```bash
+# マスターキーの確認
+curl -s -H "Authorization: Bearer development_master_key" http://localhost:7700/health
+# 環境変数の確認
+echo $MEILI_MASTER_KEY
+```

--- a/.claude/skills/update-meilisearch/references/upgrade-workarounds.md
+++ b/.claude/skills/update-meilisearch/references/upgrade-workarounds.md
@@ -1,0 +1,48 @@
+# アップグレード回避策
+
+## 背景
+
+devbox は nixpkgs のパッケージインデックスを使用しているが、新バージョンのマージ後も
+`devbox search` への反映に遅延が生じることがある。
+この場合、nixpkgs のコミットを直接参照してアップグレードを行う。
+
+## nixpkgs 直接参照でのアップグレード
+
+```
+Task 5-devbox-workaround: nixpkgs直接参照でアップグレード
+- subagent_type: Bash
+- prompt: |
+    devbox search に目的バージョンがない場合、nixpkgs を直接参照して更新してください。
+
+    1. nixpkgs で該当バージョンの PR を検索:
+       gh search prs --repo NixOS/nixpkgs "meilisearch <version>"
+
+    2. マージ済み PR のコミットハッシュを取得:
+       gh pr view <PR番号> --repo NixOS/nixpkgs --json mergeCommit
+
+    3. バージョン確認:
+       nix eval "github:NixOS/nixpkgs/<commit>#meilisearch.version"
+
+    4. store パス取得:
+       nix eval --raw "github:NixOS/nixpkgs/<commit>#meilisearch.outPath"
+
+    5. devbox.lock を手動更新:
+       - resolved: "github:NixOS/nixpkgs/<commit>#meilisearch" に変更
+       - version: 新バージョンに変更
+       - store_path: 取得した store パスに変更
+
+    6. devbox install でインストール
+
+    7. devbox run -- meilisearch --version で確認
+```
+
+## 通常フローとの使い分け
+
+| 状況 | フロー |
+|------|--------|
+| `devbox search` に目的バージョンあり | `devbox update meilisearch` → `devbox install` |
+| `devbox search` に未反映 | nixpkgs 直接参照（上記手順） |
+
+## nixpkgs のパッケージ管理場所
+
+- `pkgs/by-name/me/meilisearch/package.nix` in NixOS/nixpkgs

--- a/.claude/skills/update-meilisearch/references/verification.md
+++ b/.claude/skills/update-meilisearch/references/verification.md
@@ -1,0 +1,68 @@
+# アップグレード検証手順
+
+## 検証サブエージェント
+
+```
+Task 6: 検証
+- subagent_type: Bash
+- prompt: |
+    Meilisearchのアップグレードを検証してください。
+    バージョン確認だけでなく、データが正しく移行されているかも必ず確認すること。
+
+    devbox環境:
+      1. バージョン確認:
+         devbox run -- meilisearch --version
+
+      2. サービス起動中なら以下を全て確認:
+         a. ヘルスチェック:
+            curl -s http://localhost:7700/health
+            → {"status":"available"} を確認
+
+         b. バージョン確認:
+            curl -s -H "Authorization: Bearer development_master_key" http://localhost:7700/version
+            → 目的のバージョンを確認
+
+         c. インデックス一覧とドキュメント数:
+            curl -s -H "Authorization: Bearer development_master_key" http://localhost:7700/indexes
+            → インデックスが存在し、ドキュメント数がアップグレード前と同等であることを確認
+
+         d. 検索動作確認（tracks インデックスが存在する場合）:
+            curl -s -H "Authorization: Bearer development_master_key" \
+              "http://localhost:7700/indexes/tracks/search" \
+              -H 'Content-Type: application/json' \
+              -d '{"q": "test", "limit": 3}'
+            → 検索結果が返ってくることを確認（データが読み取り可能であること）
+
+         e. インデックス設定の確認:
+            curl -s -H "Authorization: Bearer development_master_key" \
+              http://localhost:7700/indexes/tracks/settings
+            → searchableAttributes, filterableAttributes 等が保持されていることを確認
+
+    Docker環境:
+      1. docker compose up -d meilisearch
+      2. ヘルスチェック待機（最大60秒）
+      3. 上記 a〜e と同様の検証を実施
+```
+
+## 検証チェックリスト
+
+| 項目 | 確認内容 | 期待値 |
+|------|---------|--------|
+| バージョン | `meilisearch --version` / API `/version` | 目的のバージョン |
+| ヘルスチェック | `/health` | `{"status":"available"}` |
+| インデックス数 | `/indexes` のレスポンス数 | アップグレード前と同数 |
+| ドキュメント数 | 各インデックスの `numberOfDocuments` | アップグレード前と同等 |
+| 検索動作 | `/indexes/tracks/search` | 結果が返ること |
+| インデックス設定 | `/indexes/tracks/settings` | 設定が保持されていること |
+
+## 報告フォーマット
+
+```
+検証結果:
+  - バージョン: OK/NG (実際のバージョン)
+  - ヘルスチェック: OK/NG
+  - インデックス数: <数> (アップグレード前: <数>)
+  - ドキュメント数: <数> (アップグレード前: <数>)
+  - 検索動作: OK/NG
+  - インデックス設定: OK/NG (保持されている設定一覧)
+```


### PR DESCRIPTION
## 概要

update-meilisearchスキルのSKILL.mdをProgressive Disclosure構造にリファクタリングし、コンテキストウィンドウの効率的な利用を実現。

## 変更内容

* SKILL.md を445行→266行に簡潔化（40%削減）
* 詳細手順を `references/` ディレクトリに分離:
  * `backup-restore.md`: バックアップ・リストア手順
  * `upgrade-workarounds.md`: nixpkgs直接参照によるアップグレード回避策
  * `verification.md`: アップグレード検証手順・チェックリスト
  * `troubleshooting.md`: ロールバック・障害復旧手順
* SKILL.md の `description` にトリガーキーワードを追加
* コアワークフロー図・サブエージェント委託詳細はSKILL.mdに維持

## 影響範囲

* `/update-meilisearch` スキルの動作に変更なし（ドキュメント構造のみの変更）

## 補足事項

* Claude Code スキルのベストプラクティス「Progressive Disclosure」に準拠
* コアのオーケストレーション情報はSKILL.mdに残し、詳細手順は必要時にのみ参照される構造