### PR TITLE
chore: worktree開発体験を改善するmakeターゲットと環境変数を追加

### DIFF
--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -82,11 +82,14 @@ git config --add wt.nocopy ".devbox/"      # devbox環境は共有
 git config --add wt.nocopy "data/"         # ローカルデータは共有
 ```
 
-## devboxサービスの共有
+## worktreeでの開発手順
 
-- devbox services（PostgreSQL, Meilisearch等）はメインworktreeのみで起動
-- 他のworktreeは同じDB・サービスを共有利用
-- worktree内では `devbox run -- bun run dev:web` 等で個別アプリのみ起動
+1. メインworktreeで `make up`（全サービス起動）
+2. メインworktreeで `make stop-app`（web+serverのみ停止、DB/Meilisearchは維持）
+3. worktreeに移動: `cd .worktree/<branch-name>/`
+4. `make wt-dev`（web+serverをworktreeのコードで起動）
+5. 作業完了後 Ctrl+C で停止
+6. メインに戻って `make restart` または `make up` で復帰
 
 ## PR作成後のフロー
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 	docker-clean docker-rebuild docker-reset docker-reset-deps docker-prune docker-shell-server docker-shell-web \
 	db-push db-generate db-migrate db-seed db-setup db-studio db-truncate \
 	docker-db-push docker-db-generate docker-db-migrate docker-db-seed docker-db-setup docker-db-truncate \
-	install check check-types test lint-markuplint
+	install check check-types test lint-markuplint stop-app wt-dev
 
 # デフォルトターゲット
 help: ## ヘルプを表示
@@ -46,6 +46,23 @@ restart: ## サービスを再起動
 	else \
 		echo "サービスは起動していません。make up で起動してください。"; \
 	fi
+
+stop-app: ## web+serverのみ停止（DB/Meilisearchは維持）
+	@lsof -i :3000 -sTCP:LISTEN -t 2>/dev/null | xargs kill 2>/dev/null || true
+	@lsof -i :3001 -sTCP:LISTEN -t 2>/dev/null | xargs kill 2>/dev/null || true
+	@echo "✅ web + server を停止しました"
+
+wt-dev: ## worktree内でweb+serverを起動（メインのDB/Meilisearchに接続）
+	@pg_isready -h localhost -p 5432 -q 2>/dev/null || { echo "❌ PostgreSQLが起動していません。メインworktreeで make up を実行してください"; exit 1; }
+	@curl -sf http://localhost:7700/health >/dev/null 2>&1 || { echo "❌ Meilisearchが起動していません。メインworktreeで make up を実行してください"; exit 1; }
+	@if lsof -i :3000 -sTCP:LISTEN -t >/dev/null 2>&1; then \
+		echo "❌ ポート3000が使用中です。make stop-app で停止してください"; exit 1; \
+	fi
+	@if lsof -i :3001 -sTCP:LISTEN -t >/dev/null 2>&1; then \
+		echo "❌ ポート3001が使用中です。make stop-app で停止してください"; exit 1; \
+	fi
+	@echo "🚀 web + server を起動します..."
+	@devbox run -- sh -c 'trap "kill 0" EXIT; bun run --cwd apps/server dev & bun run --cwd apps/web dev & wait'
 
 # =============================================================================
 # 開発環境（Docker）

--- a/devbox.json
+++ b/devbox.json
@@ -17,7 +17,10 @@
 		"CORS_ORIGIN": "http://localhost:3000",
 		"BETTER_AUTH_URL": "http://localhost:3000",
 		"DATABASE_URL": "postgresql://localhost:5432/thac",
-		"PGDATABASE": "thac"
+		"PGDATABASE": "thac",
+		"BETTER_AUTH_SECRET": "devbox_secret_key_change_in_production",
+		"VITE_SERVER_URL": "http://localhost:3001",
+		"SERVER_URL": "http://localhost:3001"
 	},
 	"shell": {
 		"init_hook": [


### PR DESCRIPTION
## 概要

メインworktreeのDB/Meilisearchを共有しつつ、worktreeのコードでweb+serverを起動できるようにした。

## 変更内容

* `devbox.json`: `BETTER_AUTH_SECRET`/`VITE_SERVER_URL`/`SERVER_URL` を追加（process-compose経由せずにアプリ起動するために必要）
* `Makefile`: `stop-app`（web+serverのみ停止）と `wt-dev`（worktree内でweb+server起動）ターゲットを追加
* `.claude/rules/branching.md`: worktree開発手順を記載

## 影響範囲

開発環境のみ。本番コードへの変更なし。

## 補足事項

### 使い方

```
メインworktree:  make up        → 全サービス起動（通常開発）
                 make stop-app  → web+serverのみ停止（DB/Meilisearchは維持）

任意のworktree:  make wt-dev    → web+serverを現在のworktreeから起動
```