### PR TITLE
feat: アルバム情報提供と管理者承認フローを追加

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -7,6 +7,7 @@ import { logger } from "hono/logger";
 import { authRateLimiter, methodRateLimiter } from "./middleware/rate-limit";
 import { adminRouter } from "./routes/admin";
 import { publicRouter } from "./routes/public";
+import { userRouter } from "./routes/user";
 import { pruneExpiredCache } from "./utils/cache";
 
 if (process.env.NODE_ENV === "production") {
@@ -47,6 +48,9 @@ app.on(["POST", "GET"], "/api/auth/*", (c) => auth.handler(c.req.raw));
 // 公開API（認証不要）
 app.use("/api/public/*", methodRateLimiter);
 app.route("/api/public", publicRouter);
+
+// ユーザーAPI（ログイン必須）
+app.route("/api/user", userRouter);
 
 // 管理者API
 app.route("/api/admin", adminRouter);

--- a/apps/server/src/middleware/user-auth.ts
+++ b/apps/server/src/middleware/user-auth.ts
@@ -1,0 +1,42 @@
+import { auth } from "@thac/auth";
+import type { Context, Next } from "hono";
+
+export type User = {
+	id: string;
+	name: string;
+	email: string;
+	role: string | null;
+};
+
+export type UserAuthContext = {
+	Variables: {
+		user: User;
+	};
+};
+
+/**
+ * ログイン必須APIへのアクセス制御ミドルウェア
+ *
+ * - セッションからユーザー情報を取得
+ * - 未認証リクエストに401ステータスを返却
+ * - 認証済みユーザーのみ後続処理へ進行を許可
+ */
+export async function requireUserMiddleware(c: Context, next: Next) {
+	try {
+		const session = await auth.api.getSession({
+			headers: c.req.raw.headers,
+		});
+
+		if (!session?.user) {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
+
+		// ユーザー情報をコンテキストに設定
+		c.set("user", session.user as User);
+
+		return next();
+	} catch (error) {
+		console.error("User auth middleware error:", error);
+		return c.json({ error: "Unauthorized" }, 401);
+	}
+}

--- a/apps/server/src/middleware/user-auth.ts
+++ b/apps/server/src/middleware/user-auth.ts
@@ -1,12 +1,8 @@
 import { auth } from "@thac/auth";
 import type { Context, Next } from "hono";
+import type { User } from "./admin-auth";
 
-export type User = {
-	id: string;
-	name: string;
-	email: string;
-	role: string | null;
-};
+export type { User };
 
 export type UserAuthContext = {
 	Variables: {

--- a/apps/server/src/routes/admin/album-requests/album-requests.ts
+++ b/apps/server/src/routes/admin/album-requests/album-requests.ts
@@ -1,5 +1,6 @@
 import {
 	albumRequests,
+	and,
 	count,
 	db,
 	desc,
@@ -46,7 +47,7 @@ albumRequestsAdminRouter.get("/", async (c) => {
 			? eq(albumRequests.status, status)
 			: undefined;
 
-		const [data, totalResult] = await Promise.all([
+		const [rows, totalResult] = await Promise.all([
 			db
 				.select({
 					id: albumRequests.id,
@@ -65,12 +66,10 @@ albumRequestsAdminRouter.get("/", async (c) => {
 						name: submitter.name,
 						email: submitter.email,
 					},
-					existingRelease: {
-						id: releases.id,
-						name: releases.name,
-						nameJa: releases.nameJa,
-						nameEn: releases.nameEn,
-					},
+					existingReleaseId: releases.id,
+					existingReleaseName: releases.name,
+					existingReleaseNameJa: releases.nameJa,
+					existingReleaseNameEn: releases.nameEn,
 				})
 				.from(albumRequests)
 				.leftJoin(submitter, eq(albumRequests.userId, submitter.id))
@@ -82,16 +81,37 @@ albumRequestsAdminRouter.get("/", async (c) => {
 			db.select({ count: count() }).from(albumRequests).where(whereCondition),
 		]);
 
+		const data = rows.map((row) => ({
+			id: row.id,
+			requestType: row.requestType,
+			albumName: row.albumName,
+			circleName: row.circleName,
+			referenceUrls: row.referenceUrls,
+			notes: row.notes,
+			status: row.status,
+			reviewerNotes: row.reviewerNotes,
+			reviewedAt: row.reviewedAt,
+			createdAt: row.createdAt,
+			updatedAt: row.updatedAt,
+			submittedBy: row.submittedBy,
+			existingRelease:
+				row.existingReleaseId !== null
+					? {
+							id: row.existingReleaseId,
+							name: row.existingReleaseName,
+							nameJa: row.existingReleaseNameJa,
+							nameEn: row.existingReleaseNameEn,
+						}
+					: null,
+		}));
+
 		const total = Number(totalResult[0]?.count ?? 0);
 
 		return c.json({
 			data,
-			pagination: {
-				page,
-				limit,
-				total,
-				totalPages: Math.ceil(total / limit),
-			},
+			total,
+			page,
+			limit,
 		});
 	} catch (error) {
 		return handleDbError(c, error, "GET /admin/album-requests");
@@ -106,7 +126,7 @@ albumRequestsAdminRouter.get("/:id", async (c) => {
 		const submitter = alias(user, "submitter");
 		const reviewer = alias(user, "reviewer");
 
-		const result = await db
+		const rows = await db
 			.select({
 				id: albumRequests.id,
 				requestType: albumRequests.requestType,
@@ -129,13 +149,11 @@ albumRequestsAdminRouter.get("/:id", async (c) => {
 					name: reviewer.name,
 					email: reviewer.email,
 				},
-				existingRelease: {
-					id: releases.id,
-					name: releases.name,
-					nameJa: releases.nameJa,
-					nameEn: releases.nameEn,
-					releaseDate: releases.releaseDate,
-				},
+				existingReleaseId: releases.id,
+				existingReleaseName: releases.name,
+				existingReleaseNameJa: releases.nameJa,
+				existingReleaseNameEn: releases.nameEn,
+				existingReleaseDate: releases.releaseDate,
 			})
 			.from(albumRequests)
 			.leftJoin(submitter, eq(albumRequests.userId, submitter.id))
@@ -144,15 +162,49 @@ albumRequestsAdminRouter.get("/:id", async (c) => {
 			.where(eq(albumRequests.id, id))
 			.limit(1);
 
-		if (result.length === 0) {
+		const row = rows[0];
+		if (!row) {
 			return c.json({ error: "アルバム申請が見つかりません" }, 404);
 		}
 
-		return c.json(result[0]);
+		const result = {
+			id: row.id,
+			requestType: row.requestType,
+			albumName: row.albumName,
+			circleName: row.circleName,
+			referenceUrls: row.referenceUrls,
+			notes: row.notes,
+			status: row.status,
+			reviewerNotes: row.reviewerNotes,
+			reviewedAt: row.reviewedAt,
+			createdAt: row.createdAt,
+			updatedAt: row.updatedAt,
+			submittedBy: row.submittedBy,
+			reviewer: row.reviewer,
+			existingRelease:
+				row.existingReleaseId !== null
+					? {
+							id: row.existingReleaseId,
+							name: row.existingReleaseName,
+							nameJa: row.existingReleaseNameJa,
+							nameEn: row.existingReleaseNameEn,
+							releaseDate: row.existingReleaseDate,
+						}
+					: null,
+		};
+
+		return c.json(result);
 	} catch (error) {
 		return handleDbError(c, error, "GET /admin/album-requests/:id");
 	}
 });
+
+// 内部処理結果の型（discriminated union）
+type PatchResult =
+	| { kind: "notFound" }
+	| { kind: "conflict"; id: string; status: string; updatedAt: Date | null }
+	| { kind: "alreadyProcessed" }
+	| { kind: "success"; data: Record<string, unknown> };
 
 // アルバム申請ステータス更新（楽観的ロック付きトランザクション）
 albumRequestsAdminRouter.patch("/:id", async (c) => {
@@ -172,7 +224,7 @@ albumRequestsAdminRouter.patch("/:id", async (c) => {
 			);
 		}
 
-		const updated = await db.transaction(async (tx) => {
+		const result = await db.transaction(async (tx): Promise<PatchResult> => {
 			// 存在確認 + 楽観的ロック用の現在データ取得
 			const existing = await tx
 				.select({
@@ -184,11 +236,11 @@ albumRequestsAdminRouter.patch("/:id", async (c) => {
 				.where(eq(albumRequests.id, id))
 				.limit(1);
 
-			if (existing.length === 0) {
-				return null;
-			}
-
 			const current = existing[0];
+
+			if (!current) {
+				return { kind: "notFound" };
+			}
 
 			// 楽観的ロックチェック
 			const conflict = checkOptimisticLockConflict({
@@ -196,16 +248,18 @@ albumRequestsAdminRouter.patch("/:id", async (c) => {
 				currentEntity: current,
 			});
 			if (conflict) {
-				return conflict;
+				// 公開可能なフィールドのみ返す
+				return {
+					kind: "conflict",
+					id: current.id,
+					status: current.status,
+					updatedAt: current.updatedAt,
+				};
 			}
 
 			// pending 以外は更新不可
-			if (current?.status !== "pending") {
-				return { __alreadyProcessed: true } as const;
-			}
-
-			// ステータス更新
-			const result = await tx
+			// WHERE に status='pending' を AND することで DB レベルでも競合を防ぐ
+			const updated = await tx
 				.update(albumRequests)
 				.set({
 					status: parsed.data.status,
@@ -213,27 +267,43 @@ albumRequestsAdminRouter.patch("/:id", async (c) => {
 					reviewedByUserId: c.get("user").id,
 					reviewedAt: new Date(),
 				})
-				.where(eq(albumRequests.id, id))
+				.where(
+					and(eq(albumRequests.id, id), eq(albumRequests.status, "pending")),
+				)
 				.returning();
 
-			return result[0];
+			if (updated.length === 0) {
+				// UPDATE が 0 件 = すでに pending 以外に遷移済み
+				return { kind: "alreadyProcessed" };
+			}
+
+			return { kind: "success", data: updated[0] as Record<string, unknown> };
 		});
 
-		if (updated === null) {
+		if (result.kind === "notFound") {
 			return c.json({ error: "アルバム申請が見つかりません" }, 404);
 		}
 
-		// 楽観的ロック競合
-		if (updated && "error" in updated && "code" in updated) {
-			return c.json(updated, 409);
+		if (result.kind === "conflict") {
+			return c.json(
+				{
+					error: "他のユーザーによってデータが更新されました",
+					code: "CONFLICT",
+					current: {
+						id: result.id,
+						status: result.status,
+						updatedAt: result.updatedAt,
+					},
+				},
+				409,
+			);
 		}
 
-		// 既処理チェック
-		if (updated && "__alreadyProcessed" in updated) {
+		if (result.kind === "alreadyProcessed") {
 			return c.json({ error: "このリクエストは既に処理済みです" }, 400);
 		}
 
-		return c.json(updated, 200);
+		return c.json(result.data, 200);
 	} catch (error) {
 		return handleDbError(c, error, "PATCH /admin/album-requests/:id");
 	}

--- a/apps/server/src/routes/admin/album-requests/album-requests.ts
+++ b/apps/server/src/routes/admin/album-requests/album-requests.ts
@@ -1,0 +1,242 @@
+import {
+	albumRequests,
+	count,
+	db,
+	desc,
+	eq,
+	releases,
+	updateAlbumRequestStatusSchema,
+	user,
+} from "@thac/db";
+import { alias } from "drizzle-orm/pg-core";
+import { Hono } from "hono";
+import type { AdminContext } from "../../../middleware/admin-auth";
+import { handleDbError } from "../../../utils/api-error";
+import { checkOptimisticLockConflict } from "../../../utils/conflict-check";
+
+const albumRequestsAdminRouter = new Hono<AdminContext>();
+
+// バッジ用 pending 件数取得（Cache-Control: private, max-age=30）
+albumRequestsAdminRouter.get("/pending-count", async (c) => {
+	try {
+		const result = await db
+			.select({ count: count() })
+			.from(albumRequests)
+			.where(eq(albumRequests.status, "pending"));
+
+		c.header("Cache-Control", "private, max-age=30");
+
+		return c.json({ count: Number(result[0]?.count ?? 0) });
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/album-requests/pending-count");
+	}
+});
+
+// アルバム申請一覧取得（status フィルタ、ページネーション対応）
+albumRequestsAdminRouter.get("/", async (c) => {
+	try {
+		const page = Number(c.req.query("page")) || 1;
+		const limit = Math.min(Number(c.req.query("limit")) || 20, 100);
+		const status = c.req.query("status");
+		const offset = (page - 1) * limit;
+
+		const submitter = alias(user, "submitter");
+
+		const whereCondition = status
+			? eq(albumRequests.status, status)
+			: undefined;
+
+		const [data, totalResult] = await Promise.all([
+			db
+				.select({
+					id: albumRequests.id,
+					requestType: albumRequests.requestType,
+					albumName: albumRequests.albumName,
+					circleName: albumRequests.circleName,
+					referenceUrls: albumRequests.referenceUrls,
+					notes: albumRequests.notes,
+					status: albumRequests.status,
+					reviewerNotes: albumRequests.reviewerNotes,
+					reviewedAt: albumRequests.reviewedAt,
+					createdAt: albumRequests.createdAt,
+					updatedAt: albumRequests.updatedAt,
+					submittedBy: {
+						id: submitter.id,
+						name: submitter.name,
+						email: submitter.email,
+					},
+					existingRelease: {
+						id: releases.id,
+						name: releases.name,
+						nameJa: releases.nameJa,
+						nameEn: releases.nameEn,
+					},
+				})
+				.from(albumRequests)
+				.leftJoin(submitter, eq(albumRequests.userId, submitter.id))
+				.leftJoin(releases, eq(albumRequests.existingReleaseId, releases.id))
+				.where(whereCondition)
+				.orderBy(desc(albumRequests.createdAt))
+				.limit(limit)
+				.offset(offset),
+			db.select({ count: count() }).from(albumRequests).where(whereCondition),
+		]);
+
+		const total = Number(totalResult[0]?.count ?? 0);
+
+		return c.json({
+			data,
+			pagination: {
+				page,
+				limit,
+				total,
+				totalPages: Math.ceil(total / limit),
+			},
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/album-requests");
+	}
+});
+
+// アルバム申請詳細取得（user / reviewer / existingRelease を JOIN）
+albumRequestsAdminRouter.get("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+
+		const submitter = alias(user, "submitter");
+		const reviewer = alias(user, "reviewer");
+
+		const result = await db
+			.select({
+				id: albumRequests.id,
+				requestType: albumRequests.requestType,
+				albumName: albumRequests.albumName,
+				circleName: albumRequests.circleName,
+				referenceUrls: albumRequests.referenceUrls,
+				notes: albumRequests.notes,
+				status: albumRequests.status,
+				reviewerNotes: albumRequests.reviewerNotes,
+				reviewedAt: albumRequests.reviewedAt,
+				createdAt: albumRequests.createdAt,
+				updatedAt: albumRequests.updatedAt,
+				submittedBy: {
+					id: submitter.id,
+					name: submitter.name,
+					email: submitter.email,
+				},
+				reviewer: {
+					id: reviewer.id,
+					name: reviewer.name,
+					email: reviewer.email,
+				},
+				existingRelease: {
+					id: releases.id,
+					name: releases.name,
+					nameJa: releases.nameJa,
+					nameEn: releases.nameEn,
+					releaseDate: releases.releaseDate,
+				},
+			})
+			.from(albumRequests)
+			.leftJoin(submitter, eq(albumRequests.userId, submitter.id))
+			.leftJoin(reviewer, eq(albumRequests.reviewedByUserId, reviewer.id))
+			.leftJoin(releases, eq(albumRequests.existingReleaseId, releases.id))
+			.where(eq(albumRequests.id, id))
+			.limit(1);
+
+		if (result.length === 0) {
+			return c.json({ error: "アルバム申請が見つかりません" }, 404);
+		}
+
+		return c.json(result[0]);
+	} catch (error) {
+		return handleDbError(c, error, "GET /admin/album-requests/:id");
+	}
+});
+
+// アルバム申請ステータス更新（楽観的ロック付きトランザクション）
+albumRequestsAdminRouter.patch("/:id", async (c) => {
+	try {
+		const id = c.req.param("id");
+		const body = await c.req.json();
+
+		// バリデーション
+		const parsed = updateAlbumRequestStatusSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten(),
+				},
+				400,
+			);
+		}
+
+		const updated = await db.transaction(async (tx) => {
+			// 存在確認 + 楽観的ロック用の現在データ取得
+			const existing = await tx
+				.select({
+					id: albumRequests.id,
+					status: albumRequests.status,
+					updatedAt: albumRequests.updatedAt,
+				})
+				.from(albumRequests)
+				.where(eq(albumRequests.id, id))
+				.limit(1);
+
+			if (existing.length === 0) {
+				return null;
+			}
+
+			const current = existing[0];
+
+			// 楽観的ロックチェック
+			const conflict = checkOptimisticLockConflict({
+				requestUpdatedAt: parsed.data.updatedAt,
+				currentEntity: current,
+			});
+			if (conflict) {
+				return conflict;
+			}
+
+			// pending 以外は更新不可
+			if (current?.status !== "pending") {
+				return { __alreadyProcessed: true } as const;
+			}
+
+			// ステータス更新
+			const result = await tx
+				.update(albumRequests)
+				.set({
+					status: parsed.data.status,
+					reviewerNotes: parsed.data.reviewerNotes ?? null,
+					reviewedByUserId: c.get("user").id,
+					reviewedAt: new Date(),
+				})
+				.where(eq(albumRequests.id, id))
+				.returning();
+
+			return result[0];
+		});
+
+		if (updated === null) {
+			return c.json({ error: "アルバム申請が見つかりません" }, 404);
+		}
+
+		// 楽観的ロック競合
+		if (updated && "error" in updated && "code" in updated) {
+			return c.json(updated, 409);
+		}
+
+		// 既処理チェック
+		if (updated && "__alreadyProcessed" in updated) {
+			return c.json({ error: "このリクエストは既に処理済みです" }, 400);
+		}
+
+		return c.json(updated, 200);
+	} catch (error) {
+		return handleDbError(c, error, "PATCH /admin/album-requests/:id");
+	}
+});
+
+export { albumRequestsAdminRouter };

--- a/apps/server/src/routes/admin/album-requests/index.ts
+++ b/apps/server/src/routes/admin/album-requests/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+import type { AdminContext } from "../../../middleware/admin-auth";
+import { albumRequestsAdminRouter } from "./album-requests";
+
+const albumRequestsRouter = new Hono<AdminContext>();
+
+albumRequestsRouter.route("/", albumRequestsAdminRouter);
+
+export { albumRequestsRouter };

--- a/apps/server/src/routes/admin/index.ts
+++ b/apps/server/src/routes/admin/index.ts
@@ -4,6 +4,7 @@ import {
 	adminAuthMiddleware,
 } from "../../middleware/admin-auth";
 import { methodRateLimiter } from "../../middleware/rate-limit";
+import { albumRequestsRouter } from "./album-requests";
 import { artistAliasesRouter } from "./artist-aliases";
 import { artistsRouter } from "./artists";
 import { circlesRouter } from "./circles";
@@ -56,6 +57,9 @@ adminRouter.route("/event-series", eventSeriesRouter);
 
 // イベント管理ルート
 adminRouter.route("/events", eventsAdminRouter);
+
+// アルバム申請管理ルート
+adminRouter.route("/album-requests", albumRequestsRouter);
 
 // 作品管理ルート
 adminRouter.route("/releases", releasesAdminRouter);

--- a/apps/server/src/routes/user/album-requests.ts
+++ b/apps/server/src/routes/user/album-requests.ts
@@ -1,0 +1,111 @@
+import {
+	albumRequests,
+	createAlbumRequestSchema,
+	createId,
+	db,
+	desc,
+	eq,
+	releases,
+} from "@thac/db";
+import { Hono } from "hono";
+import type { UserAuthContext } from "../../middleware/user-auth";
+import { handleDbError } from "../../utils/api-error";
+
+const albumRequestsUserRouter = new Hono<UserAuthContext>();
+
+// 自分のアルバム申請一覧取得（最新50件）
+albumRequestsUserRouter.get("/", async (c) => {
+	try {
+		const user = c.get("user");
+
+		const items = await db
+			.select({
+				id: albumRequests.id,
+				requestType: albumRequests.requestType,
+				albumName: albumRequests.albumName,
+				circleName: albumRequests.circleName,
+				referenceUrls: albumRequests.referenceUrls,
+				notes: albumRequests.notes,
+				status: albumRequests.status,
+				reviewerNotes: albumRequests.reviewerNotes,
+				reviewedAt: albumRequests.reviewedAt,
+				createdAt: albumRequests.createdAt,
+				updatedAt: albumRequests.updatedAt,
+				existingRelease: {
+					id: releases.id,
+					name: releases.name,
+					nameJa: releases.nameJa,
+					nameEn: releases.nameEn,
+					releaseDate: releases.releaseDate,
+				},
+			})
+			.from(albumRequests)
+			.leftJoin(releases, eq(albumRequests.existingReleaseId, releases.id))
+			.where(eq(albumRequests.userId, user.id))
+			.orderBy(desc(albumRequests.createdAt))
+			.limit(50);
+
+		return c.json({ items });
+	} catch (error) {
+		return handleDbError(c, error, "GET /user/album-requests");
+	}
+});
+
+// アルバム申請作成
+albumRequestsUserRouter.post("/", async (c) => {
+	try {
+		const body = await c.req.json();
+
+		// バリデーション
+		const parsed = createAlbumRequestSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					details: parsed.error.flatten(),
+				},
+				400,
+			);
+		}
+
+		const { requestType } = parsed.data;
+		const user = c.get("user");
+
+		// existing タイプの場合は既存リリースの実在チェック
+		if (requestType === "existing") {
+			const existingReleaseId = parsed.data.existingReleaseId;
+			const releaseExists = await db
+				.select({ id: releases.id })
+				.from(releases)
+				.where(eq(releases.id, existingReleaseId))
+				.limit(1);
+
+			if (releaseExists.length === 0) {
+				return c.json({ error: "指定された既存アルバムが見つかりません" }, 400);
+			}
+		}
+
+		// INSERT
+		const inserted = await db
+			.insert(albumRequests)
+			.values({
+				id: createId.albumRequest(),
+				userId: user.id,
+				status: "pending",
+				requestType,
+				existingReleaseId:
+					requestType === "existing" ? parsed.data.existingReleaseId : null,
+				albumName: parsed.data.albumName ?? null,
+				circleName: parsed.data.circleName ?? null,
+				referenceUrls: parsed.data.referenceUrls,
+				notes: parsed.data.notes ?? null,
+			})
+			.returning();
+
+		return c.json(inserted[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /user/album-requests");
+	}
+});
+
+export { albumRequestsUserRouter };

--- a/apps/server/src/routes/user/album-requests.ts
+++ b/apps/server/src/routes/user/album-requests.ts
@@ -18,7 +18,7 @@ albumRequestsUserRouter.get("/", async (c) => {
 	try {
 		const user = c.get("user");
 
-		const items = await db
+		const rows = await db
 			.select({
 				id: albumRequests.id,
 				requestType: albumRequests.requestType,
@@ -31,19 +31,41 @@ albumRequestsUserRouter.get("/", async (c) => {
 				reviewedAt: albumRequests.reviewedAt,
 				createdAt: albumRequests.createdAt,
 				updatedAt: albumRequests.updatedAt,
-				existingRelease: {
-					id: releases.id,
-					name: releases.name,
-					nameJa: releases.nameJa,
-					nameEn: releases.nameEn,
-					releaseDate: releases.releaseDate,
-				},
+				existingReleaseId: releases.id,
+				existingReleaseName: releases.name,
+				existingReleaseNameJa: releases.nameJa,
+				existingReleaseNameEn: releases.nameEn,
+				existingReleaseDate: releases.releaseDate,
 			})
 			.from(albumRequests)
 			.leftJoin(releases, eq(albumRequests.existingReleaseId, releases.id))
 			.where(eq(albumRequests.userId, user.id))
 			.orderBy(desc(albumRequests.createdAt))
 			.limit(50);
+
+		const items = rows.map((row) => ({
+			id: row.id,
+			requestType: row.requestType,
+			albumName: row.albumName,
+			circleName: row.circleName,
+			referenceUrls: row.referenceUrls,
+			notes: row.notes,
+			status: row.status,
+			reviewerNotes: row.reviewerNotes,
+			reviewedAt: row.reviewedAt,
+			createdAt: row.createdAt,
+			updatedAt: row.updatedAt,
+			existingRelease:
+				row.existingReleaseId !== null
+					? {
+							id: row.existingReleaseId,
+							name: row.existingReleaseName,
+							nameJa: row.existingReleaseNameJa,
+							nameEn: row.existingReleaseNameEn,
+							releaseDate: row.existingReleaseDate,
+						}
+					: null,
+		}));
 
 		return c.json({ items });
 	} catch (error) {

--- a/apps/server/src/routes/user/index.ts
+++ b/apps/server/src/routes/user/index.ts
@@ -1,0 +1,20 @@
+import { Hono } from "hono";
+import { methodRateLimiter } from "../../middleware/rate-limit";
+import {
+	requireUserMiddleware,
+	type UserAuthContext,
+} from "../../middleware/user-auth";
+import { albumRequestsUserRouter } from "./album-requests";
+
+const userRouter = new Hono<UserAuthContext>();
+
+// ユーザー認証ミドルウェアを適用
+userRouter.use("/*", requireUserMiddleware);
+
+// レート制限ミドルウェアを適用（認証後）
+userRouter.use("/*", methodRateLimiter);
+
+// アルバム申請ルート
+userRouter.route("/album-requests", albumRequestsUserRouter);
+
+export { userRouter };

--- a/apps/server/test/helpers/fixtures.ts
+++ b/apps/server/test/helpers/fixtures.ts
@@ -1,4 +1,4 @@
-import type { InitialScript } from "@thac/db";
+import type { AlbumRequestReferenceUrl, InitialScript } from "@thac/db";
 import { nanoid } from "nanoid";
 
 /**
@@ -369,6 +369,89 @@ export function createTestRelease(
 		eventId: null,
 		eventDayId: null,
 		notes: null,
+		...overrides,
+	};
+}
+
+/**
+ * テスト用ユーザーデータを生成
+ */
+export function createTestUser(
+	overrides?: Partial<{
+		id: string;
+		name: string;
+		email: string;
+		emailVerified: boolean;
+		role: string;
+		banned: boolean;
+		banReason: string | null;
+	}>,
+) {
+	const uniqueId = nanoid(8);
+	return {
+		id: `user_test_${uniqueId}`,
+		name: `Test User ${uniqueId}`,
+		email: `test_${uniqueId}@example.com`,
+		emailVerified: false,
+		role: "user",
+		banned: false,
+		banReason: null,
+		...overrides,
+	};
+}
+
+/**
+ * テスト用管理者ユーザーデータを生成
+ */
+export function createTestAdminUser(
+	overrides?: Partial<{
+		id: string;
+		name: string;
+		email: string;
+		emailVerified: boolean;
+		role: string;
+		banned: boolean;
+		banReason: string | null;
+	}>,
+) {
+	return createTestUser({ role: "admin", ...overrides });
+}
+
+/**
+ * テスト用アルバム申請データを生成
+ */
+export function createTestAlbumRequest(
+	overrides?: Partial<{
+		id: string;
+		userId: string;
+		requestType: string;
+		existingReleaseId: string | null;
+		albumName: string | null;
+		circleName: string | null;
+		referenceUrls: AlbumRequestReferenceUrl[];
+		notes: string | null;
+		status: string;
+		reviewedByUserId: string | null;
+		reviewerNotes: string | null;
+		reviewedAt: Date | null;
+	}>,
+) {
+	const uniqueId = nanoid(8);
+	return {
+		id: `aq_test_${uniqueId}`,
+		userId: `user_test_${uniqueId}`,
+		requestType: "new",
+		existingReleaseId: null,
+		albumName: "テストアルバム",
+		circleName: null,
+		referenceUrls: [
+			{ url: "https://example.com" },
+		] as AlbumRequestReferenceUrl[],
+		notes: null,
+		status: "pending",
+		reviewedByUserId: null,
+		reviewerNotes: null,
+		reviewedAt: null,
 		...overrides,
 	};
 }

--- a/apps/server/test/helpers/test-app.ts
+++ b/apps/server/test/helpers/test-app.ts
@@ -1,6 +1,10 @@
 import { Hono } from "hono";
 import type { AdminContext, User } from "../../src/middleware/admin-auth";
-import { createTestAuthMiddleware } from "./test-auth";
+import type { UserAuthContext } from "../../src/middleware/user-auth";
+import {
+	createTestAuthMiddleware,
+	createTestUserAuthMiddleware,
+} from "./test-auth";
 
 export interface TestAppOptions {
 	/** ユーザー情報を上書き（nullで未認証、undefinedでデフォルト管理者） */
@@ -8,7 +12,7 @@ export interface TestAppOptions {
 }
 
 /**
- * テスト用のHonoアプリを作成
+ * テスト用のHonoアプリを作成（管理者向け）
  * @param router - テスト対象のルーター
  * @param options - テストオプション
  */
@@ -20,6 +24,26 @@ export function createTestAdminApp(
 
 	// テスト用認証ミドルウェアを適用（レート制限はスキップ）
 	app.use("/*", createTestAuthMiddleware(options?.user));
+
+	// ルーターをマウント
+	app.route("/", router);
+
+	return app;
+}
+
+/**
+ * テスト用のHonoアプリを作成（ユーザー認証向け）
+ * @param router - テスト対象のルーター
+ * @param options - テストオプション
+ */
+export function createTestUserApp(
+	router: Hono<UserAuthContext>,
+	options?: TestAppOptions,
+) {
+	const app = new Hono<UserAuthContext>();
+
+	// テスト用ユーザー認証ミドルウェアを適用（レート制限はスキップ）
+	app.use("/*", createTestUserAuthMiddleware(options?.user));
 
 	// ルーターをマウント
 	app.route("/", router);

--- a/apps/server/test/helpers/test-auth.ts
+++ b/apps/server/test/helpers/test-auth.ts
@@ -12,7 +12,17 @@ export const defaultTestAdmin: User = {
 };
 
 /**
- * テスト用の認証モックミドルウェアを作成
+ * テスト用のデフォルト一般ユーザー
+ */
+export const defaultTestUser: User = {
+	id: "test-user-id",
+	name: "Test User",
+	email: "user@test.com",
+	role: "user",
+};
+
+/**
+ * テスト用の認証モックミドルウェアを作成（管理者向け）
  * @param userOverride - ユーザー情報を上書き（nullで未認証）
  */
 export function createTestAuthMiddleware(userOverride?: Partial<User> | null) {
@@ -28,6 +38,27 @@ export function createTestAuthMiddleware(userOverride?: Partial<User> | null) {
 		if (user.role !== "admin") {
 			return c.json({ error: "Forbidden" }, 403);
 		}
+
+		// ユーザー情報をコンテキストに設定
+		c.set("user", user);
+		return next();
+	};
+}
+
+/**
+ * テスト用のユーザー認証モックミドルウェアを作成（ログイン必須エンドポイント向け）
+ * @param userOverride - ユーザー情報を上書き（nullで未認証）
+ */
+export function createTestUserAuthMiddleware(
+	userOverride?: Partial<User> | null,
+) {
+	return async function testUserAuthMiddleware(c: Context, next: Next) {
+		// nullの場合は未認証
+		if (userOverride === null) {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
+
+		const user = { ...defaultTestUser, ...userOverride };
 
 		// ユーザー情報をコンテキストに設定
 		c.set("user", user);

--- a/apps/server/test/helpers/test-db.ts
+++ b/apps/server/test/helpers/test-db.ts
@@ -54,6 +54,8 @@ const schema = {
 	releaseJanCodes: dbExports.releaseJanCodes,
 	// クレジットロール
 	trackCreditRoles: dbExports.trackCreditRoles,
+	// アルバム申請
+	albumRequests: dbExports.albumRequests,
 };
 
 /**

--- a/apps/server/test/integration/admin/album-requests.test.ts
+++ b/apps/server/test/integration/admin/album-requests.test.ts
@@ -71,12 +71,9 @@ interface AlbumRequestDetail extends AlbumRequestItem {
 
 interface AlbumRequestListResponse {
 	data: AlbumRequestItem[];
-	pagination: {
-		page: number;
-		limit: number;
-		total: number;
-		totalPages: number;
-	};
+	total: number;
+	page: number;
+	limit: number;
 }
 
 interface PendingCountResponse {
@@ -152,9 +149,8 @@ describe("Admin Album Requests API", () => {
 			const json = await expectSuccess<AlbumRequestListResponse>(res);
 
 			expect(json.data).toHaveLength(2);
-			expect(json.pagination.total).toBe(2);
-			expect(json.pagination.page).toBe(1);
-			expect(json.pagination.totalPages).toBe(1);
+			expect(json.total).toBe(2);
+			expect(json.page).toBe(1);
 		});
 
 		test("status=pending フィルタ", async () => {
@@ -181,7 +177,7 @@ describe("Admin Album Requests API", () => {
 
 			expect(json.data).toHaveLength(1);
 			expect(json.data[0].id).toBe("aq_pending_001");
-			expect(json.pagination.total).toBe(1);
+			expect(json.total).toBe(1);
 		});
 
 		test("status=approved フィルタ", async () => {
@@ -246,10 +242,9 @@ describe("Admin Album Requests API", () => {
 			const json = await expectSuccess<AlbumRequestListResponse>(res);
 
 			expect(json.data).toHaveLength(2);
-			expect(json.pagination.total).toBe(5);
-			expect(json.pagination.page).toBe(2);
-			expect(json.pagination.limit).toBe(2);
-			expect(json.pagination.totalPages).toBe(3);
+			expect(json.total).toBe(5);
+			expect(json.page).toBe(2);
+			expect(json.limit).toBe(2);
 		});
 	});
 

--- a/apps/server/test/integration/admin/album-requests.test.ts
+++ b/apps/server/test/integration/admin/album-requests.test.ts
@@ -40,7 +40,6 @@ import {
 	expectNotFound,
 	expectSuccess,
 	expectUnauthorized,
-	type PaginatedResponse,
 	patchJson,
 } from "../../helpers/test-response";
 

--- a/apps/server/test/integration/admin/album-requests.test.ts
+++ b/apps/server/test/integration/admin/album-requests.test.ts
@@ -1,0 +1,583 @@
+/**
+ * Admin Album Requests API 統合テスト
+ *
+ * @description
+ * 管理者向けアルバム申請API（GET/PATCH）の認証、フィルタ、ページネーション、
+ * 楽観的ロック、ステータス遷移をテスト
+ */
+
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import type { PGlite } from "@electric-sql/pglite";
+import {
+	__resetDatabase,
+	__setTestDatabase,
+	albumRequests,
+	db,
+	releases,
+	user,
+} from "@thac/db";
+import { albumRequestsAdminRouter } from "../../../src/routes/admin/album-requests/album-requests";
+import {
+	createTestAdminUser,
+	createTestAlbumRequest,
+	createTestRelease,
+	createTestUser,
+} from "../../helpers/fixtures";
+import { createTestAdminApp } from "../../helpers/test-app";
+import { defaultTestAdmin } from "../../helpers/test-auth";
+import { createTestDatabase, truncateAllTables } from "../../helpers/test-db";
+import {
+	expectBadRequest,
+	expectConflict,
+	expectForbidden,
+	expectNotFound,
+	expectSuccess,
+	expectUnauthorized,
+	type PaginatedResponse,
+	patchJson,
+} from "../../helpers/test-response";
+
+// レスポンスの型定義
+interface AlbumRequestItem {
+	id: string;
+	requestType: string;
+	albumName: string | null;
+	circleName: string | null;
+	referenceUrls: Array<{ url: string; label?: string }>;
+	notes: string | null;
+	status: string;
+	reviewerNotes: string | null;
+	reviewedAt: string | null;
+	createdAt: string;
+	updatedAt: string;
+	submittedBy: { id: string; name: string; email: string } | null;
+	existingRelease: {
+		id: string;
+		name: string;
+		nameJa: string | null;
+		nameEn: string | null;
+	} | null;
+}
+
+interface AlbumRequestDetail extends AlbumRequestItem {
+	reviewer: { id: string; name: string; email: string } | null;
+}
+
+interface AlbumRequestListResponse {
+	data: AlbumRequestItem[];
+	pagination: {
+		page: number;
+		limit: number;
+		total: number;
+		totalPages: number;
+	};
+}
+
+interface PendingCountResponse {
+	count: number;
+}
+
+describe("Admin Album Requests API", () => {
+	let client: PGlite;
+	let app: ReturnType<typeof createTestAdminApp>;
+
+	beforeAll(async () => {
+		const testDb = await createTestDatabase();
+		client = testDb.client;
+		__setTestDatabase(testDb.db);
+		app = createTestAdminApp(albumRequestsAdminRouter);
+	});
+
+	beforeEach(async () => {
+		await truncateAllTables(client);
+	});
+
+	afterAll(async () => {
+		__resetDatabase();
+		await client.close();
+	});
+
+	// テストデータ作成ヘルパー
+	async function setupBaseUser() {
+		const testUser = createTestUser({ id: "user_submitter_001" });
+		await db.insert(user).values(testUser);
+		return testUser;
+	}
+
+	async function setupAdminUser() {
+		const adminUser = createTestAdminUser({ id: defaultTestAdmin.id });
+		await db.insert(user).values(adminUser);
+		return adminUser;
+	}
+
+	describe("GET / - アルバム申請一覧取得", () => {
+		test("未認証 → 401を返す", async () => {
+			const unauthApp = createTestAdminApp(albumRequestsAdminRouter, {
+				user: null,
+			});
+			const res = await unauthApp.request("/");
+			await expectUnauthorized(res);
+		});
+
+		test("一般ユーザー → 403を返す", async () => {
+			const nonAdminApp = createTestAdminApp(albumRequestsAdminRouter, {
+				user: { role: "user" },
+			});
+			const res = await nonAdminApp.request("/");
+			await expectForbidden(res);
+		});
+
+		test("管理者: 全件取得（pagination 構造を持つ）", async () => {
+			const submitter = await setupBaseUser();
+			await db.insert(albumRequests).values([
+				createTestAlbumRequest({
+					id: "aq_001",
+					userId: submitter.id,
+					albumName: "アルバム1",
+				}),
+				createTestAlbumRequest({
+					id: "aq_002",
+					userId: submitter.id,
+					albumName: "アルバム2",
+				}),
+			]);
+
+			const res = await app.request("/");
+			const json = await expectSuccess<AlbumRequestListResponse>(res);
+
+			expect(json.data).toHaveLength(2);
+			expect(json.pagination.total).toBe(2);
+			expect(json.pagination.page).toBe(1);
+			expect(json.pagination.totalPages).toBe(1);
+		});
+
+		test("status=pending フィルタ", async () => {
+			const submitter = await setupBaseUser();
+			const adminUser = await setupAdminUser();
+
+			await db.insert(albumRequests).values([
+				createTestAlbumRequest({
+					id: "aq_pending_001",
+					userId: submitter.id,
+					status: "pending",
+				}),
+				createTestAlbumRequest({
+					id: "aq_approved_001",
+					userId: submitter.id,
+					status: "approved",
+					reviewedByUserId: adminUser.id,
+					reviewedAt: new Date(),
+				}),
+			]);
+
+			const res = await app.request("/?status=pending");
+			const json = await expectSuccess<AlbumRequestListResponse>(res);
+
+			expect(json.data).toHaveLength(1);
+			expect(json.data[0].id).toBe("aq_pending_001");
+			expect(json.pagination.total).toBe(1);
+		});
+
+		test("status=approved フィルタ", async () => {
+			const submitter = await setupBaseUser();
+			const adminUser = await setupAdminUser();
+
+			await db.insert(albumRequests).values([
+				createTestAlbumRequest({
+					id: "aq_pending_001",
+					userId: submitter.id,
+					status: "pending",
+				}),
+				createTestAlbumRequest({
+					id: "aq_approved_001",
+					userId: submitter.id,
+					status: "approved",
+					reviewedByUserId: adminUser.id,
+					reviewedAt: new Date(),
+				}),
+			]);
+
+			const res = await app.request("/?status=approved");
+			const json = await expectSuccess<AlbumRequestListResponse>(res);
+
+			expect(json.data).toHaveLength(1);
+			expect(json.data[0].id).toBe("aq_approved_001");
+		});
+
+		test("ページネーション: page=2, limit=2", async () => {
+			const submitter = await setupBaseUser();
+
+			// 5件作成
+			await db.insert(albumRequests).values([
+				createTestAlbumRequest({
+					id: "aq_001",
+					userId: submitter.id,
+					albumName: "アルバム1",
+				}),
+				createTestAlbumRequest({
+					id: "aq_002",
+					userId: submitter.id,
+					albumName: "アルバム2",
+				}),
+				createTestAlbumRequest({
+					id: "aq_003",
+					userId: submitter.id,
+					albumName: "アルバム3",
+				}),
+				createTestAlbumRequest({
+					id: "aq_004",
+					userId: submitter.id,
+					albumName: "アルバム4",
+				}),
+				createTestAlbumRequest({
+					id: "aq_005",
+					userId: submitter.id,
+					albumName: "アルバム5",
+				}),
+			]);
+
+			const res = await app.request("/?page=2&limit=2");
+			const json = await expectSuccess<AlbumRequestListResponse>(res);
+
+			expect(json.data).toHaveLength(2);
+			expect(json.pagination.total).toBe(5);
+			expect(json.pagination.page).toBe(2);
+			expect(json.pagination.limit).toBe(2);
+			expect(json.pagination.totalPages).toBe(3);
+		});
+	});
+
+	describe("GET /pending-count - pending 件数取得", () => {
+		test("未認証 → 401を返す", async () => {
+			const unauthApp = createTestAdminApp(albumRequestsAdminRouter, {
+				user: null,
+			});
+			const res = await unauthApp.request("/pending-count");
+			await expectUnauthorized(res);
+		});
+
+		test("管理者: pending 件数を返す", async () => {
+			const submitter = await setupBaseUser();
+			const adminUser = await setupAdminUser();
+
+			await db.insert(albumRequests).values([
+				createTestAlbumRequest({
+					id: "aq_pending_001",
+					userId: submitter.id,
+					status: "pending",
+				}),
+				createTestAlbumRequest({
+					id: "aq_pending_002",
+					userId: submitter.id,
+					status: "pending",
+				}),
+				createTestAlbumRequest({
+					id: "aq_approved_001",
+					userId: submitter.id,
+					status: "approved",
+					reviewedByUserId: adminUser.id,
+					reviewedAt: new Date(),
+				}),
+			]);
+
+			const res = await app.request("/pending-count");
+			const json = await expectSuccess<PendingCountResponse>(res);
+
+			expect(json.count).toBe(2);
+		});
+
+		test("Cache-Control ヘッダが private, max-age=30 であること", async () => {
+			const res = await app.request("/pending-count");
+			expect(res.status).toBe(200);
+			expect(res.headers.get("Cache-Control")).toBe("private, max-age=30");
+		});
+	});
+
+	describe("GET /:id - アルバム申請詳細取得", () => {
+		test("未認証 → 401を返す", async () => {
+			const unauthApp = createTestAdminApp(albumRequestsAdminRouter, {
+				user: null,
+			});
+			const res = await unauthApp.request("/aq_nonexistent_999");
+			await expectUnauthorized(res);
+		});
+
+		test("存在しない id → 404を返す", async () => {
+			const res = await app.request("/aq_nonexistent_999");
+			await expectNotFound(res);
+		});
+
+		test("管理者: submittedBy / reviewer / existingRelease がネストされた形で返る", async () => {
+			const submitter = await setupBaseUser();
+			const adminUser = await setupAdminUser();
+			const release = createTestRelease({ id: "rel_test_detail_001" });
+			await db.insert(releases).values(release);
+
+			await db.insert(albumRequests).values(
+				createTestAlbumRequest({
+					id: "aq_detail_001",
+					userId: submitter.id,
+					requestType: "existing",
+					existingReleaseId: "rel_test_detail_001",
+					albumName: null,
+					status: "approved",
+					reviewedByUserId: adminUser.id,
+					reviewedAt: new Date(),
+					reviewerNotes: "確認済み",
+				}),
+			);
+
+			const res = await app.request("/aq_detail_001");
+			const json = await expectSuccess<AlbumRequestDetail>(res);
+
+			// submittedBy がネストされている
+			expect(json.submittedBy?.id).toBe(submitter.id);
+			expect(json.submittedBy?.name).toBe(submitter.name);
+
+			// reviewer がネストされている
+			expect(json.reviewer?.id).toBe(adminUser.id);
+
+			// existingRelease がネストされている
+			expect(json.existingRelease?.id).toBe("rel_test_detail_001");
+
+			// reviewerNotes が含まれる
+			expect(json.reviewerNotes).toBe("確認済み");
+		});
+
+		test("管理者: pending 申請の詳細（reviewer.id は null）", async () => {
+			const submitter = await setupBaseUser();
+
+			await db.insert(albumRequests).values(
+				createTestAlbumRequest({
+					id: "aq_pending_detail_001",
+					userId: submitter.id,
+					status: "pending",
+				}),
+			);
+
+			const res = await app.request("/aq_pending_detail_001");
+			const json = await expectSuccess<AlbumRequestDetail>(res);
+
+			// reviewer は leftJoin で null → Drizzle は { id: null, ... } として返す
+			expect(json.reviewer?.id ?? null).toBeNull();
+			expect(json.status).toBe("pending");
+		});
+	});
+
+	describe("PATCH /:id - アルバム申請ステータス更新", () => {
+		test("未認証 → 401を返す", async () => {
+			const unauthApp = createTestAdminApp(albumRequestsAdminRouter, {
+				user: null,
+			});
+			const res = await unauthApp.request(
+				"/aq_nonexistent_999",
+				patchJson({
+					status: "approved",
+					updatedAt: new Date().toISOString(),
+				}),
+			);
+			await expectUnauthorized(res);
+		});
+
+		test("一般ユーザー → 403を返す", async () => {
+			const nonAdminApp = createTestAdminApp(albumRequestsAdminRouter, {
+				user: { role: "user" },
+			});
+			const res = await nonAdminApp.request(
+				"/aq_nonexistent_999",
+				patchJson({
+					status: "approved",
+					updatedAt: new Date().toISOString(),
+				}),
+			);
+			await expectForbidden(res);
+		});
+
+		test("存在しない id → 404を返す", async () => {
+			const res = await app.request(
+				"/aq_nonexistent_999",
+				patchJson({
+					status: "approved",
+					updatedAt: new Date().toISOString(),
+				}),
+			);
+			await expectNotFound(res);
+		});
+
+		test("status=approved + reviewerNotes → 200、DB に reviewedAt/reviewedByUserId/reviewerNotes/status が記録", async () => {
+			const submitter = await setupBaseUser();
+			await setupAdminUser();
+
+			const request = createTestAlbumRequest({
+				id: "aq_to_approve_001",
+				userId: submitter.id,
+				status: "pending",
+			});
+			await db.insert(albumRequests).values(request);
+
+			// 現在のupdatedAtを取得
+			const current = await db.select().from(albumRequests).limit(1);
+			const currentUpdatedAt = current[0].updatedAt;
+
+			const res = await app.request(
+				"/aq_to_approve_001",
+				patchJson({
+					status: "approved",
+					reviewerNotes: "内容確認しました",
+					updatedAt: currentUpdatedAt.toISOString(),
+				}),
+			);
+
+			expect(res.status).toBe(200);
+			const json = (await res.json()) as {
+				status: string;
+				reviewerNotes: string | null;
+				reviewedAt: string | null;
+				reviewedByUserId: string | null;
+			};
+
+			expect(json.status).toBe("approved");
+			expect(json.reviewerNotes).toBe("内容確認しました");
+			expect(json.reviewedAt).not.toBeNull();
+			expect(json.reviewedByUserId).toBe(defaultTestAdmin.id);
+		});
+
+		test("status=rejected → 200", async () => {
+			const submitter = await setupBaseUser();
+			await setupAdminUser();
+
+			const request = createTestAlbumRequest({
+				id: "aq_to_reject_001",
+				userId: submitter.id,
+				status: "pending",
+			});
+			await db.insert(albumRequests).values(request);
+
+			const current = await db.select().from(albumRequests).limit(1);
+			const currentUpdatedAt = current[0].updatedAt;
+
+			const res = await app.request(
+				"/aq_to_reject_001",
+				patchJson({
+					status: "rejected",
+					reviewerNotes: "情報が不足しています",
+					updatedAt: currentUpdatedAt.toISOString(),
+				}),
+			);
+
+			expect(res.status).toBe(200);
+			const json = (await res.json()) as { status: string };
+			expect(json.status).toBe("rejected");
+		});
+
+		test("不正な status 値（pending など）→ 400", async () => {
+			const submitter = await setupBaseUser();
+
+			const request = createTestAlbumRequest({
+				id: "aq_invalid_status_001",
+				userId: submitter.id,
+				status: "pending",
+			});
+			await db.insert(albumRequests).values(request);
+
+			const current = await db.select().from(albumRequests).limit(1);
+			const currentUpdatedAt = current[0].updatedAt;
+
+			const res = await app.request(
+				"/aq_invalid_status_001",
+				patchJson({
+					status: "pending",
+					updatedAt: currentUpdatedAt.toISOString(),
+				}),
+			);
+
+			await expectBadRequest(res);
+		});
+
+		test("楽観的ロック競合: updatedAt を古い値で送る → 409", async () => {
+			const submitter = await setupBaseUser();
+
+			const request = createTestAlbumRequest({
+				id: "aq_conflict_001",
+				userId: submitter.id,
+				status: "pending",
+			});
+			await db.insert(albumRequests).values(request);
+
+			// 古い updatedAt を使って競合を発生させる
+			const oldUpdatedAt = new Date(Date.now() - 60_000).toISOString();
+
+			const res = await app.request(
+				"/aq_conflict_001",
+				patchJson({
+					status: "approved",
+					updatedAt: oldUpdatedAt,
+				}),
+			);
+
+			await expectConflict(res);
+		});
+
+		test("既に approved のレコードを再度更新 → 400（既に処理済みです）", async () => {
+			const submitter = await setupBaseUser();
+			const adminUser = await setupAdminUser();
+
+			const request = createTestAlbumRequest({
+				id: "aq_already_approved_001",
+				userId: submitter.id,
+				status: "approved",
+				reviewedByUserId: adminUser.id,
+				reviewedAt: new Date(),
+			});
+			await db.insert(albumRequests).values(request);
+
+			const current = await db.select().from(albumRequests).limit(1);
+			const currentUpdatedAt = current[0].updatedAt;
+
+			const res = await app.request(
+				"/aq_already_approved_001",
+				patchJson({
+					status: "rejected",
+					updatedAt: currentUpdatedAt.toISOString(),
+				}),
+			);
+
+			const json = await expectBadRequest(res);
+			expect(json.error).toContain("処理済み");
+		});
+
+		test("既に rejected のレコードを再度更新 → 400", async () => {
+			const submitter = await setupBaseUser();
+			const adminUser = await setupAdminUser();
+
+			const request = createTestAlbumRequest({
+				id: "aq_already_rejected_001",
+				userId: submitter.id,
+				status: "rejected",
+				reviewedByUserId: adminUser.id,
+				reviewedAt: new Date(),
+			});
+			await db.insert(albumRequests).values(request);
+
+			const current = await db.select().from(albumRequests).limit(1);
+			const currentUpdatedAt = current[0].updatedAt;
+
+			const res = await app.request(
+				"/aq_already_rejected_001",
+				patchJson({
+					status: "approved",
+					updatedAt: currentUpdatedAt.toISOString(),
+				}),
+			);
+
+			await expectBadRequest(res);
+		});
+	});
+});

--- a/apps/server/test/integration/user/album-requests.test.ts
+++ b/apps/server/test/integration/user/album-requests.test.ts
@@ -1,0 +1,399 @@
+/**
+ * User Album Requests API 統合テスト
+ *
+ * @description
+ * ユーザー向けアルバム申請API（POST /api/user/album-requests, GET /api/user/album-requests）の
+ * 認証、バリデーション、DB永続化をテスト
+ */
+
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import type { PGlite } from "@electric-sql/pglite";
+import {
+	__resetDatabase,
+	__setTestDatabase,
+	albumRequests,
+	db,
+	releases,
+	user,
+} from "@thac/db";
+import { albumRequestsUserRouter } from "../../../src/routes/user/album-requests";
+import {
+	createTestAlbumRequest,
+	createTestRelease,
+	createTestUser,
+} from "../../helpers/fixtures";
+import { createTestUserApp } from "../../helpers/test-app";
+import { defaultTestUser } from "../../helpers/test-auth";
+import { createTestDatabase, truncateAllTables } from "../../helpers/test-db";
+import {
+	expectBadRequest,
+	expectCreated,
+	expectSuccess,
+	expectUnauthorized,
+	postJson,
+} from "../../helpers/test-response";
+
+// レスポンスの型定義
+interface AlbumRequestResponse {
+	id: string;
+	requestType: string;
+	albumName: string | null;
+	circleName: string | null;
+	referenceUrls: Array<{ url: string; label?: string }>;
+	notes: string | null;
+	status: string;
+	reviewerNotes: string | null;
+	reviewedAt: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+interface AlbumRequestListResponse {
+	items: AlbumRequestResponse[];
+}
+
+describe("User Album Requests API", () => {
+	let client: PGlite;
+	let app: ReturnType<typeof createTestUserApp>;
+
+	beforeAll(async () => {
+		const testDb = await createTestDatabase();
+		client = testDb.client;
+		__setTestDatabase(testDb.db);
+		app = createTestUserApp(albumRequestsUserRouter);
+	});
+
+	beforeEach(async () => {
+		await truncateAllTables(client);
+	});
+
+	afterAll(async () => {
+		__resetDatabase();
+		await client.close();
+	});
+
+	describe("POST / - アルバム申請作成", () => {
+		test("未ログイン → 401を返す", async () => {
+			const unauthApp = createTestUserApp(albumRequestsUserRouter, {
+				user: null,
+			});
+			const res = await unauthApp.request(
+				"/",
+				postJson({
+					requestType: "new",
+					albumName: "テストアルバム",
+					referenceUrls: [{ url: "https://example.com" }],
+				}),
+			);
+			await expectUnauthorized(res);
+		});
+
+		test("新規リクエスト → 201 + DBにstatus=pendingで1行INSERT", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			const res = await app.request(
+				"/",
+				postJson({
+					requestType: "new",
+					albumName: "新規テストアルバム",
+					circleName: "テストサークル",
+					referenceUrls: [
+						{ url: "https://example.com/album", label: "公式サイト" },
+					],
+					notes: "テスト補足",
+				}),
+			);
+
+			const json = await expectCreated<AlbumRequestResponse>(res);
+			expect(json.requestType).toBe("new");
+			expect(json.albumName).toBe("新規テストアルバム");
+			expect(json.status).toBe("pending");
+
+			// DBに1行あることを確認
+			const rows = await db.select().from(albumRequests);
+			expect(rows).toHaveLength(1);
+			expect(rows[0].status).toBe("pending");
+			expect(rows[0].userId).toBe(defaultTestUser.id);
+		});
+
+		test("既存アルバムへの追記リクエスト → 201", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+			const release = createTestRelease({ id: "rel_test_existing_001" });
+			await db.insert(releases).values(release);
+
+			const res = await app.request(
+				"/",
+				postJson({
+					requestType: "existing",
+					existingReleaseId: "rel_test_existing_001",
+					referenceUrls: [{ url: "https://example.com" }],
+				}),
+			);
+
+			const json = await expectCreated<AlbumRequestResponse>(res);
+			expect(json.requestType).toBe("existing");
+			expect(json.status).toBe("pending");
+		});
+
+		test("existing なのに existingReleaseId 未指定 → 400", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			const res = await app.request(
+				"/",
+				postJson({
+					requestType: "existing",
+					referenceUrls: [{ url: "https://example.com" }],
+				}),
+			);
+
+			await expectBadRequest(res);
+		});
+
+		test("existing なのに existingReleaseId が DB に存在しない → 400", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			const res = await app.request(
+				"/",
+				postJson({
+					requestType: "existing",
+					existingReleaseId: "rel_nonexistent_999",
+					referenceUrls: [{ url: "https://example.com" }],
+				}),
+			);
+
+			const json = await expectBadRequest(res);
+			expect(json.error).toContain("見つかりません");
+		});
+
+		test("referenceUrls 空配列 → 400", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			const res = await app.request(
+				"/",
+				postJson({
+					requestType: "new",
+					albumName: "テストアルバム",
+					referenceUrls: [],
+				}),
+			);
+
+			await expectBadRequest(res);
+		});
+
+		test("referenceUrls の URL が mailto: スキーム → 400", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			const res = await app.request(
+				"/",
+				postJson({
+					requestType: "new",
+					albumName: "テストアルバム",
+					referenceUrls: [{ url: "mailto:test@example.com" }],
+				}),
+			);
+
+			await expectBadRequest(res);
+		});
+
+		test("referenceUrls の URL が ftp:// スキーム → 400", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			const res = await app.request(
+				"/",
+				postJson({
+					requestType: "new",
+					albumName: "テストアルバム",
+					referenceUrls: [{ url: "ftp://example.com/file" }],
+				}),
+			);
+
+			await expectBadRequest(res);
+		});
+
+		test("referenceUrls が11件 → 400", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			const urls = Array.from({ length: 11 }, (_, i) => ({
+				url: `https://example.com/${i + 1}`,
+			}));
+
+			const res = await app.request(
+				"/",
+				postJson({
+					requestType: "new",
+					albumName: "テストアルバム",
+					referenceUrls: urls,
+				}),
+			);
+
+			await expectBadRequest(res);
+		});
+
+		test("new なのに albumName 未指定 → 400", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			const res = await app.request(
+				"/",
+				postJson({
+					requestType: "new",
+					referenceUrls: [{ url: "https://example.com" }],
+				}),
+			);
+
+			await expectBadRequest(res);
+		});
+
+		test("albumName が 201 文字 → 400", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			const longName = "あ".repeat(201);
+
+			const res = await app.request(
+				"/",
+				postJson({
+					requestType: "new",
+					albumName: longName,
+					referenceUrls: [{ url: "https://example.com" }],
+				}),
+			);
+
+			await expectBadRequest(res);
+		});
+	});
+
+	describe("GET / - 自分のアルバム申請一覧取得", () => {
+		test("未ログイン → 401を返す", async () => {
+			const unauthApp = createTestUserApp(albumRequestsUserRouter, {
+				user: null,
+			});
+			const res = await unauthApp.request("/");
+			await expectUnauthorized(res);
+		});
+
+		test("ログイン済み → 自分の申請のみ返却（他ユーザーの申請が混ざらない）", async () => {
+			// 自分のユーザーを作成
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			// 他のユーザーを作成
+			const otherUser = createTestUser({ id: "user_other_001" });
+			await db.insert(user).values(otherUser);
+
+			// 自分の申請を2件作成
+			await db.insert(albumRequests).values(
+				createTestAlbumRequest({
+					id: "aq_mine_001",
+					userId: defaultTestUser.id,
+					albumName: "自分のアルバム1",
+				}),
+			);
+			await db.insert(albumRequests).values(
+				createTestAlbumRequest({
+					id: "aq_mine_002",
+					userId: defaultTestUser.id,
+					albumName: "自分のアルバム2",
+				}),
+			);
+
+			// 他のユーザーの申請を1件作成
+			await db.insert(albumRequests).values(
+				createTestAlbumRequest({
+					id: "aq_other_001",
+					userId: otherUser.id,
+					albumName: "他ユーザーのアルバム",
+				}),
+			);
+
+			const res = await app.request("/");
+			const json = await expectSuccess<AlbumRequestListResponse>(res);
+
+			// 自分の2件のみが返る（他ユーザーのものは含まれない）
+			expect(json.items).toHaveLength(2);
+			const ids = json.items.map((item) => item.id);
+			expect(ids).toContain("aq_mine_001");
+			expect(ids).toContain("aq_mine_002");
+			expect(ids).not.toContain("aq_other_001");
+		});
+
+		test("新着順（createdAt desc）で並ぶ", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+
+			// 古い方を先に作成
+			await db.insert(albumRequests).values(
+				createTestAlbumRequest({
+					id: "aq_old_001",
+					userId: defaultTestUser.id,
+					albumName: "古いアルバム",
+				}),
+			);
+			// 少し待って新しい方を作成（createdAt が異なることを保証）
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await db.insert(albumRequests).values(
+				createTestAlbumRequest({
+					id: "aq_new_001",
+					userId: defaultTestUser.id,
+					albumName: "新しいアルバム",
+				}),
+			);
+
+			const res = await app.request("/");
+			const json = await expectSuccess<AlbumRequestListResponse>(res);
+
+			expect(json.items).toHaveLength(2);
+			// 新着順なので新しい方が先
+			expect(json.items[0].id).toBe("aq_new_001");
+			expect(json.items[1].id).toBe("aq_old_001");
+		});
+
+		test("existingRelease が JOIN された形で返る（existingReleaseId がある場合）", async () => {
+			await db.insert(user).values(createTestUser({ id: defaultTestUser.id }));
+			const release = createTestRelease({ id: "rel_test_join_001" });
+			await db.insert(releases).values(release);
+
+			// existing タイプの申請を作成
+			await db.insert(albumRequests).values(
+				createTestAlbumRequest({
+					id: "aq_existing_001",
+					userId: defaultTestUser.id,
+					requestType: "existing",
+					existingReleaseId: "rel_test_join_001",
+					albumName: null,
+				}),
+			);
+
+			// new タイプ（existingRelease が null になる）
+			await db.insert(albumRequests).values(
+				createTestAlbumRequest({
+					id: "aq_new_001",
+					userId: defaultTestUser.id,
+					requestType: "new",
+					albumName: "新規アルバム",
+				}),
+			);
+
+			const res = await app.request("/");
+			const json = await expectSuccess<{
+				items: Array<
+					AlbumRequestResponse & {
+						existingRelease: { id: string; name: string } | null;
+					}
+				>;
+			}>(res);
+
+			// existing タイプの申請の existingRelease が JOIN されている
+			const existingItem = json.items.find((i) => i.id === "aq_existing_001");
+			expect(existingItem?.existingRelease).not.toBeNull();
+			expect(existingItem?.existingRelease?.id).toBe("rel_test_join_001");
+
+			// new タイプの申請の existingRelease は null
+			const newItem = json.items.find((i) => i.id === "aq_new_001");
+			expect(newItem?.existingRelease).toBeNull();
+		});
+	});
+});

--- a/apps/web/src/components/admin-sidebar.tsx
+++ b/apps/web/src/components/admin-sidebar.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { Link, useLocation } from "@tanstack/react-router";
 import {
 	Calendar,
@@ -6,6 +7,7 @@ import {
 	FolderOpen,
 	Hash,
 	Import,
+	InboxIcon,
 	Layers,
 	LayoutDashboard,
 	MonitorSmartphone,
@@ -19,6 +21,7 @@ import {
 	Users,
 	UsersRound,
 } from "lucide-react";
+import { albumRequestPendingCountQueryOptions } from "@/lib/query-options";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
@@ -143,6 +146,17 @@ const navItems: NavEntry[] = [
 		],
 	},
 	{
+		label: "申請管理",
+		icon: InboxIcon,
+		items: [
+			{
+				to: "/admin/album-requests",
+				label: "アルバム申請",
+				icon: InboxIcon,
+			},
+		],
+	},
+	{
 		label: "インポート",
 		icon: Import,
 		items: [
@@ -172,6 +186,11 @@ interface AdminSidebarProps {
 
 export function AdminSidebar({ onNavigate }: AdminSidebarProps) {
 	const location = useLocation();
+
+	const { data: pendingCountData } = useQuery(
+		albumRequestPendingCountQueryOptions,
+	);
+	const pendingCount = pendingCountData?.count ?? 0;
 
 	const activeItemClasses =
 		"border-l-3 border-primary bg-primary text-primary-content font-medium";
@@ -223,7 +242,13 @@ export function AdminSidebar({ onNavigate }: AdminSidebarProps) {
 													)}
 												>
 													<Icon className="h-4 w-4" />
-													{label}
+													<span className="flex-1">{label}</span>
+													{to === "/admin/album-requests" &&
+														pendingCount > 0 && (
+															<span className="badge badge-error badge-sm">
+																{pendingCount}
+															</span>
+														)}
 												</Link>
 											</li>
 										))}

--- a/apps/web/src/components/admin/album-request-status-badge.tsx
+++ b/apps/web/src/components/admin/album-request-status-badge.tsx
@@ -1,0 +1,22 @@
+import type { AlbumRequestStatus } from "@/lib/api-client";
+import { ALBUM_REQUEST_STATUS_LABELS } from "@/lib/api-client";
+
+interface AlbumRequestStatusBadgeProps {
+	status: AlbumRequestStatus;
+}
+
+const STATUS_BADGE_CLASSES: Record<AlbumRequestStatus, string> = {
+	pending: "badge badge-warning",
+	approved: "badge badge-success",
+	rejected: "badge badge-error",
+};
+
+export function AlbumRequestStatusBadge({
+	status,
+}: AlbumRequestStatusBadgeProps) {
+	return (
+		<span className={STATUS_BADGE_CLASSES[status]}>
+			{ALBUM_REQUEST_STATUS_LABELS[status]}
+		</span>
+	);
+}

--- a/apps/web/src/components/album-request-form.tsx
+++ b/apps/web/src/components/album-request-form.tsx
@@ -1,0 +1,354 @@
+import { useForm } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { z } from "zod";
+import { ReferenceUrlListInput } from "@/components/album-request/reference-url-list-input";
+import { SearchableSelect } from "@/components/ui/searchable-select";
+import { useDebounce } from "@/hooks/use-debounce";
+import { releasesApi } from "@/lib/api-client";
+import { Button } from "./ui/button";
+import { Label } from "./ui/label";
+
+// バリデーションヘルパー
+const httpUrlSchema = z
+	.string()
+	.trim()
+	.url("有効なURLを入力してください")
+	.regex(/^https?:\/\//i, "URLはhttp(s)://から始めてください")
+	.max(2048, "URLは2048文字以内で入力してください");
+
+function validateReferenceUrls(
+	urls: { url: string; label?: string }[],
+): string | null {
+	const filled = urls.filter((r) => r.url.trim());
+	if (filled.length === 0) return "参考URLを1件以上入力してください";
+	if (filled.length > 10) return "参考URLは最大10件までです";
+	for (const item of filled) {
+		const result = httpUrlSchema.safeParse(item.url);
+		if (!result.success) return result.error.issues[0]?.message ?? "無効なURL";
+		if (item.label && item.label.length > 100) {
+			return "ラベルは100文字以内で入力してください";
+		}
+	}
+	return null;
+}
+
+type RequestType = "new" | "existing";
+
+interface ReferenceUrl {
+	url: string;
+	label?: string;
+}
+
+interface AlbumRequestPayload {
+	requestType: RequestType;
+	existingReleaseId?: string;
+	albumName?: string;
+	circleName?: string;
+	referenceUrls: ReferenceUrl[];
+	notes?: string;
+}
+
+interface AlbumRequestFormProps {
+	onSubmit: (payload: AlbumRequestPayload) => Promise<void>;
+	isSubmitting?: boolean;
+}
+
+export function AlbumRequestForm({
+	onSubmit,
+	isSubmitting = false,
+}: AlbumRequestFormProps) {
+	const [releaseSearch, setReleaseSearch] = useState("");
+	const debouncedSearch = useDebounce(releaseSearch, 300);
+
+	const { data: releasesData } = useQuery({
+		queryKey: ["releases-search", debouncedSearch],
+		queryFn: () => releasesApi.list({ search: debouncedSearch, limit: 20 }),
+		enabled: debouncedSearch.length >= 2,
+		staleTime: 30_000,
+	});
+
+	const releaseOptions = (releasesData?.data ?? []).map((r) => ({
+		value: r.id,
+		label: r.nameJa || r.name,
+	}));
+
+	const form = useForm({
+		defaultValues: {
+			requestType: "new" as RequestType,
+			existingReleaseId: "",
+			albumName: "",
+			circleName: "",
+			referenceUrls: [{ url: "", label: "" }] as ReferenceUrl[],
+			notes: "",
+		},
+		onSubmit: async ({ value }) => {
+			const filteredUrls = value.referenceUrls.filter((r) => r.url.trim());
+
+			if (value.requestType === "existing") {
+				await onSubmit({
+					requestType: "existing",
+					existingReleaseId: value.existingReleaseId || undefined,
+					albumName: value.albumName || undefined,
+					circleName: value.circleName || undefined,
+					referenceUrls: filteredUrls,
+					notes: value.notes || undefined,
+				});
+			} else {
+				await onSubmit({
+					requestType: "new",
+					albumName: value.albumName || undefined,
+					circleName: value.circleName || undefined,
+					referenceUrls: filteredUrls,
+					notes: value.notes || undefined,
+				});
+			}
+		},
+	});
+
+	return (
+		<form
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+			className="space-y-6"
+		>
+			{/* リクエスト種別 */}
+			<form.Field name="requestType">
+				{(field) => (
+					<div className="space-y-2">
+						<Label>リクエスト種別 *</Label>
+						<div className="flex gap-4">
+							<label className="flex cursor-pointer items-center gap-2">
+								<input
+									type="radio"
+									className="radio"
+									name={field.name}
+									value="new"
+									checked={field.state.value === "new"}
+									onChange={() => field.handleChange("new")}
+								/>
+								<span>新規アルバム</span>
+							</label>
+							<label className="flex cursor-pointer items-center gap-2">
+								<input
+									type="radio"
+									className="radio"
+									name={field.name}
+									value="existing"
+									checked={field.state.value === "existing"}
+									onChange={() => field.handleChange("existing")}
+								/>
+								<span>既存アルバムへの追記</span>
+							</label>
+						</div>
+					</div>
+				)}
+			</form.Field>
+
+			{/* 既存アルバム選択 (requestType === "existing" のときのみ) */}
+			<form.Subscribe selector={(state) => state.values.requestType}>
+				{(requestType) =>
+					requestType === "existing" && (
+						<form.Field
+							name="existingReleaseId"
+							validators={{
+								onChange: ({ value }) =>
+									!value ? "既存アルバムを選択してください" : undefined,
+							}}
+						>
+							{(field) => (
+								<div className="space-y-2">
+									<Label htmlFor={field.name}>既存アルバム *</Label>
+									<SearchableSelect
+										id={field.name}
+										value={field.state.value}
+										onChange={(value) => field.handleChange(value)}
+										options={releaseOptions}
+										placeholder="アルバムを検索して選択"
+										searchPlaceholder="2文字以上入力して検索..."
+										emptyMessage={
+											debouncedSearch.length < 2
+												? "2文字以上入力して検索"
+												: "該当なし"
+										}
+										onSearchChange={setReleaseSearch}
+									/>
+									<p className="text-base-content/50 text-xs">
+										2文字以上入力すると既存アルバムを検索できます
+									</p>
+									{field.state.meta.errors.map((error) => (
+										<p key={String(error)} className="text-error text-sm">
+											{String(error)}
+										</p>
+									))}
+								</div>
+							)}
+						</form.Field>
+					)
+				}
+			</form.Subscribe>
+
+			{/* アルバム名 */}
+			<form.Subscribe selector={(state) => state.values.requestType}>
+				{(requestType) => (
+					<form.Field
+						name="albumName"
+						validators={{
+							onChange: ({ value }) => {
+								if (requestType === "new" && !value.trim()) {
+									return "アルバム名は必須です";
+								}
+								if (value.length > 200) {
+									return "アルバム名は200文字以内で入力してください";
+								}
+								return undefined;
+							},
+						}}
+					>
+						{(field) => (
+							<div className="space-y-2">
+								<Label htmlFor={field.name}>
+									アルバム名
+									{requestType === "new" ? " *" : " (任意)"}
+								</Label>
+								<input
+									id={field.name}
+									name={field.name}
+									type="text"
+									value={field.state.value}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+									placeholder="アルバム名を入力"
+									className="input w-full"
+									autoComplete="off"
+									data-1p-ignore
+									data-lpignore="true"
+									data-form-type="other"
+								/>
+								{field.state.meta.errors.map((error) => (
+									<p key={String(error)} className="text-error text-sm">
+										{String(error)}
+									</p>
+								))}
+							</div>
+						)}
+					</form.Field>
+				)}
+			</form.Subscribe>
+
+			{/* サークル名 */}
+			<form.Field
+				name="circleName"
+				validators={{
+					onChange: ({ value }) =>
+						value.length > 200
+							? "サークル名は200文字以内で入力してください"
+							: undefined,
+				}}
+			>
+				{(field) => (
+					<div className="space-y-2">
+						<Label htmlFor={field.name}>サークル名 (任意)</Label>
+						<input
+							id={field.name}
+							name={field.name}
+							type="text"
+							value={field.state.value}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="サークル名を入力"
+							className="input w-full"
+							autoComplete="off"
+							data-1p-ignore
+							data-lpignore="true"
+							data-form-type="other"
+						/>
+						{field.state.meta.errors.map((error) => (
+							<p key={String(error)} className="text-error text-sm">
+								{String(error)}
+							</p>
+						))}
+					</div>
+				)}
+			</form.Field>
+
+			{/* 参考URL */}
+			<form.Field
+				name="referenceUrls"
+				validators={{
+					onChange: ({ value }) => validateReferenceUrls(value) ?? undefined,
+				}}
+			>
+				{(field) => (
+					<div className="space-y-2">
+						<Label>参考URL *</Label>
+						<p className="text-base-content/60 text-sm">
+							アルバムに関する参考URLを1件以上入力してください（http / https
+							のみ、最大10件）
+						</p>
+						<ReferenceUrlListInput
+							value={field.state.value}
+							onChange={(value) => field.handleChange(value)}
+							error={
+								field.state.meta.errors.length > 0
+									? String(field.state.meta.errors[0])
+									: undefined
+							}
+						/>
+					</div>
+				)}
+			</form.Field>
+
+			{/* 補足 */}
+			<form.Field
+				name="notes"
+				validators={{
+					onChange: ({ value }) =>
+						value.length > 2000
+							? "補足は2000文字以内で入力してください"
+							: undefined,
+				}}
+			>
+				{(field) => (
+					<div className="space-y-2">
+						<Label htmlFor={field.name}>補足 (任意)</Label>
+						<textarea
+							id={field.name}
+							name={field.name}
+							value={field.state.value}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="管理者へ伝えたいことがあれば記入してください"
+							rows={4}
+							className="textarea w-full"
+							autoComplete="off"
+							data-1p-ignore
+							data-lpignore="true"
+							data-form-type="other"
+						/>
+						{field.state.meta.errors.map((error) => (
+							<p key={String(error)} className="text-error text-sm">
+								{String(error)}
+							</p>
+						))}
+					</div>
+				)}
+			</form.Field>
+
+			<form.Subscribe>
+				{(state) => (
+					<Button
+						type="submit"
+						className="w-full"
+						disabled={!state.canSubmit || state.isSubmitting || isSubmitting}
+					>
+						{state.isSubmitting || isSubmitting ? "送信中..." : "送信する"}
+					</Button>
+				)}
+			</form.Subscribe>
+		</form>
+	);
+}

--- a/apps/web/src/components/album-request-form.tsx
+++ b/apps/web/src/components/album-request-form.tsx
@@ -1,7 +1,7 @@
 import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
+import { referenceUrlsSchema } from "@thac/db/schema/album-request.validation";
 import { useState } from "react";
-import { z } from "zod";
 import { ReferenceUrlListInput } from "@/components/album-request/reference-url-list-input";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import { useDebounce } from "@/hooks/use-debounce";
@@ -9,26 +9,13 @@ import { releasesApi } from "@/lib/api-client";
 import { Button } from "./ui/button";
 import { Label } from "./ui/label";
 
-// バリデーションヘルパー
-const httpUrlSchema = z
-	.string()
-	.trim()
-	.url("有効なURLを入力してください")
-	.regex(/^https?:\/\//i, "URLはhttp(s)://から始めてください")
-	.max(2048, "URLは2048文字以内で入力してください");
-
 function validateReferenceUrls(
 	urls: { url: string; label?: string }[],
 ): string | null {
 	const filled = urls.filter((r) => r.url.trim());
-	if (filled.length === 0) return "参考URLを1件以上入力してください";
-	if (filled.length > 10) return "参考URLは最大10件までです";
-	for (const item of filled) {
-		const result = httpUrlSchema.safeParse(item.url);
-		if (!result.success) return result.error.issues[0]?.message ?? "無効なURL";
-		if (item.label && item.label.length > 100) {
-			return "ラベルは100文字以内で入力してください";
-		}
+	const result = referenceUrlsSchema.safeParse(filled);
+	if (!result.success) {
+		return result.error.issues[0]?.message ?? "無効なURL";
 	}
 	return null;
 }

--- a/apps/web/src/components/album-request/reference-url-list-input.tsx
+++ b/apps/web/src/components/album-request/reference-url-list-input.tsx
@@ -1,0 +1,105 @@
+import { Plus, X } from "lucide-react";
+
+const MAX_URLS = 10;
+
+interface ReferenceUrl {
+	url: string;
+	label?: string;
+}
+
+interface ReferenceUrlListInputProps {
+	value: ReferenceUrl[];
+	onChange: (value: ReferenceUrl[]) => void;
+	error?: string;
+}
+
+export function ReferenceUrlListInput({
+	value,
+	onChange,
+	error,
+}: ReferenceUrlListInputProps) {
+	const items = value.length === 0 ? [{ url: "", label: "" }] : value;
+
+	const handleUrlChange = (index: number, url: string) => {
+		const updated = items.map((item, i) =>
+			i === index ? { ...item, url } : item,
+		);
+		onChange(updated);
+	};
+
+	const handleLabelChange = (index: number, label: string) => {
+		const updated = items.map((item, i) =>
+			i === index ? { ...item, label } : item,
+		);
+		onChange(updated);
+	};
+
+	const handleAdd = () => {
+		if (items.length >= MAX_URLS) return;
+		onChange([...items, { url: "", label: "" }]);
+	};
+
+	const handleRemove = (index: number) => {
+		if (items.length <= 1) return;
+		onChange(items.filter((_, i) => i !== index));
+	};
+
+	return (
+		<div className="space-y-2">
+			{items.map((item, index) => (
+				// biome-ignore lint/suspicious/noArrayIndexKey: index is stable for this input list
+				<div key={index} className="flex gap-2">
+					<div className="flex-1 space-y-1">
+						<input
+							type="url"
+							value={item.url}
+							onChange={(e) => handleUrlChange(index, e.target.value)}
+							placeholder="https://example.com/album"
+							className="input w-full"
+							autoComplete="off"
+							data-1p-ignore
+							data-lpignore="true"
+							data-form-type="other"
+						/>
+						<input
+							type="text"
+							value={item.label ?? ""}
+							onChange={(e) => handleLabelChange(index, e.target.value)}
+							placeholder="ラベル（公式サイト / Bandcamp 等、任意）"
+							className="input input-sm w-full"
+							autoComplete="off"
+							data-1p-ignore
+							data-lpignore="true"
+							data-form-type="other"
+						/>
+					</div>
+					<button
+						type="button"
+						onClick={() => handleRemove(index)}
+						disabled={items.length <= 1}
+						className="btn btn-ghost btn-sm btn-square self-start"
+						aria-label="この参考URLを削除"
+					>
+						<X className="h-4 w-4" />
+					</button>
+				</div>
+			))}
+
+			{error && <p className="text-error text-sm">{error}</p>}
+
+			{items.length < MAX_URLS && (
+				<button
+					type="button"
+					onClick={handleAdd}
+					className="btn btn-ghost btn-sm gap-1"
+				>
+					<Plus className="h-4 w-4" />
+					参考URLを追加
+				</button>
+			)}
+			<p className="text-base-content/50 text-xs">
+				{items.length} / {MAX_URLS} 件
+			</p>
+		</div>
+	);
+}

--- a/apps/web/src/components/ui/searchable-select.tsx
+++ b/apps/web/src/components/ui/searchable-select.tsx
@@ -18,6 +18,8 @@ interface SearchableSelectProps {
 	clearable?: boolean;
 	disabled?: boolean;
 	className?: string;
+	/** 外部から検索変更を受け取りたい場合に指定（APIドリブン検索用） */
+	onSearchChange?: (search: string) => void;
 }
 
 export function SearchableSelect({
@@ -31,6 +33,7 @@ export function SearchableSelect({
 	clearable = true,
 	disabled = false,
 	className,
+	onSearchChange,
 }: SearchableSelectProps) {
 	const generatedId = useId();
 	const componentId = id || generatedId;
@@ -80,6 +83,7 @@ export function SearchableSelect({
 		onChange(optionValue);
 		setIsOpen(false);
 		setSearch("");
+		onSearchChange?.("");
 	};
 
 	const handleClear = (e: React.MouseEvent) => {
@@ -87,6 +91,7 @@ export function SearchableSelect({
 		onChange("");
 		setIsOpen(false);
 		setSearch("");
+		onSearchChange?.("");
 	};
 
 	return (
@@ -136,7 +141,10 @@ export function SearchableSelect({
 								id={id ? `${id}-search` : undefined}
 								name={id ? `${id}-search` : undefined}
 								value={search}
-								onChange={(e) => setSearch(e.target.value)}
+								onChange={(e) => {
+									setSearch(e.target.value);
+									onSearchChange?.(e.target.value);
+								}}
 								placeholder={searchPlaceholder}
 								className="input input-sm w-full pl-9"
 							/>

--- a/apps/web/src/components/user-menu.tsx
+++ b/apps/web/src/components/user-menu.tsx
@@ -60,6 +60,9 @@ export default function UserMenu() {
 				<li>
 					<Link to="/user/settings">設定</Link>
 				</li>
+				<li>
+					<Link to="/user/album-requests">アルバム情報の提供</Link>
+				</li>
 				<div className="divider my-0" />
 				<li>
 					<button type="button" onClick={handleSignOut} className="text-error">

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -3066,3 +3066,118 @@ export const trackTagsApi = {
 			},
 		),
 };
+
+// ===== アルバム申請 =====
+
+export type AlbumRequestStatus = "pending" | "approved" | "rejected";
+export type AlbumRequestType = "new" | "existing";
+
+export interface AlbumRequestReferenceUrl {
+	url: string;
+	label?: string;
+}
+
+export interface AlbumRequestUser {
+	id: string | null;
+	name: string | null;
+	email: string | null;
+}
+
+export interface AlbumRequestExistingRelease {
+	id: string | null;
+	name: string | null;
+	nameJa: string | null;
+	nameEn: string | null;
+}
+
+export interface AlbumRequestListItem {
+	id: string;
+	requestType: string;
+	albumName: string | null;
+	circleName: string | null;
+	referenceUrls: AlbumRequestReferenceUrl[];
+	notes: string | null;
+	status: string;
+	reviewerNotes: string | null;
+	reviewedAt: string | null;
+	createdAt: string;
+	updatedAt: string;
+	submittedBy: AlbumRequestUser;
+	existingRelease: AlbumRequestExistingRelease;
+}
+
+export interface AlbumRequestExistingReleaseDetail
+	extends AlbumRequestExistingRelease {
+	releaseDate: string | null;
+}
+
+export interface AlbumRequestDetail {
+	id: string;
+	requestType: string;
+	albumName: string | null;
+	circleName: string | null;
+	referenceUrls: AlbumRequestReferenceUrl[];
+	notes: string | null;
+	status: string;
+	reviewerNotes: string | null;
+	reviewedAt: string | null;
+	createdAt: string;
+	updatedAt: string;
+	submittedBy: AlbumRequestUser;
+	reviewer: AlbumRequestUser;
+	existingRelease: AlbumRequestExistingReleaseDetail;
+}
+
+export interface AlbumRequestListResponse {
+	data: AlbumRequestListItem[];
+	pagination: {
+		page: number;
+		limit: number;
+		total: number;
+		totalPages: number;
+	};
+}
+
+export const ALBUM_REQUEST_STATUS_LABELS: Record<AlbumRequestStatus, string> = {
+	pending: "未処理",
+	approved: "承認済",
+	rejected: "却下",
+};
+
+export const ALBUM_REQUEST_TYPE_LABELS: Record<AlbumRequestType, string> = {
+	new: "新規",
+	existing: "既存への追記",
+};
+
+// Album Requests (管理者向け)
+export const albumRequestsApi = {
+	pendingCount: () =>
+		fetchWithAuth<{ count: number }>("/api/admin/album-requests/pending-count"),
+
+	list: (params?: { status?: string; page?: number; limit?: number }) => {
+		const searchParams = new URLSearchParams();
+		if (params?.status) searchParams.set("status", params.status);
+		if (params?.page) searchParams.set("page", String(params.page));
+		if (params?.limit) searchParams.set("limit", String(params.limit));
+		const query = searchParams.toString();
+		return fetchWithAuth<AlbumRequestListResponse>(
+			`/api/admin/album-requests${query ? `?${query}` : ""}`,
+		);
+	},
+
+	get: (id: string) =>
+		fetchWithAuth<AlbumRequestDetail>(`/api/admin/album-requests/${id}`),
+
+	updateStatus: (
+		id: string,
+		data: {
+			status: "approved" | "rejected";
+			reviewerNotes?: string;
+			updatedAt: string;
+		},
+	) =>
+		fetchWithAuth<AlbumRequestDetail>(`/api/admin/album-requests/${id}`, {
+			method: "PATCH",
+			body: JSON.stringify(data),
+		}),
+};

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -3149,6 +3149,52 @@ export const ALBUM_REQUEST_TYPE_LABELS: Record<AlbumRequestType, string> = {
 	existing: "既存への追記",
 };
 
+// ===== ユーザー向けアルバム申請 =====
+
+export interface AlbumRequestForUser {
+	id: string;
+	requestType: string;
+	albumName: string | null;
+	circleName: string | null;
+	referenceUrls: AlbumRequestReferenceUrl[];
+	notes: string | null;
+	status: string;
+	reviewerNotes: string | null;
+	reviewedAt: string | null;
+	createdAt: string;
+	updatedAt: string;
+	existingRelease: {
+		id: string | null;
+		name: string | null;
+		nameJa: string | null;
+		nameEn: string | null;
+		releaseDate: string | null;
+	} | null;
+}
+
+export interface UserAlbumRequestListResponse {
+	items: AlbumRequestForUser[];
+}
+
+// Album Requests (ユーザー向け)
+export const userAlbumRequestsApi = {
+	submit: (payload: {
+		requestType: "new" | "existing";
+		existingReleaseId?: string;
+		albumName?: string;
+		circleName?: string;
+		referenceUrls: AlbumRequestReferenceUrl[];
+		notes?: string;
+	}) =>
+		fetchWithAuth<AlbumRequestForUser>("/api/user/album-requests", {
+			method: "POST",
+			body: JSON.stringify(payload),
+		}),
+
+	listMine: () =>
+		fetchWithAuth<UserAlbumRequestListResponse>("/api/user/album-requests"),
+};
+
 // Album Requests (管理者向け)
 export const albumRequestsApi = {
 	pendingCount: () =>

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -3103,7 +3103,7 @@ export interface AlbumRequestListItem {
 	createdAt: string;
 	updatedAt: string;
 	submittedBy: AlbumRequestUser;
-	existingRelease: AlbumRequestExistingRelease;
+	existingRelease: AlbumRequestExistingRelease | null;
 }
 
 export interface AlbumRequestExistingReleaseDetail
@@ -3124,18 +3124,8 @@ export interface AlbumRequestDetail {
 	createdAt: string;
 	updatedAt: string;
 	submittedBy: AlbumRequestUser;
-	reviewer: AlbumRequestUser;
-	existingRelease: AlbumRequestExistingReleaseDetail;
-}
-
-export interface AlbumRequestListResponse {
-	data: AlbumRequestListItem[];
-	pagination: {
-		page: number;
-		limit: number;
-		total: number;
-		totalPages: number;
-	};
+	reviewer: AlbumRequestUser | null;
+	existingRelease: AlbumRequestExistingReleaseDetail | null;
 }
 
 export const ALBUM_REQUEST_STATUS_LABELS: Record<AlbumRequestStatus, string> = {
@@ -3206,7 +3196,7 @@ export const albumRequestsApi = {
 		if (params?.page) searchParams.set("page", String(params.page));
 		if (params?.limit) searchParams.set("limit", String(params.limit));
 		const query = searchParams.toString();
-		return fetchWithAuth<AlbumRequestListResponse>(
+		return fetchWithAuth<PaginatedResponse<AlbumRequestListItem>>(
 			`/api/admin/album-requests${query ? `?${query}` : ""}`,
 		);
 	},

--- a/apps/web/src/lib/mutation-options.ts
+++ b/apps/web/src/lib/mutation-options.ts
@@ -22,6 +22,7 @@ import {
 	type ArtistAlias,
 	type ArtistFullResponse,
 	type ArtistWithAliases,
+	albumRequestsApi,
 	aliasTypesApi,
 	artistAliasesApi,
 	artistsApi,
@@ -3486,6 +3487,32 @@ export const trackIsrcMutations = {
 				queryKey: ["track-isrcs", variables.trackId],
 			});
 			queryClient.invalidateQueries({ queryKey: ["track", variables.trackId] });
+		},
+	}),
+};
+
+// ===== アルバム申請 =====
+
+type UpdateAlbumRequestStatusData = {
+	id: string;
+	status: "approved" | "rejected";
+	reviewerNotes?: string;
+	updatedAt: string;
+};
+
+export const albumRequestMutations = {
+	updateStatus: (queryClient: QueryClient) => ({
+		mutationFn: ({
+			id,
+			status,
+			reviewerNotes,
+			updatedAt,
+		}: UpdateAlbumRequestStatusData) =>
+			albumRequestsApi.updateStatus(id, { status, reviewerNotes, updatedAt }),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["admin", "album-requests"],
+			});
 		},
 	}),
 };

--- a/apps/web/src/lib/mutation-options.ts
+++ b/apps/web/src/lib/mutation-options.ts
@@ -83,6 +83,7 @@ import {
 	trackOfficialSongsApi,
 	trackPublicationsApi,
 	tracksApi,
+	userAlbumRequestsApi,
 } from "./api-client";
 
 // ===== 共通型定義 =====
@@ -3512,6 +3513,29 @@ export const albumRequestMutations = {
 		onSuccess: () => {
 			queryClient.invalidateQueries({
 				queryKey: ["admin", "album-requests"],
+			});
+		},
+	}),
+};
+
+// ===== ユーザー向けアルバム申請 =====
+
+type SubmitAlbumRequestData = {
+	requestType: "new" | "existing";
+	existingReleaseId?: string;
+	albumName?: string;
+	circleName?: string;
+	referenceUrls: { url: string; label?: string }[];
+	notes?: string;
+};
+
+export const userAlbumRequestMutations = {
+	submit: (queryClient: QueryClient) => ({
+		mutationFn: (data: SubmitAlbumRequestData) =>
+			userAlbumRequestsApi.submit(data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["user", "album-requests"],
 			});
 		},
 	}),

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -17,7 +17,7 @@ import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { ssrFetch } from "@/functions/ssr-fetcher";
 import type {
 	AlbumRequestDetail,
-	AlbumRequestListResponse,
+	AlbumRequestListItem,
 	AliasType,
 	Artist,
 	ArtistAlias,
@@ -957,7 +957,7 @@ export const albumRequestsListQueryOptions = (
 			params.limit,
 		],
 		queryFn: () =>
-			ssrFetch<AlbumRequestListResponse>(
+			ssrFetch<PaginatedResponse<AlbumRequestListItem>>(
 				`/api/admin/album-requests?${searchParams.toString()}`,
 			),
 		staleTime: STALE_TIME.SHORT,

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -16,6 +16,8 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { ssrFetch } from "@/functions/ssr-fetcher";
 import type {
+	AlbumRequestDetail,
+	AlbumRequestListResponse,
 	AliasType,
 	Artist,
 	ArtistAlias,
@@ -45,6 +47,7 @@ import type {
 	TrackDetail,
 	TrackWithCreditCount,
 } from "@/lib/api-client";
+import { albumRequestsApi } from "@/lib/api-client";
 import {
 	transformEventDaysToSelectOptions,
 	transformEventsToSelectOptions,
@@ -925,3 +928,59 @@ export const officialWorkCategoryDetailQueryOptions = (code: string) =>
 			),
 		staleTime: STALE_TIME.MEDIUM,
 	});
+
+// ===== アルバム申請 =====
+
+interface AlbumRequestListParams {
+	status?: string;
+	page: number;
+	limit: number;
+}
+
+/**
+ * アルバム申請一覧のqueryOptions
+ */
+export const albumRequestsListQueryOptions = (
+	params: AlbumRequestListParams,
+) => {
+	const searchParams = new URLSearchParams();
+	if (params.status) searchParams.set("status", params.status);
+	searchParams.set("page", String(params.page));
+	searchParams.set("limit", String(params.limit));
+
+	return queryOptions({
+		queryKey: [
+			"admin",
+			"album-requests",
+			params.status,
+			params.page,
+			params.limit,
+		],
+		queryFn: () =>
+			ssrFetch<AlbumRequestListResponse>(
+				`/api/admin/album-requests?${searchParams.toString()}`,
+			),
+		staleTime: STALE_TIME.SHORT,
+	});
+};
+
+/**
+ * アルバム申請詳細のqueryOptions
+ */
+export const albumRequestQueryOptions = (id: string) =>
+	queryOptions({
+		queryKey: ["admin", "album-requests", id],
+		queryFn: () =>
+			ssrFetch<AlbumRequestDetail>(`/api/admin/album-requests/${id}`),
+		staleTime: STALE_TIME.SHORT,
+	});
+
+/**
+ * アルバム申請 pending 件数のqueryOptions（サイドバーバッジ用）
+ */
+export const albumRequestPendingCountQueryOptions = queryOptions({
+	queryKey: ["admin", "album-requests", "pending-count"],
+	queryFn: () => albumRequestsApi.pendingCount(),
+	staleTime: 30_000,
+	refetchInterval: 60_000,
+});

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -47,7 +47,7 @@ import type {
 	TrackDetail,
 	TrackWithCreditCount,
 } from "@/lib/api-client";
-import { albumRequestsApi } from "@/lib/api-client";
+import { albumRequestsApi, userAlbumRequestsApi } from "@/lib/api-client";
 import {
 	transformEventDaysToSelectOptions,
 	transformEventsToSelectOptions,
@@ -983,4 +983,15 @@ export const albumRequestPendingCountQueryOptions = queryOptions({
 	queryFn: () => albumRequestsApi.pendingCount(),
 	staleTime: 30_000,
 	refetchInterval: 60_000,
+});
+
+// ===== ユーザー向けアルバム申請 =====
+
+/**
+ * 自分のアルバム申請一覧のqueryOptions（ユーザー向け）
+ */
+export const userAlbumRequestsQueryOptions = queryOptions({
+	queryKey: ["user", "album-requests"],
+	queryFn: () => userAlbumRequestsApi.listMine(),
+	staleTime: STALE_TIME.SHORT,
 });

--- a/apps/web/src/routes/admin/_admin/album-requests.tsx
+++ b/apps/web/src/routes/admin/_admin/album-requests.tsx
@@ -1,0 +1,208 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
+import { Home } from "lucide-react";
+import { useState } from "react";
+import { AlbumRequestStatusBadge } from "@/components/admin/album-request-status-badge";
+import { DataTablePagination } from "@/components/admin/data-table-pagination";
+import { DataTableSkeleton } from "@/components/admin/data-table-skeleton";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import {
+	ALBUM_REQUEST_STATUS_LABELS,
+	ALBUM_REQUEST_TYPE_LABELS,
+	type AlbumRequestStatus,
+} from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
+import { albumRequestsListQueryOptions } from "@/lib/query-options";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 20;
+
+export const Route = createFileRoute("/admin/_admin/album-requests")({
+	head: () => createPageHead("アルバム申請"),
+	loader: ({ context }) =>
+		context.queryClient.ensureQueryData(
+			albumRequestsListQueryOptions({
+				page: DEFAULT_PAGE,
+				limit: DEFAULT_PAGE_SIZE,
+			}),
+		),
+	component: AlbumRequestsPage,
+});
+
+type StatusTab = AlbumRequestStatus | "all";
+
+const STATUS_TABS: { value: StatusTab; label: string }[] = [
+	{ value: "all", label: "すべて" },
+	{ value: "pending", label: ALBUM_REQUEST_STATUS_LABELS.pending },
+	{ value: "approved", label: ALBUM_REQUEST_STATUS_LABELS.approved },
+	{ value: "rejected", label: ALBUM_REQUEST_STATUS_LABELS.rejected },
+];
+
+function AlbumRequestsPage() {
+	const [page, setPage] = useState(DEFAULT_PAGE);
+	const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+	const [activeTab, setActiveTab] = useState<StatusTab>("all");
+
+	const statusParam = activeTab === "all" ? undefined : activeTab;
+
+	const { data, isPending, error } = useQuery(
+		albumRequestsListQueryOptions({
+			status: statusParam,
+			page,
+			limit: pageSize,
+		}),
+	);
+
+	const requests = data?.data ?? [];
+	const total = data?.pagination.total ?? 0;
+
+	const handleTabChange = (tab: StatusTab) => {
+		setActiveTab(tab);
+		setPage(1);
+	};
+
+	const handlePageChange = (newPage: number) => {
+		setPage(newPage);
+	};
+
+	const handlePageSizeChange = (newPageSize: number) => {
+		setPageSize(newPageSize);
+		setPage(1);
+	};
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			<nav className="breadcrumbs text-sm">
+				<ul>
+					<li>
+						<Link to="/admin">
+							<Home className="h-4 w-4" />
+						</Link>
+					</li>
+					<li>アルバム申請</li>
+				</ul>
+			</nav>
+
+			<h1 className="font-bold text-2xl">アルバム申請</h1>
+
+			{/* ステータスタブ */}
+			<div role="tablist" className="tabs tabs-box">
+				{STATUS_TABS.map((tab) => (
+					<button
+						key={tab.value}
+						type="button"
+						role="tab"
+						className={`tab${activeTab === tab.value ? "tab-active" : ""}`}
+						onClick={() => handleTabChange(tab.value)}
+					>
+						{tab.label}
+					</button>
+				))}
+			</div>
+
+			<div className="rounded-lg border border-base-300 bg-base-100">
+				{error && (
+					<div className="border-base-300 border-b bg-error p-4 text-error-content text-sm">
+						{error instanceof Error ? error.message : "エラーが発生しました"}
+					</div>
+				)}
+
+				{isPending && !data ? (
+					<DataTableSkeleton
+						rows={5}
+						columns={6}
+						showActionBar={false}
+						showPagination={false}
+					/>
+				) : (
+					<>
+						<Table zebra>
+							<TableHeader>
+								<TableRow className="hover:bg-transparent">
+									<TableHead className="w-[120px]">ステータス</TableHead>
+									<TableHead className="w-[120px]">タイプ</TableHead>
+									<TableHead className="min-w-[200px]">
+										アルバム名 / 対象作品
+									</TableHead>
+									<TableHead className="min-w-[150px]">サークル名</TableHead>
+									<TableHead className="min-w-[150px]">提出者</TableHead>
+									<TableHead className="w-[160px]">提出日時</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{requests.length === 0 ? (
+									<TableRow>
+										<TableCell
+											colSpan={6}
+											className="h-24 text-center text-base-content/50"
+										>
+											該当するアルバム申請が見つかりません
+										</TableCell>
+									</TableRow>
+								) : (
+									requests.map((request) => (
+										<TableRow
+											key={request.id}
+											className="cursor-pointer hover:bg-base-200"
+											onClick={() => {
+												window.location.href = `/admin/album-requests/${request.id}`;
+											}}
+										>
+											<TableCell>
+												<AlbumRequestStatusBadge
+													status={request.status as AlbumRequestStatus}
+												/>
+											</TableCell>
+											<TableCell className="text-base-content/70">
+												{ALBUM_REQUEST_TYPE_LABELS[
+													request.requestType as keyof typeof ALBUM_REQUEST_TYPE_LABELS
+												] ?? request.requestType}
+											</TableCell>
+											<TableCell className="font-medium">
+												{request.requestType === "existing"
+													? (request.existingRelease?.name ?? "-")
+													: (request.albumName ?? "-")}
+											</TableCell>
+											<TableCell className="text-base-content/70">
+												{request.circleName ?? "-"}
+											</TableCell>
+											<TableCell className="text-base-content/70">
+												{request.submittedBy?.name ?? "-"}
+											</TableCell>
+											<TableCell className="whitespace-nowrap text-base-content/70 text-sm">
+												{format(
+													new Date(request.createdAt),
+													"yyyy/MM/dd HH:mm",
+													{ locale: ja },
+												)}
+											</TableCell>
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+
+						<div className="border-base-300 border-t p-4">
+							<DataTablePagination
+								page={page}
+								pageSize={pageSize}
+								total={total}
+								onPageChange={handlePageChange}
+								onPageSizeChange={handlePageSizeChange}
+							/>
+						</div>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/routes/admin/_admin/album-requests.tsx
+++ b/apps/web/src/routes/admin/_admin/album-requests.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 import { Home } from "lucide-react";
@@ -51,6 +51,7 @@ function AlbumRequestsPage() {
 	const [page, setPage] = useState(DEFAULT_PAGE);
 	const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
 	const [activeTab, setActiveTab] = useState<StatusTab>("all");
+	const navigate = useNavigate();
 
 	const statusParam = activeTab === "all" ? undefined : activeTab;
 
@@ -63,7 +64,7 @@ function AlbumRequestsPage() {
 	);
 
 	const requests = data?.data ?? [];
-	const total = data?.pagination.total ?? 0;
+	const total = data?.total ?? 0;
 
 	const handleTabChange = (tab: StatusTab) => {
 		setActiveTab(tab);
@@ -101,7 +102,7 @@ function AlbumRequestsPage() {
 						key={tab.value}
 						type="button"
 						role="tab"
-						className={`tab${activeTab === tab.value ? "tab-active" : ""}`}
+						className={activeTab === tab.value ? "tab tab-active" : "tab"}
 						onClick={() => handleTabChange(tab.value)}
 					>
 						{tab.label}
@@ -153,9 +154,12 @@ function AlbumRequestsPage() {
 										<TableRow
 											key={request.id}
 											className="cursor-pointer hover:bg-base-200"
-											onClick={() => {
-												window.location.href = `/admin/album-requests/${request.id}`;
-											}}
+											onClick={() =>
+												navigate({
+													to: "/admin/album-requests/$id",
+													params: { id: request.id },
+												})
+											}
 										>
 											<TableCell>
 												<AlbumRequestStatusBadge

--- a/apps/web/src/routes/admin/_admin/album-requests_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/album-requests_.$id.tsx
@@ -1,0 +1,334 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
+import { ArrowLeft, ExternalLink, Home } from "lucide-react";
+import { useState } from "react";
+import { AlbumRequestStatusBadge } from "@/components/admin/album-request-status-badge";
+import { DetailPageSkeleton } from "@/components/admin/detail-page-skeleton";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	ALBUM_REQUEST_STATUS_LABELS,
+	ALBUM_REQUEST_TYPE_LABELS,
+	type AlbumRequestStatus,
+	isConflictError,
+} from "@/lib/api-client";
+import { createPageHead } from "@/lib/head";
+import { albumRequestMutations } from "@/lib/mutation-options";
+import { albumRequestQueryOptions } from "@/lib/query-options";
+
+export const Route = createFileRoute("/admin/_admin/album-requests_/$id")({
+	head: () => createPageHead("アルバム申請詳細"),
+	loader: ({ context, params }) =>
+		context.queryClient.ensureQueryData(albumRequestQueryOptions(params.id)),
+	component: AlbumRequestDetailPage,
+});
+
+function AlbumRequestDetailPage() {
+	const { id } = Route.useParams();
+	const queryClient = useQueryClient();
+
+	const [reviewerNotes, setReviewerNotes] = useState("");
+	const [actionError, setActionError] = useState<string | null>(null);
+	const [actionSuccess, setActionSuccess] = useState<string | null>(null);
+
+	const { data: request, isPending } = useQuery(albumRequestQueryOptions(id));
+
+	const updateStatusMutation = useMutation(
+		albumRequestMutations.updateStatus(queryClient),
+	);
+
+	if (isPending || !request) {
+		return <DetailPageSkeleton />;
+	}
+
+	const isPending_ = request.status === "pending";
+
+	const handleAction = (status: "approved" | "rejected") => {
+		setActionError(null);
+		setActionSuccess(null);
+
+		updateStatusMutation.mutate(
+			{
+				id,
+				status,
+				reviewerNotes: reviewerNotes || undefined,
+				updatedAt: request.updatedAt,
+			},
+			{
+				onSuccess: () => {
+					const label = ALBUM_REQUEST_STATUS_LABELS[status];
+					setActionSuccess(`申請を「${label}」に更新しました。`);
+					setReviewerNotes("");
+				},
+				onError: (error) => {
+					if (isConflictError(error)) {
+						setActionError(
+							"他の管理者が更新したため再読込が必要です。ページをリロードしてください。",
+						);
+					} else {
+						setActionError(
+							error instanceof Error ? error.message : "エラーが発生しました",
+						);
+					}
+				},
+			},
+		);
+	};
+
+	const submittedAt = format(
+		new Date(request.createdAt),
+		"yyyy/MM/dd HH:mm:ss",
+		{
+			locale: ja,
+		},
+	);
+	const reviewedAt = request.reviewedAt
+		? format(new Date(request.reviewedAt), "yyyy/MM/dd HH:mm:ss", {
+				locale: ja,
+			})
+		: null;
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			{/* パンくず */}
+			<nav className="breadcrumbs text-sm">
+				<ul>
+					<li>
+						<Link to="/admin">
+							<Home className="h-4 w-4" />
+						</Link>
+					</li>
+					<li>
+						<Link to="/admin/album-requests">アルバム申請</Link>
+					</li>
+					<li>詳細</li>
+				</ul>
+			</nav>
+
+			{/* ヘッダー */}
+			<div className="flex items-center gap-4">
+				<Link to="/admin/album-requests" className="btn btn-ghost btn-sm">
+					<ArrowLeft className="h-4 w-4" />
+				</Link>
+				<h1 className="font-bold text-2xl">アルバム申請詳細</h1>
+			</div>
+
+			{/* 成功/エラーバナー */}
+			{actionSuccess && (
+				<div className="rounded-lg bg-success p-4 text-sm text-success-content">
+					{actionSuccess}
+				</div>
+			)}
+			{actionError && (
+				<div className="rounded-lg bg-error p-4 text-error-content text-sm">
+					{actionError}
+				</div>
+			)}
+
+			<div className="grid gap-6 lg:grid-cols-3">
+				{/* メインコンテンツ */}
+				<div className="space-y-6 lg:col-span-2">
+					{/* 基本情報 */}
+					<div className="rounded-lg border border-base-300 bg-base-100 p-6">
+						<h2 className="mb-4 font-semibold text-lg">基本情報</h2>
+						<dl className="grid gap-4">
+							<div className="grid grid-cols-[140px_1fr] gap-2">
+								<dt className="text-base-content/70 text-sm">ステータス</dt>
+								<dd>
+									<AlbumRequestStatusBadge
+										status={request.status as AlbumRequestStatus}
+									/>
+								</dd>
+							</div>
+							<div className="grid grid-cols-[140px_1fr] gap-2">
+								<dt className="text-base-content/70 text-sm">
+									リクエストタイプ
+								</dt>
+								<dd className="text-sm">
+									{ALBUM_REQUEST_TYPE_LABELS[
+										request.requestType as keyof typeof ALBUM_REQUEST_TYPE_LABELS
+									] ?? request.requestType}
+								</dd>
+							</div>
+							{request.albumName && (
+								<div className="grid grid-cols-[140px_1fr] gap-2">
+									<dt className="text-base-content/70 text-sm">アルバム名</dt>
+									<dd className="text-sm">{request.albumName}</dd>
+								</div>
+							)}
+							{request.circleName && (
+								<div className="grid grid-cols-[140px_1fr] gap-2">
+									<dt className="text-base-content/70 text-sm">サークル名</dt>
+									<dd className="text-sm">{request.circleName}</dd>
+								</div>
+							)}
+							{request.notes && (
+								<div className="grid grid-cols-[140px_1fr] gap-2">
+									<dt className="text-base-content/70 text-sm">補足</dt>
+									<dd className="whitespace-pre-wrap text-sm">
+										{request.notes}
+									</dd>
+								</div>
+							)}
+						</dl>
+					</div>
+
+					{/* 既存作品への追記の場合 */}
+					{request.requestType === "existing" &&
+						request.existingRelease?.id && (
+							<div className="rounded-lg border border-base-300 bg-base-100 p-6">
+								<h2 className="mb-4 font-semibold text-lg">対象作品</h2>
+								<div className="flex items-center gap-2">
+									<span className="text-sm">
+										{request.existingRelease.name}
+										{request.existingRelease.nameJa &&
+											request.existingRelease.nameJa !==
+												request.existingRelease.name && (
+												<span className="ml-2 text-base-content/60">
+													({request.existingRelease.nameJa})
+												</span>
+											)}
+									</span>
+									<a
+										href={`/admin/releases/${request.existingRelease.id}`}
+										target="_blank"
+										rel="noreferrer"
+										className="btn btn-ghost btn-xs"
+									>
+										<ExternalLink className="h-3 w-3" />
+										<span>管理画面で開く</span>
+									</a>
+								</div>
+								{request.existingRelease.releaseDate && (
+									<p className="mt-2 text-base-content/60 text-sm">
+										頒布日: {request.existingRelease.releaseDate}
+									</p>
+								)}
+							</div>
+						)}
+
+					{/* 参考URL */}
+					{request.referenceUrls.length > 0 && (
+						<div className="rounded-lg border border-base-300 bg-base-100 p-6">
+							<h2 className="mb-4 font-semibold text-lg">参考URL</h2>
+							<ul className="space-y-2">
+								{request.referenceUrls.map((ref, index) => (
+									// biome-ignore lint/suspicious/noArrayIndexKey: 参考URLは順序付きリストでインデックスが適切
+									<li key={`${ref.url}-${index}`} className="text-sm">
+										<a
+											href={ref.url}
+											target="_blank"
+											rel="noreferrer"
+											className="inline-flex items-center gap-1 text-primary hover:underline"
+										>
+											<ExternalLink className="h-3 w-3 shrink-0" />
+											{ref.label || ref.url}
+										</a>
+										{ref.label && (
+											<span className="ml-2 text-base-content/50 text-xs">
+												{ref.url}
+											</span>
+										)}
+									</li>
+								))}
+							</ul>
+						</div>
+					)}
+				</div>
+
+				{/* サイドバー */}
+				<div className="space-y-6">
+					{/* 提出者情報 */}
+					<div className="rounded-lg border border-base-300 bg-base-100 p-6">
+						<h2 className="mb-4 font-semibold text-lg">提出者</h2>
+						<dl className="space-y-2">
+							<div>
+								<dt className="text-base-content/70 text-xs">名前</dt>
+								<dd className="text-sm">{request.submittedBy?.name ?? "-"}</dd>
+							</div>
+							<div>
+								<dt className="text-base-content/70 text-xs">メール</dt>
+								<dd className="text-sm">{request.submittedBy?.email ?? "-"}</dd>
+							</div>
+							<div>
+								<dt className="text-base-content/70 text-xs">提出日時</dt>
+								<dd className="text-sm">{submittedAt}</dd>
+							</div>
+						</dl>
+					</div>
+
+					{/* レビュー履歴（pending 以外のとき） */}
+					{request.status !== "pending" && (
+						<div className="rounded-lg border border-base-300 bg-base-100 p-6">
+							<h2 className="mb-4 font-semibold text-lg">レビュー履歴</h2>
+							<dl className="space-y-2">
+								<div>
+									<dt className="text-base-content/70 text-xs">レビュアー</dt>
+									<dd className="text-sm">{request.reviewer?.name ?? "-"}</dd>
+								</div>
+								<div>
+									<dt className="text-base-content/70 text-xs">レビュー日時</dt>
+									<dd className="text-sm">{reviewedAt ?? "-"}</dd>
+								</div>
+								{request.reviewerNotes && (
+									<div>
+										<dt className="text-base-content/70 text-xs">
+											レビューメモ
+										</dt>
+										<dd className="mt-1 whitespace-pre-wrap rounded-md bg-base-200 p-3 text-sm">
+											{request.reviewerNotes}
+										</dd>
+									</div>
+								)}
+							</dl>
+						</div>
+					)}
+
+					{/* アクション（pending のみ） */}
+					{isPending_ && (
+						<div className="rounded-lg border border-base-300 bg-base-100 p-6">
+							<h2 className="mb-4 font-semibold text-lg">審査</h2>
+							<div className="space-y-4">
+								<div className="space-y-2">
+									<Label htmlFor="reviewer-notes">レビューメモ（任意）</Label>
+									<Textarea
+										id="reviewer-notes"
+										value={reviewerNotes}
+										onChange={(e) => setReviewerNotes(e.target.value)}
+										rows={4}
+										placeholder="承認・却下の理由など"
+										autoComplete="off"
+										data-1p-ignore
+										data-lpignore="true"
+										data-form-type="other"
+									/>
+								</div>
+								<div className="flex gap-2">
+									<Button
+										variant="primary"
+										className="flex-1"
+										onClick={() => handleAction("approved")}
+										disabled={updateStatusMutation.isPending}
+									>
+										{updateStatusMutation.isPending ? "処理中..." : "承認"}
+									</Button>
+									<Button
+										variant="destructive"
+										className="flex-1"
+										onClick={() => handleAction("rejected")}
+										disabled={updateStatusMutation.isPending}
+									>
+										{updateStatusMutation.isPending ? "処理中..." : "却下"}
+									</Button>
+								</div>
+							</div>
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/routes/admin/_admin/album-requests_.$id.tsx
+++ b/apps/web/src/routes/admin/_admin/album-requests_.$id.tsx
@@ -1,11 +1,14 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	useMutation,
+	useQueryClient,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 import { ArrowLeft, ExternalLink, Home } from "lucide-react";
 import { useState } from "react";
 import { AlbumRequestStatusBadge } from "@/components/admin/album-request-status-badge";
-import { DetailPageSkeleton } from "@/components/admin/detail-page-skeleton";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -34,15 +37,11 @@ function AlbumRequestDetailPage() {
 	const [actionError, setActionError] = useState<string | null>(null);
 	const [actionSuccess, setActionSuccess] = useState<string | null>(null);
 
-	const { data: request, isPending } = useQuery(albumRequestQueryOptions(id));
+	const { data: request } = useSuspenseQuery(albumRequestQueryOptions(id));
 
 	const updateStatusMutation = useMutation(
 		albumRequestMutations.updateStatus(queryClient),
 	);
-
-	if (isPending || !request) {
-		return <DetailPageSkeleton />;
-	}
 
 	const isPending_ = request.status === "pending";
 

--- a/apps/web/src/routes/user/album-requests.new.tsx
+++ b/apps/web/src/routes/user/album-requests.new.tsx
@@ -1,0 +1,101 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+	createFileRoute,
+	Link,
+	redirect,
+	useNavigate,
+} from "@tanstack/react-router";
+import { useState } from "react";
+import { AlbumRequestForm } from "@/components/album-request-form";
+import { PublicHeader } from "@/components/public/public-header";
+import { Banner } from "@/components/ui/banner";
+import { getUser } from "@/functions/get-user";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
+import { createPageHead } from "@/lib/head";
+import { userAlbumRequestMutations } from "@/lib/mutation-options";
+
+export const Route = createFileRoute("/user/album-requests/new")({
+	head: () => createPageHead("アルバム情報の提供"),
+	headers: () => CACHE_HEADERS.PRIVATE,
+	beforeLoad: async () => {
+		const session = await getUser();
+
+		if (!session?.user) {
+			throw redirect({
+				to: "/login",
+				search: { returnTo: "/user/album-requests/new" },
+			});
+		}
+
+		return { user: session.user };
+	},
+	component: AlbumRequestNewPage,
+});
+
+function AlbumRequestNewPage() {
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+	const [submitError, setSubmitError] = useState<string | null>(null);
+
+	const { mutateAsync, isPending } = useMutation(
+		userAlbumRequestMutations.submit(queryClient),
+	);
+
+	const handleSubmit = async (payload: Parameters<typeof mutateAsync>[0]) => {
+		setSubmitError(null);
+		try {
+			await mutateAsync(payload);
+			navigate({ to: "/user/album-requests" });
+		} catch (error) {
+			setSubmitError(
+				error instanceof Error ? error.message : "送信に失敗しました",
+			);
+		}
+	};
+
+	return (
+		<div className="flex min-h-screen flex-col">
+			<PublicHeader />
+			<main className="flex-1 bg-base-200/30">
+				<div className="mx-auto max-w-2xl px-4 py-8">
+					<div className="mb-2">
+						<Link
+							to="/user/album-requests"
+							className="text-base-content/60 text-sm hover:text-base-content"
+						>
+							← 提供リクエスト一覧へ
+						</Link>
+					</div>
+					<div className="mb-6">
+						<h1 className="font-bold text-2xl">アルバム情報の提供</h1>
+						<p className="mt-2 text-base-content/70">
+							新しいアルバムの登録を依頼するか、既存アルバムへの情報追記を提案できます。
+						</p>
+					</div>
+
+					{submitError && (
+						<Banner
+							variant="error"
+							onDismiss={() => setSubmitError(null)}
+							className="mb-4"
+						>
+							{submitError}
+						</Banner>
+					)}
+
+					<div className="rounded-box bg-base-100 p-6 shadow">
+						<AlbumRequestForm
+							onSubmit={handleSubmit}
+							isSubmitting={isPending}
+						/>
+					</div>
+				</div>
+			</main>
+			<footer className="bg-base-200 py-6 text-center text-base-content/60 text-sm">
+				<p>
+					&copy; {new Date().getFullYear()} 迷い家の白猫. All rights reserved.
+				</p>
+			</footer>
+		</div>
+	);
+}

--- a/apps/web/src/routes/user/album-requests.new.tsx
+++ b/apps/web/src/routes/user/album-requests.new.tsx
@@ -36,6 +36,7 @@ function AlbumRequestNewPage() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const [submitError, setSubmitError] = useState<string | null>(null);
+	const [submitSuccess, setSubmitSuccess] = useState(false);
 
 	const { mutateAsync, isPending } = useMutation(
 		userAlbumRequestMutations.submit(queryClient),
@@ -45,7 +46,10 @@ function AlbumRequestNewPage() {
 		setSubmitError(null);
 		try {
 			await mutateAsync(payload);
-			navigate({ to: "/user/album-requests" });
+			setSubmitSuccess(true);
+			setTimeout(() => {
+				navigate({ to: "/user/album-requests" });
+			}, 1500);
 		} catch (error) {
 			setSubmitError(
 				error instanceof Error ? error.message : "送信に失敗しました",
@@ -72,6 +76,12 @@ function AlbumRequestNewPage() {
 							新しいアルバムの登録を依頼するか、既存アルバムへの情報追記を提案できます。
 						</p>
 					</div>
+
+					{submitSuccess && (
+						<Banner variant="success" className="mb-4">
+							申請を送信しました。承認をお待ちください。
+						</Banner>
+					)}
 
 					{submitError && (
 						<Banner

--- a/apps/web/src/routes/user/album-requests.tsx
+++ b/apps/web/src/routes/user/album-requests.tsx
@@ -1,0 +1,170 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { ExternalLink } from "lucide-react";
+import { AlbumRequestStatusBadge } from "@/components/admin/album-request-status-badge";
+import { PublicHeader } from "@/components/public/public-header";
+import { getUser } from "@/functions/get-user";
+import type {
+	AlbumRequestForUser,
+	AlbumRequestStatus,
+	AlbumRequestType,
+} from "@/lib/api-client";
+import { ALBUM_REQUEST_TYPE_LABELS } from "@/lib/api-client";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
+import { createPageHead } from "@/lib/head";
+import { userAlbumRequestsQueryOptions } from "@/lib/query-options";
+
+export const Route = createFileRoute("/user/album-requests")({
+	head: () => createPageHead("提供リクエスト一覧"),
+	headers: () => CACHE_HEADERS.PRIVATE,
+	beforeLoad: async () => {
+		const session = await getUser();
+
+		if (!session?.user) {
+			throw redirect({
+				to: "/login",
+				search: { returnTo: "/user/album-requests" },
+			});
+		}
+
+		return { user: session.user };
+	},
+	component: AlbumRequestsPage,
+});
+
+function AlbumRequestsPage() {
+	const { data } = useSuspenseQuery(userAlbumRequestsQueryOptions);
+
+	return (
+		<div className="flex min-h-screen flex-col">
+			<PublicHeader />
+			<main className="flex-1 bg-base-200/30">
+				<div className="mx-auto max-w-3xl px-4 py-8">
+					<div className="mb-6 flex items-center justify-between">
+						<h1 className="font-bold text-2xl">あなたの提供リクエスト</h1>
+						<Link
+							to="/user/album-requests/new"
+							className="btn btn-primary btn-sm"
+						>
+							新しいリクエストを作成
+						</Link>
+					</div>
+
+					{data.items.length === 0 ? (
+						<div className="rounded-box bg-base-100 p-12 text-center shadow">
+							<p className="text-base-content/60">まだリクエストはありません</p>
+							<Link
+								to="/user/album-requests/new"
+								className="btn btn-primary mt-4"
+							>
+								最初のリクエストを作成する
+							</Link>
+						</div>
+					) : (
+						<ul className="space-y-4">
+							{data.items.map((item) => (
+								<li key={item.id}>
+									<AlbumRequestCard item={item} />
+								</li>
+							))}
+						</ul>
+					)}
+				</div>
+			</main>
+			<footer className="bg-base-200 py-6 text-center text-base-content/60 text-sm">
+				<p>
+					&copy; {new Date().getFullYear()} 迷い家の白猫. All rights reserved.
+				</p>
+			</footer>
+		</div>
+	);
+}
+
+interface AlbumRequestCardProps {
+	item: AlbumRequestForUser;
+}
+
+function AlbumRequestCard({ item }: AlbumRequestCardProps) {
+	const formattedDate = new Intl.DateTimeFormat("ja-JP", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	}).format(new Date(item.createdAt));
+
+	const requestTypeLabel =
+		ALBUM_REQUEST_TYPE_LABELS[item.requestType as AlbumRequestType] ??
+		item.requestType;
+
+	return (
+		<div className="rounded-box bg-base-100 p-5 shadow">
+			<div className="mb-3 flex flex-wrap items-center gap-2">
+				<AlbumRequestStatusBadge status={item.status as AlbumRequestStatus} />
+				<span className="text-base-content/60 text-sm">
+					{formattedDate} 提出
+				</span>
+			</div>
+
+			<div className="mb-2">
+				<span className="badge badge-outline badge-sm mr-2">
+					{requestTypeLabel}
+				</span>
+				{item.requestType === "existing" && item.existingRelease?.id ? (
+					<span className="font-medium">
+						{item.existingRelease.nameJa ||
+							item.existingRelease.name ||
+							"(既存アルバム)"}
+					</span>
+				) : (
+					<span className="font-medium">
+						{item.albumName ?? "(アルバム名未設定)"}
+					</span>
+				)}
+			</div>
+
+			{item.circleName && (
+				<p className="mb-2 text-base-content/70 text-sm">
+					サークル: {item.circleName}
+				</p>
+			)}
+
+			{item.referenceUrls.length > 0 && (
+				<div className="mb-2">
+					<p className="mb-1 font-medium text-base-content/60 text-xs">
+						参考URL
+					</p>
+					<ul className="space-y-0.5">
+						{item.referenceUrls.map((ref) => (
+							<li key={ref.url}>
+								<a
+									href={ref.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="inline-flex items-center gap-1 text-primary text-sm hover:underline"
+								>
+									<ExternalLink className="h-3 w-3 shrink-0" />
+									{ref.label || ref.url}
+								</a>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+
+			{item.notes && (
+				<p className="mb-2 text-base-content/70 text-sm">
+					<span className="font-medium">補足: </span>
+					{item.notes}
+				</p>
+			)}
+
+			{item.reviewerNotes && (
+				<div className="mt-3 rounded-field border border-base-300 bg-base-200 p-3">
+					<p className="mb-1 font-medium text-base-content/60 text-xs">
+						管理者コメント
+					</p>
+					<p className="text-sm">{item.reviewerNotes}</p>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/routes/user/album-requests_.new.tsx
+++ b/apps/web/src/routes/user/album-requests_.new.tsx
@@ -14,7 +14,7 @@ import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPageHead } from "@/lib/head";
 import { userAlbumRequestMutations } from "@/lib/mutation-options";
 
-export const Route = createFileRoute("/user/album-requests/new")({
+export const Route = createFileRoute("/user/album-requests_/new")({
 	head: () => createPageHead("アルバム情報の提供"),
 	headers: () => CACHE_HEADERS.PRIVATE,
 	beforeLoad: async () => {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,6 +8,9 @@
 		"./*": {
 			"default": "./src/*.ts"
 		},
+		"./schema/*": {
+			"default": "./src/schema/*.ts"
+		},
 		"./utils/*": {
 			"default": "./src/utils/*.ts"
 		}

--- a/packages/db/src/migrations/0004_great_beast.sql
+++ b/packages/db/src/migrations/0004_great_beast.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "album_requests" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"request_type" text NOT NULL,
+	"existing_release_id" text,
+	"album_name" text,
+	"circle_name" text,
+	"reference_urls" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"notes" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"reviewed_by_user_id" text,
+	"reviewer_notes" text,
+	"reviewed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "check_album_request_status" CHECK (status IN ('pending','approved','rejected')),
+	CONSTRAINT "check_album_request_type" CHECK (request_type IN ('new','existing')),
+	CONSTRAINT "check_album_request_type_consistency" CHECK ((request_type='existing' AND existing_release_id IS NOT NULL)
+        OR (request_type='new' AND album_name IS NOT NULL)),
+	CONSTRAINT "check_album_request_review_consistency" CHECK ((status='pending' AND reviewed_at IS NULL AND reviewed_by_user_id IS NULL)
+        OR (status<>'pending' AND reviewed_at IS NOT NULL AND reviewed_by_user_id IS NOT NULL))
+);
+--> statement-breakpoint
+ALTER TABLE "album_requests" ADD CONSTRAINT "album_requests_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "album_requests" ADD CONSTRAINT "album_requests_existing_release_id_releases_id_fk" FOREIGN KEY ("existing_release_id") REFERENCES "public"."releases"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "album_requests" ADD CONSTRAINT "album_requests_reviewed_by_user_id_user_id_fk" FOREIGN KEY ("reviewed_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_album_requests_user" ON "album_requests" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_album_requests_existing_release" ON "album_requests" USING btree ("existing_release_id");--> statement-breakpoint
+CREATE INDEX "idx_album_requests_status" ON "album_requests" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_album_requests_created_at" ON "album_requests" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "idx_album_requests_status_created_at" ON "album_requests" USING btree ("status","created_at");--> statement-breakpoint
+CREATE INDEX "idx_album_requests_reviewed_by" ON "album_requests" USING btree ("reviewed_by_user_id");

--- a/packages/db/src/migrations/meta/0004_snapshot.json
+++ b/packages/db/src/migrations/meta/0004_snapshot.json
@@ -1,0 +1,4839 @@
+{
+	"id": "6955eeb6-48d8-46f7-a432-e495ca2295fa",
+	"prevId": "038c853b-fe54-42ad-a1cf-1443517f7356",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.album_requests": {
+			"name": "album_requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_type": {
+					"name": "request_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"existing_release_id": {
+					"name": "existing_release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"circle_name": {
+					"name": "circle_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_urls": {
+					"name": "reference_urls",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"reviewed_by_user_id": {
+					"name": "reviewed_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reviewer_notes": {
+					"name": "reviewer_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reviewed_at": {
+					"name": "reviewed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_album_requests_user": {
+					"name": "idx_album_requests_user",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_existing_release": {
+					"name": "idx_album_requests_existing_release",
+					"columns": [
+						{
+							"expression": "existing_release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_status": {
+					"name": "idx_album_requests_status",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_created_at": {
+					"name": "idx_album_requests_created_at",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_status_created_at": {
+					"name": "idx_album_requests_status_created_at",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_reviewed_by": {
+					"name": "idx_album_requests_reviewed_by",
+					"columns": [
+						{
+							"expression": "reviewed_by_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"album_requests_user_id_user_id_fk": {
+					"name": "album_requests_user_id_user_id_fk",
+					"tableFrom": "album_requests",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				},
+				"album_requests_existing_release_id_releases_id_fk": {
+					"name": "album_requests_existing_release_id_releases_id_fk",
+					"tableFrom": "album_requests",
+					"tableTo": "releases",
+					"columnsFrom": ["existing_release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"album_requests_reviewed_by_user_id_user_id_fk": {
+					"name": "album_requests_reviewed_by_user_id_user_id_fk",
+					"tableFrom": "album_requests",
+					"tableTo": "user",
+					"columnsFrom": ["reviewed_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_album_request_status": {
+					"name": "check_album_request_status",
+					"value": "status IN ('pending','approved','rejected')"
+				},
+				"check_album_request_type": {
+					"name": "check_album_request_type",
+					"value": "request_type IN ('new','existing')"
+				},
+				"check_album_request_type_consistency": {
+					"name": "check_album_request_type_consistency",
+					"value": "(request_type='existing' AND existing_release_id IS NOT NULL)\n        OR (request_type='new' AND album_name IS NOT NULL)"
+				},
+				"check_album_request_review_consistency": {
+					"name": "check_album_request_review_consistency",
+					"value": "(status='pending' AND reviewed_at IS NULL AND reviewed_by_user_id IS NULL)\n        OR (status<>'pending' AND reviewed_at IS NOT NULL AND reviewed_by_user_id IS NOT NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.artist_aliases": {
+			"name": "artist_aliases",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"alias_type_code": {
+					"name": "alias_type_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_initial": {
+					"name": "name_initial",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"initial_script": {
+					"name": "initial_script",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"period_from": {
+					"name": "period_from",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_to": {
+					"name": "period_to",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_artist_aliases_artist_id": {
+					"name": "idx_artist_aliases_artist_id",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artist_aliases_alias_type": {
+					"name": "idx_artist_aliases_alias_type",
+					"columns": [
+						{
+							"expression": "alias_type_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_artist_aliases_name": {
+					"name": "uq_artist_aliases_name",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artist_aliases_name_lower": {
+					"name": "idx_artist_aliases_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artist_aliases_name_trgm": {
+					"name": "idx_artist_aliases_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"artist_aliases_artist_id_artists_id_fk": {
+					"name": "artist_aliases_artist_id_artists_id_fk",
+					"tableFrom": "artist_aliases",
+					"tableTo": "artists",
+					"columnsFrom": ["artist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"artist_aliases_alias_type_code_alias_types_code_fk": {
+					"name": "artist_aliases_alias_type_code_alias_types_code_fk",
+					"tableFrom": "artist_aliases",
+					"tableTo": "alias_types",
+					"columnsFrom": ["alias_type_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.artists": {
+			"name": "artists",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_name": {
+					"name": "sort_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_initial": {
+					"name": "name_initial",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"initial_script": {
+					"name": "initial_script",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uq_artists_name": {
+					"name": "uq_artists_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_sort": {
+					"name": "idx_artists_sort",
+					"columns": [
+						{
+							"expression": "sort_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_initial": {
+					"name": "idx_artists_initial",
+					"columns": [
+						{
+							"expression": "name_initial",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "initial_script",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_name_lower": {
+					"name": "idx_artists_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_name_trgm": {
+					"name": "idx_artists_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.circle_links": {
+			"name": "circle_links",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"circle_id": {
+					"name": "circle_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_id": {
+					"name": "platform_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"handle": {
+					"name": "handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_official": {
+					"name": "is_official",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_circle_links_circle_id": {
+					"name": "idx_circle_links_circle_id",
+					"columns": [
+						{
+							"expression": "circle_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circle_links_platform": {
+					"name": "idx_circle_links_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_circle_links_circle_url": {
+					"name": "uq_circle_links_circle_url",
+					"columns": [
+						{
+							"expression": "circle_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"circle_links_circle_id_circles_id_fk": {
+					"name": "circle_links_circle_id_circles_id_fk",
+					"tableFrom": "circle_links",
+					"tableTo": "circles",
+					"columnsFrom": ["circle_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"circle_links_platform_code_platforms_code_fk": {
+					"name": "circle_links_platform_code_platforms_code_fk",
+					"tableFrom": "circle_links",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.circles": {
+			"name": "circles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_name": {
+					"name": "sort_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_initial": {
+					"name": "name_initial",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"initial_script": {
+					"name": "initial_script",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uq_circles_name": {
+					"name": "uq_circles_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circles_initial": {
+					"name": "idx_circles_initial",
+					"columns": [
+						{
+							"expression": "name_initial",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "initial_script",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circles_name_lower": {
+					"name": "idx_circles_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circles_name_trgm": {
+					"name": "idx_circles_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_circles_name_ja_trgm": {
+					"name": "idx_circles_name_ja_trgm",
+					"columns": [
+						{
+							"expression": "\"name_ja\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_circles_name_en_trgm": {
+					"name": "idx_circles_name_en_trgm",
+					"columns": [
+						{
+							"expression": "\"name_en\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"onboarding_completed": {
+					"name": "onboarding_completed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.event_days": {
+			"name": "event_days",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"event_id": {
+					"name": "event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"day_number": {
+					"name": "day_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_event_days_event_id": {
+					"name": "idx_event_days_event_id",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_days_date": {
+					"name": "idx_event_days_date",
+					"columns": [
+						{
+							"expression": "date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_event_days_event_day_number": {
+					"name": "uq_event_days_event_day_number",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "day_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_event_days_event_date": {
+					"name": "uq_event_days_event_date",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"event_days_event_id_events_id_fk": {
+					"name": "event_days_event_id_events_id_fk",
+					"tableFrom": "event_days",
+					"tableTo": "events",
+					"columnsFrom": ["event_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.event_series": {
+			"name": "event_series",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_event_series_name": {
+					"name": "idx_event_series_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_series_sort_order": {
+					"name": "idx_event_series_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_event_series_name": {
+					"name": "uq_event_series_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_series_name_lower": {
+					"name": "idx_event_series_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.events": {
+			"name": "events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"event_series_id": {
+					"name": "event_series_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"edition": {
+					"name": "edition",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_days": {
+					"name": "total_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"venue": {
+					"name": "venue",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_events_event_series_id": {
+					"name": "idx_events_event_series_id",
+					"columns": [
+						{
+							"expression": "event_series_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_events_edition": {
+					"name": "idx_events_edition",
+					"columns": [
+						{
+							"expression": "edition",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_events_start_date": {
+					"name": "idx_events_start_date",
+					"columns": [
+						{
+							"expression": "start_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_events_series_edition": {
+					"name": "uq_events_series_edition",
+					"columns": [
+						{
+							"expression": "event_series_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "edition",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"events_event_series_id_event_series_id_fk": {
+					"name": "events_event_series_id_event_series_id_fk",
+					"tableFrom": "events",
+					"tableTo": "event_series",
+					"columnsFrom": ["event_series_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.genres": {
+			"name": "genres",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"color": {
+					"name": "color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_genres_sort_order": {
+					"name": "idx_genres_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_genres": {
+			"name": "track_genres",
+			"schema": "",
+			"columns": {
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"genre_code": {
+					"name": "genre_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_genres_track": {
+					"name": "idx_track_genres_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_genres_genre": {
+					"name": "idx_track_genres_genre",
+					"columns": [
+						{
+							"expression": "genre_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_genres_track_position": {
+					"name": "idx_track_genres_track_position",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_genres_track_id_tracks_id_fk": {
+					"name": "track_genres_track_id_tracks_id_fk",
+					"tableFrom": "track_genres",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_genres_genre_code_genres_code_fk": {
+					"name": "track_genres_genre_code_genres_code_fk",
+					"tableFrom": "track_genres",
+					"tableTo": "genres",
+					"columnsFrom": ["genre_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"track_genres_track_id_genre_code_pk": {
+					"name": "track_genres_track_id_genre_code_pk",
+					"columns": ["track_id", "genre_code"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_track_genres_position": {
+					"name": "check_track_genres_position",
+					"value": "\"position\" >= 1 AND \"position\" <= 5"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.release_jan_codes": {
+			"name": "release_jan_codes",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"jan_code": {
+					"name": "jan_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"country_code": {
+					"name": "country_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_release_jan_codes_release": {
+					"name": "idx_release_jan_codes_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_release_jan_codes_jan": {
+					"name": "uq_release_jan_codes_jan",
+					"columns": [
+						{
+							"expression": "jan_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_release_jan_codes_primary": {
+					"name": "uq_release_jan_codes_primary",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"release_jan_codes\".\"is_primary\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"release_jan_codes_release_id_releases_id_fk": {
+					"name": "release_jan_codes_release_id_releases_id_fk",
+					"tableFrom": "release_jan_codes",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_isrcs": {
+			"name": "track_isrcs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"isrc": {
+					"name": "isrc",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_isrcs_track": {
+					"name": "idx_track_isrcs_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_isrcs": {
+					"name": "uq_track_isrcs",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "isrc",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_isrcs_primary": {
+					"name": "uq_track_isrcs_primary",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"track_isrcs\".\"is_primary\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_isrcs_track_id_tracks_id_fk": {
+					"name": "track_isrcs_track_id_tracks_id_fk",
+					"tableFrom": "track_isrcs",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.alias_types": {
+			"name": "alias_types",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_alias_types_sort_order": {
+					"name": "idx_alias_types_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.credit_roles": {
+			"name": "credit_roles",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_credit_roles_sort_order": {
+					"name": "idx_credit_roles_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_work_categories": {
+			"name": "official_work_categories",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_work_categories_sort_order": {
+					"name": "idx_official_work_categories_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.platforms": {
+			"name": "platforms",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url_pattern": {
+					"name": "url_pattern",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_platforms_category": {
+					"name": "idx_platforms_category",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_platforms_sort_order": {
+					"name": "idx_platforms_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_song_links": {
+			"name": "official_song_links",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"official_song_id": {
+					"name": "official_song_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_song_links_song_id": {
+					"name": "idx_official_song_links_song_id",
+					"columns": [
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_song_links_platform": {
+					"name": "idx_official_song_links_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_official_song_links_song_url": {
+					"name": "uq_official_song_links_song_url",
+					"columns": [
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_song_links_official_song_id_official_songs_id_fk": {
+					"name": "official_song_links_official_song_id_official_songs_id_fk",
+					"tableFrom": "official_song_links",
+					"tableTo": "official_songs",
+					"columnsFrom": ["official_song_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"official_song_links_platform_code_platforms_code_fk": {
+					"name": "official_song_links_platform_code_platforms_code_fk",
+					"tableFrom": "official_song_links",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_songs": {
+			"name": "official_songs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"official_work_id": {
+					"name": "official_work_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_number": {
+					"name": "track_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"composer_name": {
+					"name": "composer_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"arranger_name": {
+					"name": "arranger_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_original": {
+					"name": "is_original",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"source_song_id": {
+					"name": "source_song_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_songs_work": {
+					"name": "idx_official_songs_work",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_songs_source": {
+					"name": "idx_official_songs_source",
+					"columns": [
+						{
+							"expression": "source_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_songs_work_original": {
+					"name": "idx_official_songs_work_original",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "is_original",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_songs_official_work_id_official_works_id_fk": {
+					"name": "official_songs_official_work_id_official_works_id_fk",
+					"tableFrom": "official_songs",
+					"tableTo": "official_works",
+					"columnsFrom": ["official_work_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_work_links": {
+			"name": "official_work_links",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"official_work_id": {
+					"name": "official_work_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_work_links_work_id": {
+					"name": "idx_official_work_links_work_id",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_work_links_platform": {
+					"name": "idx_official_work_links_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_official_work_links_work_url": {
+					"name": "uq_official_work_links_work_url",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_work_links_official_work_id_official_works_id_fk": {
+					"name": "official_work_links_official_work_id_official_works_id_fk",
+					"tableFrom": "official_work_links",
+					"tableTo": "official_works",
+					"columnsFrom": ["official_work_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"official_work_links_platform_code_platforms_code_fk": {
+					"name": "official_work_links_platform_code_platforms_code_fk",
+					"tableFrom": "official_work_links",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_works": {
+			"name": "official_works",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"category_code": {
+					"name": "category_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"short_name_ja": {
+					"name": "short_name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"short_name_en": {
+					"name": "short_name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"number_in_series": {
+					"name": "number_in_series",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"official_organization": {
+					"name": "official_organization",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_works_category": {
+					"name": "idx_official_works_category",
+					"columns": [
+						{
+							"expression": "category_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_works_release_date": {
+					"name": "idx_official_works_release_date",
+					"columns": [
+						{
+							"expression": "release_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_works_position": {
+					"name": "idx_official_works_position",
+					"columns": [
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_works_category_code_official_work_categories_code_fk": {
+					"name": "official_works_category_code_official_work_categories_code_fk",
+					"tableFrom": "official_works",
+					"tableTo": "official_work_categories",
+					"columnsFrom": ["category_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.release_publications": {
+			"name": "release_publications",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_release_publications_release": {
+					"name": "idx_release_publications_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_release_publications_platform": {
+					"name": "idx_release_publications_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_release_publications_url": {
+					"name": "uq_release_publications_url",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"release_publications_release_id_releases_id_fk": {
+					"name": "release_publications_release_id_releases_id_fk",
+					"tableFrom": "release_publications",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"release_publications_platform_code_platforms_code_fk": {
+					"name": "release_publications_platform_code_platforms_code_fk",
+					"tableFrom": "release_publications",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_publications": {
+			"name": "track_publications",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_publications_track": {
+					"name": "idx_track_publications_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_publications_platform": {
+					"name": "idx_track_publications_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_publications_url": {
+					"name": "uq_track_publications_url",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_publications_track_id_tracks_id_fk": {
+					"name": "track_publications_track_id_tracks_id_fk",
+					"tableFrom": "track_publications",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_publications_platform_code_platforms_code_fk": {
+					"name": "track_publications_platform_code_platforms_code_fk",
+					"tableFrom": "track_publications",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.discs": {
+			"name": "discs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"disc_number": {
+					"name": "disc_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"disc_name": {
+					"name": "disc_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_discs_release": {
+					"name": "idx_discs_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_discs_release_number": {
+					"name": "uq_discs_release_number",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "disc_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"discs_release_id_releases_id_fk": {
+					"name": "discs_release_id_releases_id_fk",
+					"tableFrom": "discs",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.release_circles": {
+			"name": "release_circles",
+			"schema": "",
+			"columns": {
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"circle_id": {
+					"name": "circle_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"participation_type": {
+					"name": "participation_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 1
+				}
+			},
+			"indexes": {
+				"idx_release_circles_release": {
+					"name": "idx_release_circles_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_release_circles_circle": {
+					"name": "idx_release_circles_circle",
+					"columns": [
+						{
+							"expression": "circle_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_release_circles_release_participation": {
+					"name": "idx_release_circles_release_participation",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "participation_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"release_circles_release_id_releases_id_fk": {
+					"name": "release_circles_release_id_releases_id_fk",
+					"tableFrom": "release_circles",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"release_circles_circle_id_circles_id_fk": {
+					"name": "release_circles_circle_id_circles_id_fk",
+					"tableFrom": "release_circles",
+					"tableTo": "circles",
+					"columnsFrom": ["circle_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"release_circles_release_id_circle_id_participation_type_pk": {
+					"name": "release_circles_release_id_circle_id_participation_type_pk",
+					"columns": ["release_id", "circle_id", "participation_type"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.releases": {
+			"name": "releases",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_year": {
+					"name": "release_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_month": {
+					"name": "release_month",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_day": {
+					"name": "release_day",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_type": {
+					"name": "release_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_id": {
+					"name": "event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_day_id": {
+					"name": "event_day_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_releases_date": {
+					"name": "idx_releases_date",
+					"columns": [
+						{
+							"expression": "release_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_year": {
+					"name": "idx_releases_year",
+					"columns": [
+						{
+							"expression": "release_year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_year_month": {
+					"name": "idx_releases_year_month",
+					"columns": [
+						{
+							"expression": "release_year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "release_month",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_type": {
+					"name": "idx_releases_type",
+					"columns": [
+						{
+							"expression": "release_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_event": {
+					"name": "idx_releases_event",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_event_day": {
+					"name": "idx_releases_event_day",
+					"columns": [
+						{
+							"expression": "event_day_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_updated_at": {
+					"name": "idx_releases_updated_at",
+					"columns": [
+						{
+							"expression": "updated_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"releases_event_id_events_id_fk": {
+					"name": "releases_event_id_events_id_fk",
+					"tableFrom": "releases",
+					"tableTo": "events",
+					"columnsFrom": ["event_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"releases_event_day_id_event_days_id_fk": {
+					"name": "releases_event_day_id_event_days_id_fk",
+					"tableFrom": "releases",
+					"tableTo": "event_days",
+					"columnsFrom": ["event_day_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_release_year": {
+					"name": "check_release_year",
+					"value": "\"release_year\" >= 1900 AND \"release_year\" <= 2200"
+				},
+				"check_release_month": {
+					"name": "check_release_month",
+					"value": "\"release_month\" >= 1 AND \"release_month\" <= 12"
+				},
+				"check_release_day": {
+					"name": "check_release_day",
+					"value": "\"release_day\" >= 1 AND \"release_day\" <= 31"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.tags": {
+			"name": "tags",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attributes": {
+					"name": "attributes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_tags_attributes_gin": {
+					"name": "idx_tags_attributes_gin",
+					"columns": [
+						{
+							"expression": "attributes",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"tags_name_unique": {
+					"name": "tags_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_tags": {
+			"name": "track_tags",
+			"schema": "",
+			"columns": {
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tag_id": {
+					"name": "tag_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_locked": {
+					"name": "is_locked",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_tags_track": {
+					"name": "idx_track_tags_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_tags_tag": {
+					"name": "idx_track_tags_tag",
+					"columns": [
+						{
+							"expression": "tag_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_tags_track_locked_pos": {
+					"name": "idx_track_tags_track_locked_pos",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "is_locked",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_tags_track_id_tracks_id_fk": {
+					"name": "track_tags_track_id_tracks_id_fk",
+					"tableFrom": "track_tags",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_tags_tag_id_tags_id_fk": {
+					"name": "track_tags_tag_id_tags_id_fk",
+					"tableFrom": "track_tags",
+					"tableTo": "tags",
+					"columnsFrom": ["tag_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"track_tags_track_id_tag_id_pk": {
+					"name": "track_tags_track_id_tag_id_pk",
+					"columns": ["track_id", "tag_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_track_tags_position": {
+					"name": "check_track_tags_position",
+					"value": "\"position\" >= 1 AND \"position\" <= 15"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.track_credit_roles": {
+			"name": "track_credit_roles",
+			"schema": "",
+			"columns": {
+				"track_credit_id": {
+					"name": "track_credit_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role_code": {
+					"name": "role_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role_position": {
+					"name": "role_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				}
+			},
+			"indexes": {
+				"idx_track_credit_roles_credit": {
+					"name": "idx_track_credit_roles_credit",
+					"columns": [
+						{
+							"expression": "track_credit_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credit_roles_role": {
+					"name": "idx_track_credit_roles_role",
+					"columns": [
+						{
+							"expression": "role_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credit_roles_composite": {
+					"name": "idx_track_credit_roles_composite",
+					"columns": [
+						{
+							"expression": "track_credit_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "role_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_credit_roles_track_credit_id_track_credits_id_fk": {
+					"name": "track_credit_roles_track_credit_id_track_credits_id_fk",
+					"tableFrom": "track_credit_roles",
+					"tableTo": "track_credits",
+					"columnsFrom": ["track_credit_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_credit_roles_role_code_credit_roles_code_fk": {
+					"name": "track_credit_roles_role_code_credit_roles_code_fk",
+					"tableFrom": "track_credit_roles",
+					"tableTo": "credit_roles",
+					"columnsFrom": ["role_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"track_credit_roles_track_credit_id_role_code_role_position_pk": {
+					"name": "track_credit_roles_track_credit_id_role_code_role_position_pk",
+					"columns": ["track_credit_id", "role_code", "role_position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_credits": {
+			"name": "track_credits",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credit_name": {
+					"name": "credit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"alias_type_code": {
+					"name": "alias_type_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"credit_position": {
+					"name": "credit_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"artist_alias_id": {
+					"name": "artist_alias_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_credits_track": {
+					"name": "idx_track_credits_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_artist": {
+					"name": "idx_track_credits_artist",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_alias": {
+					"name": "idx_track_credits_alias",
+					"columns": [
+						{
+							"expression": "artist_alias_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_alias_type": {
+					"name": "idx_track_credits_alias_type",
+					"columns": [
+						{
+							"expression": "alias_type_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_track_artist": {
+					"name": "idx_track_credits_track_artist",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_artist_track": {
+					"name": "idx_track_credits_artist_track",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_credits_no_alias": {
+					"name": "uq_track_credits_no_alias",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"track_credits\".\"artist_alias_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_credits_with_alias": {
+					"name": "uq_track_credits_with_alias",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_alias_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"track_credits\".\"artist_alias_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_credits_track_id_tracks_id_fk": {
+					"name": "track_credits_track_id_tracks_id_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_credits_artist_id_artists_id_fk": {
+					"name": "track_credits_artist_id_artists_id_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "artists",
+					"columnsFrom": ["artist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				},
+				"track_credits_alias_type_code_alias_types_code_fk": {
+					"name": "track_credits_alias_type_code_alias_types_code_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "alias_types",
+					"columnsFrom": ["alias_type_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"track_credits_artist_alias_id_artist_aliases_id_fk": {
+					"name": "track_credits_artist_alias_id_artist_aliases_id_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "artist_aliases",
+					"columnsFrom": ["artist_alias_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracks": {
+			"name": "tracks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"disc_id": {
+					"name": "disc_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_number": {
+					"name": "track_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_year": {
+					"name": "release_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_month": {
+					"name": "release_month",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_day": {
+					"name": "release_day",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_id": {
+					"name": "event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_day_id": {
+					"name": "event_day_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_tracks_release": {
+					"name": "idx_tracks_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_disc": {
+					"name": "idx_tracks_disc",
+					"columns": [
+						{
+							"expression": "disc_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_date": {
+					"name": "idx_tracks_date",
+					"columns": [
+						{
+							"expression": "release_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_year": {
+					"name": "idx_tracks_year",
+					"columns": [
+						{
+							"expression": "release_year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_event": {
+					"name": "idx_tracks_event",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_event_day": {
+					"name": "idx_tracks_event_day",
+					"columns": [
+						{
+							"expression": "event_day_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_ordering": {
+					"name": "idx_tracks_ordering",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "disc_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_tracks_release_tracknumber": {
+					"name": "uq_tracks_release_tracknumber",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"tracks\".\"disc_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_tracks_disc_tracknumber": {
+					"name": "uq_tracks_disc_tracknumber",
+					"columns": [
+						{
+							"expression": "disc_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"tracks\".\"disc_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracks_release_id_releases_id_fk": {
+					"name": "tracks_release_id_releases_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracks_disc_id_discs_id_fk": {
+					"name": "tracks_disc_id_discs_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "discs",
+					"columnsFrom": ["disc_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracks_event_id_events_id_fk": {
+					"name": "tracks_event_id_events_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "events",
+					"columnsFrom": ["event_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"tracks_event_day_id_event_days_id_fk": {
+					"name": "tracks_event_day_id_event_days_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "event_days",
+					"columnsFrom": ["event_day_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_derivations": {
+			"name": "track_derivations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"child_track_id": {
+					"name": "child_track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"parent_track_id": {
+					"name": "parent_track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_derivations_child": {
+					"name": "idx_track_derivations_child",
+					"columns": [
+						{
+							"expression": "child_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_derivations_parent": {
+					"name": "idx_track_derivations_parent",
+					"columns": [
+						{
+							"expression": "parent_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_derivations": {
+					"name": "uq_track_derivations",
+					"columns": [
+						{
+							"expression": "child_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "parent_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_derivations_child_track_id_tracks_id_fk": {
+					"name": "track_derivations_child_track_id_tracks_id_fk",
+					"tableFrom": "track_derivations",
+					"tableTo": "tracks",
+					"columnsFrom": ["child_track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_derivations_parent_track_id_tracks_id_fk": {
+					"name": "track_derivations_parent_track_id_tracks_id_fk",
+					"tableFrom": "track_derivations",
+					"tableTo": "tracks",
+					"columnsFrom": ["parent_track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_official_songs": {
+			"name": "track_official_songs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"official_song_id": {
+					"name": "official_song_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"custom_song_name": {
+					"name": "custom_song_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"part_position": {
+					"name": "part_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_second": {
+					"name": "start_second",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"end_second": {
+					"name": "end_second",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_official_songs_track": {
+					"name": "idx_track_official_songs_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_official_songs_song": {
+					"name": "idx_track_official_songs_song",
+					"columns": [
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_official_songs": {
+					"name": "uq_track_official_songs",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "part_position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_official_songs_track_id_tracks_id_fk": {
+					"name": "track_official_songs_track_id_tracks_id_fk",
+					"tableFrom": "track_official_songs",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_official_songs_official_song_id_official_songs_id_fk": {
+					"name": "track_official_songs_official_song_id_official_songs_id_fk",
+					"tableFrom": "track_official_songs",
+					"tableTo": "official_songs",
+					"columnsFrom": ["official_song_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1770775729518,
 			"tag": "0003_cooing_betty_brant",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1777213613998,
+			"tag": "0004_great_beast",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/schema/album-request.ts
+++ b/packages/db/src/schema/album-request.ts
@@ -1,0 +1,111 @@
+import { type InferSelectModel, relations, sql } from "drizzle-orm";
+import {
+	check,
+	index,
+	jsonb,
+	pgTable,
+	text,
+	timestamp,
+} from "drizzle-orm/pg-core";
+import { user } from "./auth";
+import { releases } from "./release";
+
+// アルバム申請ステータスの定義
+export const ALBUM_REQUEST_STATUSES = [
+	"pending",
+	"approved",
+	"rejected",
+] as const;
+
+export type AlbumRequestStatus = (typeof ALBUM_REQUEST_STATUSES)[number];
+
+// アルバム申請タイプの定義
+export const ALBUM_REQUEST_TYPES = ["new", "existing"] as const;
+
+export type AlbumRequestType = (typeof ALBUM_REQUEST_TYPES)[number];
+
+// 参考URL型
+export type AlbumRequestReferenceUrl = { url: string; label?: string };
+
+// アルバム申請テーブル
+export const albumRequests = pgTable(
+	"album_requests",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "restrict" }),
+		requestType: text("request_type").notNull(),
+		existingReleaseId: text("existing_release_id").references(
+			() => releases.id,
+			{ onDelete: "set null" },
+		),
+		albumName: text("album_name"),
+		circleName: text("circle_name"),
+		referenceUrls: jsonb("reference_urls")
+			.$type<AlbumRequestReferenceUrl[]>()
+			.notNull()
+			.default(sql`'[]'::jsonb`),
+		notes: text("notes"),
+		status: text("status").notNull().default("pending"),
+		reviewedByUserId: text("reviewed_by_user_id").references(() => user.id, {
+			onDelete: "set null",
+		}),
+		reviewerNotes: text("reviewer_notes"),
+		reviewedAt: timestamp("reviewed_at", { withTimezone: true }),
+		createdAt: timestamp("created_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.defaultNow()
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => [
+		index("idx_album_requests_user").on(table.userId),
+		index("idx_album_requests_existing_release").on(table.existingReleaseId),
+		index("idx_album_requests_status").on(table.status),
+		index("idx_album_requests_created_at").on(table.createdAt),
+		index("idx_album_requests_status_created_at").on(
+			table.status,
+			table.createdAt,
+		),
+		index("idx_album_requests_reviewed_by").on(table.reviewedByUserId),
+		check(
+			"check_album_request_status",
+			sql`status IN ('pending','approved','rejected')`,
+		),
+		check("check_album_request_type", sql`request_type IN ('new','existing')`),
+		check(
+			"check_album_request_type_consistency",
+			sql`(request_type='existing' AND existing_release_id IS NOT NULL)
+        OR (request_type='new' AND album_name IS NOT NULL)`,
+		),
+		check(
+			"check_album_request_review_consistency",
+			sql`(status='pending' AND reviewed_at IS NULL AND reviewed_by_user_id IS NULL)
+        OR (status<>'pending' AND reviewed_at IS NOT NULL AND reviewed_by_user_id IS NOT NULL)`,
+		),
+	],
+);
+
+// リレーション定義
+export const albumRequestRelations = relations(albumRequests, ({ one }) => ({
+	user: one(user, {
+		fields: [albumRequests.userId],
+		references: [user.id],
+		relationName: "albumRequestUser",
+	}),
+	reviewer: one(user, {
+		fields: [albumRequests.reviewedByUserId],
+		references: [user.id],
+		relationName: "albumRequestReviewer",
+	}),
+	existingRelease: one(releases, {
+		fields: [albumRequests.existingReleaseId],
+		references: [releases.id],
+	}),
+}));
+
+// Type exports
+export type AlbumRequest = InferSelectModel<typeof albumRequests>;

--- a/packages/db/src/schema/album-request.validation.ts
+++ b/packages/db/src/schema/album-request.validation.ts
@@ -1,0 +1,99 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { albumRequests } from "./album-request";
+
+// HTTP URLスキーマ
+const httpUrlSchema = z
+	.string()
+	.trim()
+	.url()
+	.regex(/^https?:\/\//i, "URLはhttp(s)://から始めてください")
+	.max(2048, "URLは2048文字以内で入力してください");
+
+// 参考URLアイテムスキーマ
+const referenceUrlItemSchema = z.object({
+	url: httpUrlSchema,
+	label: z
+		.string()
+		.trim()
+		.max(100, "ラベルは100文字以内で入力してください")
+		.optional(),
+});
+
+// 参考URLリストスキーマ
+export const referenceUrlsSchema = z
+	.array(referenceUrlItemSchema)
+	.min(1, "参考URLを1件以上入力してください")
+	.max(10, "参考URLは最大10件までです");
+
+// 新規アルバム申請スキーマ
+const newAlbumRequestSchema = z.object({
+	requestType: z.literal("new"),
+	existingReleaseId: z.undefined().optional(),
+	albumName: z
+		.string()
+		.trim()
+		.min(1, "アルバム名は必須です")
+		.max(200, "アルバム名は200文字以内で入力してください"),
+	circleName: z
+		.string()
+		.trim()
+		.max(200, "サークル名は200文字以内で入力してください")
+		.optional(),
+	referenceUrls: referenceUrlsSchema,
+	notes: z
+		.string()
+		.trim()
+		.max(2000, "補足は2000文字以内で入力してください")
+		.optional(),
+});
+
+// 既存アルバムへの追記申請スキーマ
+const existingAlbumRequestSchema = z.object({
+	requestType: z.literal("existing"),
+	existingReleaseId: z.string().min(1, "既存アルバムを選択してください"),
+	albumName: z
+		.string()
+		.trim()
+		.max(200, "アルバム名は200文字以内で入力してください")
+		.optional(),
+	circleName: z
+		.string()
+		.trim()
+		.max(200, "サークル名は200文字以内で入力してください")
+		.optional(),
+	referenceUrls: referenceUrlsSchema,
+	notes: z
+		.string()
+		.trim()
+		.max(2000, "補足は2000文字以内で入力してください")
+		.optional(),
+});
+
+// アルバム申請作成スキーマ（requestTypeで分岐）
+export const createAlbumRequestSchema = z.discriminatedUnion("requestType", [
+	newAlbumRequestSchema,
+	existingAlbumRequestSchema,
+]);
+
+// アルバム申請ステータス更新スキーマ（楽観的ロック用updatedAt必須）
+export const updateAlbumRequestStatusSchema = z.object({
+	status: z.enum(["approved", "rejected"]),
+	reviewerNotes: z
+		.string()
+		.trim()
+		.max(2000, "レビューメモは2000文字以内で入力してください")
+		.optional()
+		.nullable(),
+	updatedAt: z.string(),
+});
+
+// selectスキーマ
+export const selectAlbumRequestSchema = createSelectSchema(albumRequests);
+
+// Type exports
+export type CreateAlbumRequest = z.infer<typeof createAlbumRequestSchema>;
+export type UpdateAlbumRequestStatus = z.infer<
+	typeof updateAlbumRequestStatusSchema
+>;
+export type SelectAlbumRequest = z.infer<typeof selectAlbumRequestSchema>;

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,3 +1,5 @@
+export * from "./album-request";
+export * from "./album-request.validation";
 export * from "./artist-circle";
 export * from "./artist-circle.validation";
 export * from "./auth";

--- a/packages/db/src/truncate-non-master.ts
+++ b/packages/db/src/truncate-non-master.ts
@@ -5,6 +5,7 @@ const { client, db } = createScriptClient();
 
 // Non-master tables to truncate
 const NON_MASTER_TABLES = [
+	"album_requests",
 	"track_derivations",
 	"track_official_songs",
 	"track_credit_roles",

--- a/packages/db/src/utils/id.ts
+++ b/packages/db/src/utils/id.ts
@@ -21,4 +21,5 @@ export const createId = {
 	officialWorkLink: () => typeid("wl").toString(),
 	officialSongLink: () => typeid("sl").toString(),
 	tag: () => typeid("tag").toString(),
+	albumRequest: () => typeid("aq").toString(),
 } as const;


### PR DESCRIPTION
## 概要

提供者が新規アルバムの登録依頼や既存アルバムへの情報追記を送信し、管理者が承認/却下するワークフローを追加。提供者の手間を最小化（参考URL中心の入力）し、ログイン必須で悪用を抑制。

## 変更内容

### データモデル
* `album_requests` テーブルを新設（`packages/db/src/schema/album-request.ts`）
  - `status`: pending / approved / rejected
  - `requestType`: new / existing
  - `referenceUrls` を `jsonb` で保持（`{ url, label? }[]`）
  - `pgEnum` 不使用、`as const` + check 制約パターンを踏襲
  - 4つの check 制約で型・整合性をDB層で保証
* `0004_great_beast.sql` マイグレーション追加

### API
* 新規ミドルウェア `requireUserMiddleware`（`apps/server/src/middleware/user-auth.ts`）
* ログイン必須名前空間 `/api/user/*` を新設
  - `POST /api/user/album-requests` - リクエスト送信
  - `GET /api/user/album-requests` - 自分のリクエスト一覧
* 管理API（`/api/admin/album-requests`）
  - `GET /` 一覧（status フィルタ、ページネ、新着順）
  - `GET /pending-count` サイドバーバッジ用（Cache-Control: private, max-age=30）
  - `GET /:id` 詳細
  - `PATCH /:id` 承認/却下（楽観的ロック + UPDATE WHERE status='pending' で二重処理を防止）
* バリデーションは `packages/db/src/schema/album-request.validation.ts` に集約し、`z.discriminatedUnion` で new/existing を型安全に分岐

### UI（提供者）
* `/user/album-requests/new` 提供フォーム（未ログインなら `/login?returnTo=...` へリダイレクト）
* `/user/album-requests` 自分のリクエスト一覧
* `UserMenu` ドロップダウンに「アルバム情報の提供」リンク追加
* TanStack Form + Zod。`SearchableSelect` で既存リリース検索（debounce 300ms）

### UI（管理者）
* `/admin/album-requests` 一覧（status タブ、新着順、ページネ、検索）
* `/admin/album-requests/:id` 詳細（提供者・参考URL・既存追記対象リンク・レビュー履歴・承認/却下ボタン）
* サイドバーに pending 件数バッジ（staleTime 30s, refetchInterval 60s）

### テスト
* 統合テスト 37 ケース追加（admin: 22 / user: 15）
* 認可、バリデーション、楽観的ロック競合、二重処理防止、自分のリクエストのみ取得など網羅
* 全体 977 pass / 0 fail

## 影響範囲

* 新規テーブル `album_requests` 追加（既存テーブルへの破壊的変更なし）
* `apps/server/src/index.ts` に `/api/user` マウント追加
* `apps/web/src/components/ui/searchable-select.tsx` に `onSearchChange` prop を追加（オプショナル、後方互換）
* `packages/db/package.json` の `exports` に `./schema/*` サブパスを追加（バリデーションスキーマを web から import するため）
* `make db-truncate` の `NON_MASTER_TABLES` に `album_requests` を追加

## 補足事項

* **承認 = ステータス変更のみ**。`releases` への正式登録は既存の `/admin/releases` で別途手動で行う（提供情報が最小限のため自動コピーは行わない）
* 通知機構（メール/Slack）は導入せず、管理画面サイドバーのバッジで未処理件数を表示
* 一度確定（approved/rejected）したリクエストは pending に戻せない（履歴の明瞭性のため）
* 残存 Minor 指摘（別PRで対応予定）:
  - `updatedAt` の Zod を `z.string().datetime()` に強化
  - `status` クエリパラメータを `z.enum(...).optional()` で防御
  - テーブルホバーを `hover:bg-base-300` に（daisyUI v5 規約）
  - `/user/album-requests` の loader プリフェッチ追加
  - 参考URL表示時の `javascript:` スキーム追加防御