### PR TITLE
fix: 公開ページの初回ロードスピナーを網羅的に解消（SSRプリフェッチ + フェッチアンチパターン撤廃）

### DIFF
--- a/apps/web/src/lib/public-query-options.ts
+++ b/apps/web/src/lib/public-query-options.ts
@@ -545,6 +545,20 @@ export const publicCircleTracksQueryOptions = (
 		staleTime: STALE_TIME_PUBLIC.STATS,
 	});
 
+/**
+ * 公式作品の楽曲一覧クエリオプション
+ * 原曲一覧ページのアコーディオン展開時に使用
+ */
+export const publicWorkSongsQueryOptions = (
+	workId: string,
+	params: { limit: number },
+) =>
+	queryOptions({
+		queryKey: ["public", "works", workId, "songs", params],
+		queryFn: () => publicApi.songs.list({ workId, limit: params.limit }),
+		staleTime: STALE_TIME_PUBLIC.STATS,
+	});
+
 // =============================================================================
 // タグ用クエリオプション
 // =============================================================================
@@ -581,5 +595,19 @@ export const publicTagCloudQueryOptions = (limit?: number) =>
 	queryOptions({
 		queryKey: ["public", "tags", "cloud", limit],
 		queryFn: () => publicApi.tags.cloud(limit),
+		staleTime: STALE_TIME_PUBLIC.STATS,
+	});
+
+/**
+ * タグのトラック一覧クエリオプション
+ * タグ詳細ページのトラック一覧で使用
+ */
+export const publicTagTracksQueryOptions = (
+	tagId: string,
+	params: { page: number; limit: number },
+) =>
+	queryOptions({
+		queryKey: ["public", "tags", tagId, "tracks", params],
+		queryFn: () => publicApi.tags.tracks(tagId, params),
 		staleTime: STALE_TIME_PUBLIC.STATS,
 	});

--- a/apps/web/src/lib/public-query-options.ts
+++ b/apps/web/src/lib/public-query-options.ts
@@ -487,6 +487,65 @@ export const searchTracksQueryOptions = (params: TrackSearchParams) =>
 	});
 
 // =============================================================================
+// 詳細ページ用 ページネーションクエリオプション
+// =============================================================================
+
+/** アーティスト名義のトラック一覧パラメータ */
+interface PublicArtistTracksParams {
+	page: number;
+	limit: number;
+	role?: string;
+}
+
+/**
+ * アーティスト名義のトラック一覧クエリオプション
+ * アーティスト詳細ページのトラックタブで使用
+ */
+export const publicArtistTracksQueryOptions = (
+	artistId: string,
+	params: PublicArtistTracksParams,
+) =>
+	queryOptions({
+		queryKey: ["public", "artists", artistId, "tracks", params],
+		queryFn: () => publicApi.artists.tracks(artistId, params),
+		staleTime: STALE_TIME_PUBLIC.STATS,
+	});
+
+/** サークル作品/トラック一覧パラメータ */
+interface PublicCirclePaginationParams {
+	page: number;
+	limit: number;
+}
+
+/**
+ * サークルの作品一覧クエリオプション
+ * サークル詳細ページの作品タブで使用
+ */
+export const publicCircleReleasesQueryOptions = (
+	circleId: string,
+	params: PublicCirclePaginationParams,
+) =>
+	queryOptions({
+		queryKey: ["public", "circles", circleId, "releases", params],
+		queryFn: () => publicApi.circles.releases(circleId, params),
+		staleTime: STALE_TIME_PUBLIC.STATS,
+	});
+
+/**
+ * サークルのトラック一覧クエリオプション
+ * サークル詳細ページのトラックタブで使用
+ */
+export const publicCircleTracksQueryOptions = (
+	circleId: string,
+	params: PublicCirclePaginationParams,
+) =>
+	queryOptions({
+		queryKey: ["public", "circles", circleId, "tracks", params],
+		queryFn: () => publicApi.circles.tracks(circleId, params),
+		staleTime: STALE_TIME_PUBLIC.STATS,
+	});
+
+// =============================================================================
 // タグ用クエリオプション
 // =============================================================================
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -41,6 +41,8 @@ export const getRouter = () => {
 		scrollRestoration: true,
 		defaultPreload: "intent", // ホバー・タッチ時にプリフェッチ
 		defaultPreloadStaleTime: 30_000, // 30秒間はキャッシュを使用
+		defaultPendingMs: 1000, // loader完了が1秒以内ならpendingComponentを出さない
+		defaultPendingMinMs: 500, // pendingComponentを出した場合は最低500ms表示してちらつき防止
 		context: {
 			queryClient,
 		},

--- a/apps/web/src/routes/_public/artists.tsx
+++ b/apps/web/src/routes/_public/artists.tsx
@@ -97,6 +97,27 @@ export const Route = createFileRoute("/_public/artists")({
 			search: typeof search.search === "string" ? search.search : undefined,
 		};
 	},
+	loaderDeps: ({ search }) => ({
+		search: search.search,
+		script: search.script,
+		initial: search.initial,
+		row: search.row,
+		role: search.role,
+	}),
+	loader: async ({ deps, context }) => {
+		const scriptCategory = deps.script ?? "all";
+		const role = deps.role ?? "all";
+		await context.queryClient.ensureInfiniteQueryData(
+			publicArtistsInfiniteQueryOptions({
+				limit: PAGE_SIZE,
+				search: deps.search || undefined,
+				initialScript: scriptCategory === "all" ? undefined : scriptCategory,
+				initial: scriptCategory === "alphabet" ? deps.initial : undefined,
+				row: scriptCategory === "kana" ? deps.row : undefined,
+				role: role === "all" ? undefined : role,
+			}),
+		);
+	},
 });
 
 // =============================================================================

--- a/apps/web/src/routes/_public/artists_.$id.tsx
+++ b/apps/web/src/routes/_public/artists_.$id.tsx
@@ -1,6 +1,7 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { ChevronDown, Disc3, Loader2, Music, UserRound } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
 	DetailTabs,
 	EmptyState,
@@ -22,8 +23,9 @@ import {
 	TAB_LABELS,
 } from "@/lib/detail-tab-utils";
 import { createPublicArtistHead } from "@/lib/head";
-import { type PublicArtistTrack, publicApi } from "@/lib/public-api";
+import { publicApi } from "@/lib/public-api";
 import {
+	publicArtistTracksQueryOptions,
 	publicWorkStatsSimpleQueryOptions,
 	publicWorkStatsStackedQueryOptions,
 } from "@/lib/public-query-options";
@@ -32,13 +34,16 @@ interface ArtistDetailSearchParams {
 	tab?: ArtistDetailTab;
 }
 
+const PAGE_SIZE = 20;
+
 export const Route = createFileRoute("/_public/artists_/$id")({
 	validateSearch: (
 		search: Record<string, unknown>,
 	): ArtistDetailSearchParams => ({
 		tab: parseArtistDetailTab(search.tab),
 	}),
-	loader: async ({ params, context }) => {
+	loaderDeps: ({ search }) => ({ tab: search.tab }),
+	loader: async ({ params, context, deps }) => {
 		try {
 			const artist = await publicApi.artists.get(params.id);
 
@@ -50,6 +55,17 @@ export const Route = createFileRoute("/_public/artists_/$id")({
 				publicWorkStatsSimpleQueryOptions("artist", params.id),
 			);
 
+			// tracksタブ（デフォルト）の場合は初回トラック一覧を SSR プリフェッチ
+			const activeTab = deps.tab ?? "tracks";
+			if (activeTab === "tracks") {
+				await context.queryClient.ensureQueryData(
+					publicArtistTracksQueryOptions(params.id, {
+						page: 1,
+						limit: PAGE_SIZE,
+					}),
+				);
+			}
+
 			return { artist };
 		} catch {
 			return { artist: null };
@@ -59,8 +75,6 @@ export const Route = createFileRoute("/_public/artists_/$id")({
 	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	component: ArtistDetailPage,
 });
-
-const PAGE_SIZE = 20;
 
 // 名義タイプ名
 const aliasTypeNames: Record<string, string> = {
@@ -99,15 +113,23 @@ function ArtistDetailPage() {
 		}
 	}, [activeTab, contentTab]);
 
-	// トラック一覧の状態
-	const [tracks, setTracks] = useState<PublicArtistTrack[]>([]);
-	const [tracksTotal, setTracksTotal] = useState(0);
+	// トラック一覧のページネーション・フィルター状態
 	const [tracksPage, setTracksPage] = useState(1);
-	const [tracksLoading, setTracksLoading] = useState(false);
-	const [tracksLoaded, setTracksLoaded] = useState(false);
-
-	// フィルター（名義単位なので役割フィルターのみ）
 	const [roleFilter, setRoleFilter] = useState<string>("all");
+
+	// トラック一覧クエリ
+	const tracksQuery = useQuery({
+		...publicArtistTracksQueryOptions(id, {
+			page: tracksPage,
+			limit: PAGE_SIZE,
+			role: roleFilter === "all" ? undefined : roleFilter,
+		}),
+		enabled: activeTab === "tracks" && !!artist,
+	});
+
+	const tracks = tracksQuery.data?.data ?? [];
+	const tracksTotal = tracksQuery.data?.total ?? 0;
+	const tracksLoading = tracksQuery.isLoading;
 
 	// タブ切り替え
 	const handleTabChange = (tab: ArtistDetailTab) => {
@@ -118,47 +140,15 @@ function ArtistDetailPage() {
 		});
 	};
 
-	// トラック一覧を取得
-	const fetchTracks = useCallback(
-		async (page: number, role?: string) => {
-			if (!artist) return;
-			setTracksLoading(true);
-			try {
-				const res = await publicApi.artists.tracks(id, {
-					page,
-					limit: PAGE_SIZE,
-					role: role === "all" ? undefined : role,
-				});
-				setTracks(res.data);
-				setTracksTotal(res.total);
-				setTracksPage(page);
-				setTracksLoaded(true);
-			} catch {
-				setTracks([]);
-				setTracksTotal(0);
-			} finally {
-				setTracksLoading(false);
-			}
-		},
-		[artist, id],
-	);
-
-	// タブ切替時に遅延読み込み
-	useEffect(() => {
-		if (activeTab === "tracks" && !tracksLoaded && artist) {
-			fetchTracks(1, roleFilter);
-		}
-	}, [activeTab, tracksLoaded, artist, fetchTracks, roleFilter]);
-
 	// フィルター変更時
 	const handleRoleFilterChange = (value: string) => {
 		setRoleFilter(value);
-		fetchTracks(1, value);
+		setTracksPage(1);
 	};
 
 	// ページ変更時
 	const handlePageChange = (page: number) => {
-		fetchTracks(page, roleFilter);
+		setTracksPage(page);
 	};
 
 	// メタ情報の折りたたみ状態

--- a/apps/web/src/routes/_public/circles.tsx
+++ b/apps/web/src/routes/_public/circles.tsx
@@ -56,6 +56,24 @@ export const Route = createFileRoute("/_public/circles")({
 			search: typeof search.search === "string" ? search.search : undefined,
 		};
 	},
+	loaderDeps: ({ search }) => ({
+		search: search.search,
+		script: search.script,
+		initial: search.initial,
+		row: search.row,
+	}),
+	loader: async ({ deps, context }) => {
+		const scriptCategory = deps.script ?? "all";
+		await context.queryClient.ensureInfiniteQueryData(
+			publicCirclesInfiniteQueryOptions({
+				limit: PAGE_SIZE,
+				search: deps.search || undefined,
+				initialScript: scriptCategory === "all" ? undefined : scriptCategory,
+				initial: scriptCategory === "alphabet" ? deps.initial : undefined,
+				row: scriptCategory === "kana" ? deps.row : undefined,
+			}),
+		);
+	},
 });
 
 // =============================================================================

--- a/apps/web/src/routes/_public/circles_.$id.tsx
+++ b/apps/web/src/routes/_public/circles_.$id.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import {
 	Calendar,
@@ -7,7 +8,7 @@ import {
 	UserRound,
 	Users,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
 	DetailTabs,
 	EmptyState,
@@ -32,12 +33,10 @@ import {
 	TAB_LABELS,
 } from "@/lib/detail-tab-utils";
 import { createPublicCircleHead } from "@/lib/head";
+import { publicApi } from "@/lib/public-api";
 import {
-	type PublicCircleRelease,
-	type PublicCircleTrack,
-	publicApi,
-} from "@/lib/public-api";
-import {
+	publicCircleReleasesQueryOptions,
+	publicCircleTracksQueryOptions,
 	publicWorkStatsSimpleQueryOptions,
 	publicWorkStatsStackedQueryOptions,
 } from "@/lib/public-query-options";
@@ -46,13 +45,17 @@ interface CircleDetailSearchParams {
 	tab?: CircleDetailTab;
 }
 
+const STORAGE_KEY_VIEW = "circle-detail-view-mode";
+const PAGE_SIZE = 20;
+
 export const Route = createFileRoute("/_public/circles_/$id")({
 	validateSearch: (
 		search: Record<string, unknown>,
 	): CircleDetailSearchParams => ({
 		tab: parseCircleDetailTab(search.tab),
 	}),
-	loader: async ({ params, context }) => {
+	loaderDeps: ({ search }) => ({ tab: search.tab }),
+	loader: async ({ params, context, deps }) => {
 		try {
 			const circle = await publicApi.circles.get(params.id);
 
@@ -64,6 +67,24 @@ export const Route = createFileRoute("/_public/circles_/$id")({
 				publicWorkStatsSimpleQueryOptions("circle", params.id),
 			);
 
+			// アクティブタブの初回データを SSR プリフェッチ
+			const activeTab = deps.tab ?? "releases";
+			if (activeTab === "releases") {
+				await context.queryClient.ensureQueryData(
+					publicCircleReleasesQueryOptions(params.id, {
+						page: 1,
+						limit: PAGE_SIZE,
+					}),
+				);
+			} else if (activeTab === "tracks") {
+				await context.queryClient.ensureQueryData(
+					publicCircleTracksQueryOptions(params.id, {
+						page: 1,
+						limit: PAGE_SIZE,
+					}),
+				);
+			}
+
 			return { circle };
 		} catch {
 			return { circle: null };
@@ -73,9 +94,6 @@ export const Route = createFileRoute("/_public/circles_/$id")({
 	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	component: CircleDetailPage,
 });
-
-const STORAGE_KEY_VIEW = "circle-detail-view-mode";
-const PAGE_SIZE = 20;
 
 // プラットフォーム名
 const platformNames: Record<string, string> = {
@@ -136,19 +154,33 @@ function CircleDetailPage() {
 		}
 	}, [activeTab, contentTab]);
 
-	// 作品一覧の状態
-	const [releases, setReleases] = useState<PublicCircleRelease[]>([]);
-	const [releasesTotal, setReleasesTotal] = useState(0);
+	// ページネーション状態
 	const [releasesPage, setReleasesPage] = useState(1);
-	const [releasesLoading, setReleasesLoading] = useState(false);
-	const [releasesLoaded, setReleasesLoaded] = useState(false);
-
-	// トラック一覧の状態
-	const [tracks, setTracks] = useState<PublicCircleTrack[]>([]);
-	const [tracksTotal, setTracksTotal] = useState(0);
 	const [tracksPage, setTracksPage] = useState(1);
-	const [tracksLoading, setTracksLoading] = useState(false);
-	const [tracksLoaded, setTracksLoaded] = useState(false);
+
+	// 作品一覧クエリ
+	const releasesQuery = useQuery({
+		...publicCircleReleasesQueryOptions(id, {
+			page: releasesPage,
+			limit: PAGE_SIZE,
+		}),
+		enabled: activeTab === "releases" && !!circle,
+	});
+	const releases = releasesQuery.data?.data ?? [];
+	const releasesTotal = releasesQuery.data?.total ?? 0;
+	const releasesLoading = releasesQuery.isLoading;
+
+	// トラック一覧クエリ
+	const tracksQuery = useQuery({
+		...publicCircleTracksQueryOptions(id, {
+			page: tracksPage,
+			limit: PAGE_SIZE,
+		}),
+		enabled: activeTab === "tracks" && !!circle,
+	});
+	const tracks = tracksQuery.data?.data ?? [];
+	const tracksTotal = tracksQuery.data?.total ?? 0;
+	const tracksLoading = tracksQuery.isLoading;
 
 	// ビューモードの保存
 	useEffect(() => {
@@ -169,68 +201,6 @@ function CircleDetailPage() {
 			search: { tab },
 		});
 	};
-
-	// 作品一覧を取得
-	const fetchReleases = useCallback(
-		async (page: number) => {
-			if (!circle) return;
-			setReleasesLoading(true);
-			try {
-				const res = await publicApi.circles.releases(id, {
-					page,
-					limit: PAGE_SIZE,
-				});
-				setReleases(res.data);
-				setReleasesTotal(res.total);
-				setReleasesPage(page);
-				setReleasesLoaded(true);
-			} catch {
-				// エラー時は空配列
-			} finally {
-				setReleasesLoading(false);
-			}
-		},
-		[circle, id],
-	);
-
-	// トラック一覧を取得
-	const fetchTracks = useCallback(
-		async (page: number) => {
-			if (!circle) return;
-			setTracksLoading(true);
-			try {
-				const res = await publicApi.circles.tracks(id, {
-					page,
-					limit: PAGE_SIZE,
-				});
-				setTracks(res.data);
-				setTracksTotal(res.total);
-				setTracksPage(page);
-				setTracksLoaded(true);
-			} catch {
-				// エラー時は空配列
-			} finally {
-				setTracksLoading(false);
-			}
-		},
-		[circle, id],
-	);
-
-	// タブ切替時に遅延読み込み
-	useEffect(() => {
-		if (activeTab === "releases" && !releasesLoaded && circle) {
-			fetchReleases(1);
-		} else if (activeTab === "tracks" && !tracksLoaded && circle) {
-			fetchTracks(1);
-		}
-	}, [
-		activeTab,
-		releasesLoaded,
-		tracksLoaded,
-		circle,
-		fetchReleases,
-		fetchTracks,
-	]);
 
 	// サークルが見つからない場合
 	if (!circle) {
@@ -474,7 +444,7 @@ function CircleDetailPage() {
 						<Pagination
 							currentPage={releasesPage}
 							totalPages={releasesTotalPages}
-							onPageChange={(page) => fetchReleases(page)}
+							onPageChange={setReleasesPage}
 						/>
 					)}
 				</>
@@ -615,7 +585,7 @@ function CircleDetailPage() {
 						<Pagination
 							currentPage={tracksPage}
 							totalPages={tracksTotalPages}
-							onPageChange={(page) => fetchTracks(page)}
+							onPageChange={setTracksPage}
 						/>
 					)}
 				</>

--- a/apps/web/src/routes/_public/events_.$id.tsx
+++ b/apps/web/src/routes/_public/events_.$id.tsx
@@ -82,7 +82,13 @@ export const Route = createFileRoute("/_public/events_/$id")({
 		sortBy: parseReleaseSortBy(search.sortBy),
 		sortOrder: parseSortOrder(search.sortOrder),
 	}),
-	loader: async ({ params, context }) => {
+	loaderDeps: ({ search }) => ({
+		tab: search.tab,
+		search: search.search,
+		sortBy: search.sortBy,
+		sortOrder: search.sortOrder,
+	}),
+	loader: async ({ params, context, deps }) => {
 		try {
 			const event = await publicApi.events.get(params.id);
 
@@ -93,6 +99,20 @@ export const Route = createFileRoute("/_public/events_/$id")({
 			context.queryClient.prefetchQuery(
 				publicWorkStatsSimpleQueryOptions("event", params.id),
 			);
+
+			// releasesタブ（デフォルト）の場合は無限スクロール初回ページを SSR プリフェッチ
+			const activeTab = deps.tab ?? "releases";
+			if (activeTab === "releases") {
+				await context.queryClient.ensureInfiniteQueryData(
+					publicEventReleasesInfiniteQueryOptions({
+						eventId: params.id,
+						limit: PAGE_SIZE,
+						search: deps.search || undefined,
+						sortBy: deps.sortBy ?? "name",
+						sortOrder: deps.sortOrder ?? "asc",
+					}),
+				);
+			}
 
 			return { event };
 		} catch {

--- a/apps/web/src/routes/_public/original-songs.tsx
+++ b/apps/web/src/routes/_public/original-songs.tsx
@@ -1,6 +1,7 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { ChevronRight, Loader2, Music } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
 	FilterDrawer,
 	FilterDrawerTrigger,
@@ -17,6 +18,7 @@ import {
 	type PublicWorkItem,
 	publicApi,
 } from "@/lib/public-api";
+import { publicWorkSongsQueryOptions } from "@/lib/public-query-options";
 
 // =============================================================================
 // URL パラメータの定義と検証
@@ -120,13 +122,6 @@ function OriginalSongsPage() {
 	// モバイルフィルタードロワーの状態
 	const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false);
 
-	// 遅延読み込み用の状態管理
-	const [songCache, setSongCache] = useState<Map<string, PublicSongItem[]>>(
-		new Map(),
-	);
-	const [loadingWorks, setLoadingWorks] = useState<Set<string>>(new Set());
-	const [errorWorks, setErrorWorks] = useState<Map<string, string>>(new Map());
-
 	// 展開中の作品ID一覧（URLパラメータから取得）
 	const expandedWorkIdsFromUrl = useMemo(() => {
 		if (open) {
@@ -138,38 +133,6 @@ function OriginalSongsPage() {
 	}, [open, works]);
 
 	const expandedWorkIds = expandedWorkIdsFromUrl;
-
-	// 楽曲を遅延取得する関数
-	const fetchSongsForWork = useCallback(
-		async (workId: string) => {
-			// キャッシュ済みならスキップ
-			if (songCache.has(workId)) return;
-
-			// ローディング状態を設定
-			setLoadingWorks((prev) => new Set(prev).add(workId));
-			setErrorWorks((prev) => {
-				const next = new Map(prev);
-				next.delete(workId);
-				return next;
-			});
-
-			try {
-				const response = await publicApi.songs.list({ workId, limit: 100 });
-				setSongCache((prev) => new Map(prev).set(workId, response.data));
-			} catch (_error) {
-				setErrorWorks((prev) =>
-					new Map(prev).set(workId, "楽曲の読み込みに失敗しました"),
-				);
-			} finally {
-				setLoadingWorks((prev) => {
-					const next = new Set(prev);
-					next.delete(workId);
-					return next;
-				});
-			}
-		},
-		[songCache],
-	);
 
 	// 初回マウント時に localStorage から復元（URL パラメータがない場合のみ）
 	// biome-ignore lint/correctness/useExhaustiveDependencies: 意図的に初回マウント時のみ実行
@@ -195,14 +158,6 @@ function OriginalSongsPage() {
 		}
 	}, []);
 
-	// 展開中の作品の楽曲を取得
-	// biome-ignore lint/correctness/useExhaustiveDependencies: expandedWorkIdsの変更時のみ実行
-	useEffect(() => {
-		for (const workId of expandedWorkIds) {
-			fetchSongsForWork(workId);
-		}
-	}, [expandedWorkIds]);
-
 	// 作品アコーディオンの展開/折りたたみ
 	const handleToggle = (workId: string) => {
 		const next = new Set(expandedWorkIds);
@@ -210,11 +165,8 @@ function OriginalSongsPage() {
 			next.delete(workId);
 		} else {
 			next.add(workId);
-			// 展開時に楽曲を取得
-			fetchSongsForWork(workId);
 		}
 
-		// URLとlocalStorageを更新
 		const openParam = next.size > 0 ? [...next].join(",") : undefined;
 		if (next.size > 0) {
 			localStorage.setItem(STORAGE_KEY, JSON.stringify([...next]));
@@ -229,11 +181,6 @@ function OriginalSongsPage() {
 
 	// カテゴリ変更
 	const handleTypeChange = (newType: string) => {
-		// キャッシュをクリア
-		setSongCache(new Map());
-		setLoadingWorks(new Set());
-		setErrorWorks(new Map());
-
 		navigate({
 			search: { type: newType, open: undefined },
 		});
@@ -368,10 +315,7 @@ function OriginalSongsPage() {
 							<WorkAccordion
 								key={work.id}
 								work={work}
-								songs={songCache.get(work.id)}
 								isExpanded={expandedWorkIds.has(work.id)}
-								isLoading={loadingWorks.has(work.id)}
-								error={errorWorks.get(work.id) ?? null}
 								onToggle={() => handleToggle(work.id)}
 							/>
 						))}
@@ -426,22 +370,21 @@ function OriginalSongsPage() {
 
 interface WorkAccordionProps {
 	work: PublicWorkItem;
-	songs: PublicSongItem[] | undefined;
 	isExpanded: boolean;
-	isLoading: boolean;
-	error: string | null;
 	onToggle: () => void;
 }
 
-function WorkAccordion({
-	work,
-	songs,
-	isExpanded,
-	isLoading,
-	error,
-	onToggle,
-}: WorkAccordionProps) {
+function WorkAccordion({ work, isExpanded, onToggle }: WorkAccordionProps) {
 	const displayName = work.nameJa;
+
+	const songsQuery = useQuery({
+		...publicWorkSongsQueryOptions(work.id, { limit: 100 }),
+		enabled: isExpanded,
+	});
+
+	const songs = songsQuery.data?.data;
+	const isLoading = songsQuery.isLoading;
+	const error = songsQuery.isError ? "楽曲の読み込みに失敗しました" : null;
 
 	// トラック番号でソート
 	const sortedSongs = useMemo(() => {
@@ -492,7 +435,7 @@ function WorkAccordion({
 						</tr>
 					</thead>
 					<tbody>
-						{sortedSongs.map((song) => (
+						{sortedSongs.map((song: PublicSongItem) => (
 							<tr key={song.id} className="hover:bg-base-200/50">
 								<td className="text-base-content/70">
 									{song.trackNumber != null

--- a/apps/web/src/routes/_public/stats_.artists.tsx
+++ b/apps/web/src/routes/_public/stats_.artists.tsx
@@ -16,6 +16,11 @@ const PAGE_SIZE = 20;
 export const Route = createFileRoute("/_public/stats_/artists")({
 	head: () => createPageHead("アーティスト楽曲数ランキング"),
 	component: ArtistsRankingPage,
+	loader: async ({ context }) => {
+		await context.queryClient.ensureInfiniteQueryData(
+			artistsRankingInfiniteQueryOptions(PAGE_SIZE),
+		);
+	},
 });
 
 function ArtistsRankingPage() {

--- a/apps/web/src/routes/_public/stats_.circles.tsx
+++ b/apps/web/src/routes/_public/stats_.circles.tsx
@@ -16,6 +16,11 @@ const PAGE_SIZE = 20;
 export const Route = createFileRoute("/_public/stats_/circles")({
 	head: () => createPageHead("サークル作品数ランキング"),
 	component: CirclesRankingPage,
+	loader: async ({ context }) => {
+		await context.queryClient.ensureInfiniteQueryData(
+			circlesRankingInfiniteQueryOptions(PAGE_SIZE),
+		);
+	},
 });
 
 function CirclesRankingPage() {

--- a/apps/web/src/routes/_public/stats_.original-songs.tsx
+++ b/apps/web/src/routes/_public/stats_.original-songs.tsx
@@ -16,6 +16,11 @@ const PAGE_SIZE = 20;
 export const Route = createFileRoute("/_public/stats_/original-songs")({
 	head: () => createPageHead("原曲アレンジ数ランキング"),
 	component: OriginalSongsRankingPage,
+	loader: async ({ context }) => {
+		await context.queryClient.ensureInfiniteQueryData(
+			originalSongsRankingInfiniteQueryOptions(PAGE_SIZE),
+		);
+	},
 });
 
 function OriginalSongsRankingPage() {

--- a/apps/web/src/routes/_public/stats_.song-pairs.tsx
+++ b/apps/web/src/routes/_public/stats_.song-pairs.tsx
@@ -16,6 +16,11 @@ const PAGE_SIZE = 20;
 export const Route = createFileRoute("/_public/stats_/song-pairs")({
 	head: () => createPageHead("原曲2曲組み合わせランキング"),
 	component: SongPairsRankingPage,
+	loader: async ({ context }) => {
+		await context.queryClient.ensureInfiniteQueryData(
+			songPairsRankingInfiniteQueryOptions(PAGE_SIZE),
+		);
+	},
 });
 
 function SongPairsRankingPage() {

--- a/apps/web/src/routes/_public/tags.tsx
+++ b/apps/web/src/routes/_public/tags.tsx
@@ -15,6 +15,11 @@ export const Route = createFileRoute("/_public/tags")({
 	head: () => createPageHead("タグ一覧"),
 	headers: () => CACHE_HEADERS.PUBLIC_LIST,
 	component: TagsPage,
+	loader: async ({ context }) => {
+		await context.queryClient.ensureQueryData(
+			publicTagsListQueryOptions({ limit: 500 }),
+		);
+	},
 });
 
 function TagsPage() {

--- a/apps/web/src/routes/_public/tags_.$tagId.tsx
+++ b/apps/web/src/routes/_public/tags_.$tagId.tsx
@@ -1,6 +1,7 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Calendar, Hash, Loader2, Music, UserRound } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import {
 	EmptyState,
 	EntityDetailHeader,
@@ -13,22 +14,24 @@ import {
 } from "@/components/public";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPageHead } from "@/lib/head";
-import { type PublicArrangeTrack, publicApi } from "@/lib/public-api";
+import { publicApi } from "@/lib/public-api";
+import { publicTagTracksQueryOptions } from "@/lib/public-query-options";
+
+const PAGE_SIZE = 20;
 
 export const Route = createFileRoute("/_public/tags_/$tagId")({
-	loader: async ({ params }) => {
+	loader: async ({ params, context }) => {
 		try {
-			const [tag, tracksRes] = await Promise.all([
-				publicApi.tags.get(params.tagId),
-				publicApi.tags.tracks(params.tagId, { page: 1, limit: 20 }),
-			]);
-			return {
-				tag,
-				initialTracks: tracksRes.data,
-				totalTracks: tracksRes.total,
-			};
+			const tag = await publicApi.tags.get(params.tagId);
+			await context.queryClient.ensureQueryData(
+				publicTagTracksQueryOptions(params.tagId, {
+					page: 1,
+					limit: PAGE_SIZE,
+				}),
+			);
+			return { tag };
 		} catch {
-			return { tag: null, initialTracks: [], totalTracks: 0 };
+			return { tag: null };
 		}
 	},
 	head: ({ loaderData }) =>
@@ -38,8 +41,6 @@ export const Route = createFileRoute("/_public/tags_/$tagId")({
 	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
 	component: TagDetailPage,
 });
-
-const PAGE_SIZE = 20;
 
 // 役割名
 const roleNames: Record<string, string> = {
@@ -54,41 +55,20 @@ const roleNames: Record<string, string> = {
 
 function TagDetailPage() {
 	const { tagId } = Route.useParams();
-	const { tag, initialTracks, totalTracks } = Route.useLoaderData();
+	const { tag } = Route.useLoaderData();
 
-	const [tracks, setTracks] = useState<PublicArrangeTrack[]>(initialTracks);
-	const [tracksTotal, setTracksTotal] = useState(totalTracks);
 	const [tracksPage, setTracksPage] = useState(1);
-	const [tracksLoading, setTracksLoading] = useState(false);
 
-	// 初期データが変わったら更新
-	useEffect(() => {
-		setTracks(initialTracks);
-		setTracksTotal(totalTracks);
-		setTracksPage(1);
-	}, [initialTracks, totalTracks]);
-
-	// トラック一覧を取得
-	const fetchTracks = useCallback(
-		async (page: number) => {
-			if (!tag) return;
-			setTracksLoading(true);
-			try {
-				const res = await publicApi.tags.tracks(tagId, {
-					page,
-					limit: PAGE_SIZE,
-				});
-				setTracks(res.data);
-				setTracksTotal(res.total);
-				setTracksPage(page);
-			} catch {
-				// エラー時は空配列
-			} finally {
-				setTracksLoading(false);
-			}
-		},
-		[tag, tagId],
-	);
+	const tracksQuery = useQuery({
+		...publicTagTracksQueryOptions(tagId, {
+			page: tracksPage,
+			limit: PAGE_SIZE,
+		}),
+		enabled: !!tag,
+	});
+	const tracks = tracksQuery.data?.data ?? [];
+	const tracksTotal = tracksQuery.data?.total ?? 0;
+	const tracksLoading = tracksQuery.isLoading;
 
 	// タグが見つからない場合
 	if (!tag) {
@@ -294,7 +274,7 @@ function TagDetailPage() {
 					<Pagination
 						currentPage={tracksPage}
 						totalPages={tracksTotalPages}
-						onPageChange={(page) => fetchTracks(page)}
+						onPageChange={setTracksPage}
 					/>
 				)}
 			</div>


### PR DESCRIPTION
## 概要

公開ページの初回ロード時に発生していたローディングスピナー（クルクル）を網羅的に解消する。SSRプリフェッチを各ルートに追加するとともに、`react-patterns.md` 禁止パターン #4（`useEffect` + `useState` + `publicApi` 直接呼び出し）を撤廃して `useQuery` ベースに統一する。

## 問題の原因

公開ページ群で以下の3系統の問題が初回スピナーの原因になっていた:

1. **一覧/ランキングページ**: `loader` を持たず、`useQuery` / `useInfiniteQuery` でクライアント側のみ初回データ取得していたため、ハイドレーション後に `isLoading` 中のスピナーが表示されていた。
2. **詳細ページのタブ内容**: `useState` + `useEffect` + `useCallback` + 直接API呼び出しでデータ取得していたため、`?tab=tracks` 等で直接アクセスすると初回スピナーが出ていた（`react-patterns.md` 禁止パターン #4）。
3. **Router の遷移pending**: `defaultPendingMs` 未設定で `defaultPendingComponent` が即座に表示されていたため、loaderが数百msで終わるページでもクリック遷移時にクルクルが瞬間的に出ていた。

## 変更内容

5コミットで段階的に対応した:

* **ced75f6** — 公開一覧/ランキング7ページ（artists / circles / tags / stats × 4）に `loader` + `loaderDeps` を追加し、`ensureInfiniteQueryData` / `ensureQueryData` でSSRプリフェッチ。
* **fa17242** — アーティスト/サークル詳細ページのトラック・作品タブを `useQuery` 化。loader で `loaderDeps` + `ensureQueryData` で初回タブ分をプリフェッチ。`useState` 15個 / `useCallback` 3個 / `useEffect` 2個 を削除し `useQuery` 3個に置換。
* **26216b7** — `router.tsx` に `defaultPendingMs: 1000` / `defaultPendingMinMs: 500` を追加。1秒以内に終わる遷移ではスピナーを出さず、出した場合は最低500ms保持してちらつき防止。
* **a627a7d** — イベント詳細ページのreleasesタブ（デフォルト）を `loaderDeps` + `ensureInfiniteQueryData` でSSRプリフェッチ。`search` / `sortBy` / `sortOrder` も依存に含める。
* **fbce3c7** — タグ詳細・原曲一覧の残るアンチパターンを撤廃。`useState` 6個 / `useCallback` 2個 / `useEffect` 3個 を削除し `useQuery` 2個に置換。`WorkAccordion` 内で `useQuery` + `enabled: isExpanded` を使うことで親側の `songCache` / `loadingWorks` / `errorWorks` Map/Set を撤廃。

`apps/web/src/lib/public-query-options.ts` にはこれらに対応する `queryOptions` を計5つ追加（`publicArtistTracksQueryOptions` / `publicCircleReleasesQueryOptions` / `publicCircleTracksQueryOptions` / `publicTagTracksQueryOptions` / `publicWorkSongsQueryOptions`）。

## 影響範囲

* 修正対象: 公開ページ12ファイル + ルーター設定 + クエリオプション集約ファイル。管理画面 / APIサーバー / DBスキーマには変更なし。
* `useQuery`化により `useState` 21個 / `useCallback` 5個 / `useEffect` 5個 を削除。`react-patterns.md` 禁止パターン #4 違反は公開ページから完全撲滅。
* SSRレスポンスサイズが該当ページで増加（プリフェッチ分のデータをHTMLに含むため）。
* loaderDeps 追加により、URLの search パラメータ変更時にloaderが再実行される。`ensureQueryData` はキャッシュヒット時に即座に返すため、staleTime 内の再アクセスは追加リクエストなし。

## 補足事項

* `loader` 内で渡すクエリオプションは画面内の既存 `useQuery` / `useInfiniteQuery` 呼び出しと完全一致させてあり、queryKeyが揃うのでハイドレーション時に確実にキャッシュヒットする。
* `/search` はクエリ入力後にだけ走るので「初回ロードクルクル」が実質発生せず、対象外とした。
* `/admin/*` の同種ページ（artists / circles / tags / tracks等）は SEO 不要・認証必須でUX優先度が低いため別タスクで対応する想定。
* `defaultPendingMs` 設定は全ルート横断で効くため、今後追加するルートでも自動的に「速い遷移ではスピナーなし」のUXになる。

## 検証

ローカル `devbox services up` で起動し、以下を Cmd+Shift+R で完全リロードしてスピナー無表示を確認:

* `/artists`、`/circles`、`/tags`、`/stats/artists` 等の一覧/ランキング
* `/artists/$id?tab=tracks`、`/circles/$id?tab=releases|tracks` の詳細タブ
* `/events/$id?tab=releases` のイベント作品一覧
* `/tags/$tagId` のページネーション後再読込
* `/original-songs` のアコーディオン展開＆カテゴリ切替
* ページ間リンククリックでの速い遷移（1秒以内のloaderはスピナー無し）

SSRレスポンスをcurlで確認し、`animate-spin` / `loading-spinner` クラスが0件、データ完全包含であることを検証済み。
