### PR TITLE
feat: ユーザーコレクション+お気に入り機能 (Phase 1)

### DIFF
--- a/apps/server/src/constants/error-messages.ts
+++ b/apps/server/src/constants/error-messages.ts
@@ -75,6 +75,20 @@ export const ERROR_MESSAGES = {
 		"この公式楽曲は既に同じ順序でこのトラックに紐付けられています",
 	ITEMS_REQUIRED_NON_EMPTY: "itemsは必須で、空でない配列である必要があります",
 
+	// ===== コレクション関連 =====
+	COLLECTION_NOT_FOUND: "コレクションが見つかりません",
+	COLLECTION_DEFAULT_LIKED_DELETE_FORBIDDEN:
+		"デフォルトのお気に入りコレクションは削除できません",
+	COLLECTION_LIMIT_EXCEEDED: "コレクション数の上限（100件）を超えています",
+	COLLECTION_ITEM_LIMIT_EXCEEDED:
+		"1コレクションに登録できるアイテム数の上限（1000件）を超えています",
+	COLLECTION_ITEM_NOT_FOUND: "コレクションアイテムが見つかりません",
+	COLLECTION_TARGET_NOT_FOUND: "対象が見つかりません",
+	COLLECTION_REORDER_NOT_ORDERED:
+		"並び替えできないコレクションです（ordered=false）",
+	COLLECTION_REORDER_INVALID:
+		"並び替えデータが不正です（itemIdが一致しないかpositionに重複/欠番があります）",
+
 	// ===== 削除制約エラー =====
 	CANNOT_DELETE_SERIES_WITH_EVENTS:
 		"関連するイベントがあるため、このシリーズは削除できません",

--- a/apps/server/src/constants/error-messages.ts
+++ b/apps/server/src/constants/error-messages.ts
@@ -75,6 +75,10 @@ export const ERROR_MESSAGES = {
 		"この公式楽曲は既に同じ順序でこのトラックに紐付けられています",
 	ITEMS_REQUIRED_NON_EMPTY: "itemsは必須で、空でない配列である必要があります",
 
+	// ===== お気に入り関連 =====
+	LIKE_TARGET_NOT_FOUND: "対象が見つかりません",
+	LIKE_NOT_FOUND: "お気に入りに登録されていません",
+
 	// ===== コレクション関連 =====
 	COLLECTION_NOT_FOUND: "コレクションが見つかりません",
 	COLLECTION_DEFAULT_LIKED_DELETE_FORBIDDEN:

--- a/apps/server/src/routes/public/collections.ts
+++ b/apps/server/src/routes/public/collections.ts
@@ -1,4 +1,4 @@
-import { db, eq, userCollections } from "@thac/db";
+import { db, eq, user, userCollections } from "@thac/db";
 import { Hono } from "hono";
 import { handleDbError } from "../../utils/api-error";
 import { loadCollectionItemsWithTargets } from "../../utils/collection-items-loader";
@@ -21,6 +21,7 @@ publicCollectionsRouter.get("/:shortId", async (c) => {
 				shortId: userCollections.shortId,
 				createdAt: userCollections.createdAt,
 				updatedAt: userCollections.updatedAt,
+				userId: userCollections.userId,
 			})
 			.from(userCollections)
 			.where(eq(userCollections.shortId, shortId))
@@ -37,9 +38,23 @@ publicCollectionsRouter.get("/:shortId", async (c) => {
 			return c.json({ error: "Not found", code: "NOT_FOUND" }, 404);
 		}
 
+		// owner 情報を取得
+		const ownerRows = await db
+			.select({ id: user.id, name: user.name })
+			.from(user)
+			.where(eq(user.id, collection.userId))
+			.limit(1);
+
+		const owner = ownerRows[0] ?? {
+			id: collection.userId,
+			name: "不明なユーザー",
+		};
+
 		const items = await loadCollectionItemsWithTargets(collection.id);
 
-		return c.json({ collection, items });
+		const { userId: _, ...collectionWithoutUserId } = collection;
+
+		return c.json({ collection: { ...collectionWithoutUserId, owner }, items });
 	} catch (error) {
 		return handleDbError(c, error, "GET /public/collections/:shortId");
 	}

--- a/apps/server/src/routes/public/collections.ts
+++ b/apps/server/src/routes/public/collections.ts
@@ -1,0 +1,48 @@
+import { db, eq, userCollections } from "@thac/db";
+import { Hono } from "hono";
+import { handleDbError } from "../../utils/api-error";
+import { loadCollectionItemsWithTargets } from "../../utils/collection-items-loader";
+
+const publicCollectionsRouter = new Hono();
+
+// 公開コレクション詳細取得（unlisted/public のみ閲覧可、private は 404）
+publicCollectionsRouter.get("/:shortId", async (c) => {
+	try {
+		const shortId = c.req.param("shortId");
+
+		const collectionRows = await db
+			.select({
+				id: userCollections.id,
+				name: userCollections.name,
+				description: userCollections.description,
+				kind: userCollections.kind,
+				visibility: userCollections.visibility,
+				ordered: userCollections.ordered,
+				shortId: userCollections.shortId,
+				createdAt: userCollections.createdAt,
+				updatedAt: userCollections.updatedAt,
+			})
+			.from(userCollections)
+			.where(eq(userCollections.shortId, shortId))
+			.limit(1);
+
+		const collection = collectionRows[0];
+
+		if (!collection) {
+			return c.json({ error: "Not found", code: "NOT_FOUND" }, 404);
+		}
+
+		// private は 404 で隠蔽（情報漏洩防止）
+		if (collection.visibility === "private") {
+			return c.json({ error: "Not found", code: "NOT_FOUND" }, 404);
+		}
+
+		const items = await loadCollectionItemsWithTargets(collection.id);
+
+		return c.json({ collection, items });
+	} catch (error) {
+		return handleDbError(c, error, "GET /public/collections/:shortId");
+	}
+});
+
+export { publicCollectionsRouter };

--- a/apps/server/src/routes/public/collections.ts
+++ b/apps/server/src/routes/public/collections.ts
@@ -18,6 +18,7 @@ publicCollectionsRouter.get("/:shortId", async (c) => {
 				kind: userCollections.kind,
 				visibility: userCollections.visibility,
 				ordered: userCollections.ordered,
+				itemType: userCollections.itemType,
 				shortId: userCollections.shortId,
 				createdAt: userCollections.createdAt,
 				updatedAt: userCollections.updatedAt,

--- a/apps/server/src/routes/public/index.ts
+++ b/apps/server/src/routes/public/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { artistsRouter } from "./artists";
 import { categoriesRouter } from "./categories";
 import { circlesRouter } from "./circles";
+import { publicCollectionsRouter } from "./collections";
 import { eventSeriesRouter } from "./event-series";
 import { eventsRouter } from "./events";
 import { genresRouter } from "./genres";
@@ -29,5 +30,6 @@ publicRouter.route("/tracks", tracksRouter);
 publicRouter.route("/tags", tagsRouter);
 publicRouter.route("/stats", statsRouter);
 publicRouter.route("/search", searchRouter);
+publicRouter.route("/collections", publicCollectionsRouter);
 
 export { publicRouter };

--- a/apps/server/src/routes/user/collections.ts
+++ b/apps/server/src/routes/user/collections.ts
@@ -1,7 +1,6 @@
 import {
 	addUserCollectionItemSchema,
 	and,
-	asc,
 	circles,
 	count,
 	createId,
@@ -9,7 +8,6 @@ import {
 	db,
 	desc,
 	eq,
-	inArray,
 	max,
 	releases,
 	reorderUserCollectionItemsSchema,
@@ -23,6 +21,7 @@ import { nanoid } from "nanoid";
 import { ERROR_MESSAGES } from "../../constants/error-messages";
 import type { UserAuthContext } from "../../middleware/user-auth";
 import { handleDbError } from "../../utils/api-error";
+import { loadCollectionItemsWithTargets } from "../../utils/collection-items-loader";
 
 const collectionsUserRouter = new Hono<UserAuthContext>();
 
@@ -141,7 +140,9 @@ collectionsUserRouter.get("/:id", async (c) => {
 			)
 			.limit(1);
 
-		if (collectionRows.length === 0) {
+		const collection = collectionRows[0];
+
+		if (!collection) {
 			return c.json(
 				{
 					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
@@ -151,80 +152,7 @@ collectionsUserRouter.get("/:id", async (c) => {
 			);
 		}
 
-		const collection = collectionRows[0];
-
-		const items = await db
-			.select()
-			.from(userCollectionItems)
-			.where(eq(userCollectionItems.collectionId, collectionId))
-			.orderBy(
-				asc(userCollectionItems.position),
-				desc(userCollectionItems.addedAt),
-			);
-
-		const trackIds = items
-			.filter((i) => i.targetType === "track")
-			.map((i) => i.targetId);
-		const releaseIds = items
-			.filter((i) => i.targetType === "release")
-			.map((i) => i.targetId);
-		const circleIds = items
-			.filter((i) => i.targetType === "circle")
-			.map((i) => i.targetId);
-
-		const [trackRows, releaseRows, circleRows] = await Promise.all([
-			trackIds.length > 0
-				? db
-						.select({
-							id: tracks.id,
-							name: tracks.name,
-							nameJa: tracks.nameJa,
-							nameEn: tracks.nameEn,
-							releaseId: tracks.releaseId,
-						})
-						.from(tracks)
-						.where(inArray(tracks.id, trackIds))
-				: Promise.resolve([]),
-			releaseIds.length > 0
-				? db
-						.select({
-							id: releases.id,
-							name: releases.name,
-							nameJa: releases.nameJa,
-							nameEn: releases.nameEn,
-							releaseDate: releases.releaseDate,
-						})
-						.from(releases)
-						.where(inArray(releases.id, releaseIds))
-				: Promise.resolve([]),
-			circleIds.length > 0
-				? db
-						.select({
-							id: circles.id,
-							name: circles.name,
-							nameJa: circles.nameJa,
-							nameEn: circles.nameEn,
-						})
-						.from(circles)
-						.where(inArray(circles.id, circleIds))
-				: Promise.resolve([]),
-		]);
-
-		const trackMap = new Map(trackRows.map((r) => [r.id, r]));
-		const releaseMap = new Map(releaseRows.map((r) => [r.id, r]));
-		const circleMap = new Map(circleRows.map((r) => [r.id, r]));
-
-		const itemsWithTarget = items.map((item) => {
-			let target: unknown = null;
-			if (item.targetType === "track") {
-				target = trackMap.get(item.targetId) ?? null;
-			} else if (item.targetType === "release") {
-				target = releaseMap.get(item.targetId) ?? null;
-			} else if (item.targetType === "circle") {
-				target = circleMap.get(item.targetId) ?? null;
-			}
-			return { ...item, target };
-		});
+		const itemsWithTarget = await loadCollectionItemsWithTargets(collectionId);
 
 		return c.json({ ...collection, items: itemsWithTarget });
 	} catch (error) {

--- a/apps/server/src/routes/user/collections.ts
+++ b/apps/server/src/routes/user/collections.ts
@@ -1,6 +1,7 @@
 import {
 	addUserCollectionItemSchema,
 	and,
+	artists,
 	circles,
 	count,
 	createId,
@@ -37,7 +38,8 @@ collectionsUserRouter.get("/", async (c) => {
 		const hasTarget =
 			(targetType === "track" ||
 				targetType === "release" ||
-				targetType === "circle") &&
+				targetType === "circle" ||
+				targetType === "artist") &&
 			!!targetId;
 
 		const excludeDefaultLiked = c.req.query("excludeDefaultLiked") === "true";
@@ -63,11 +65,16 @@ collectionsUserRouter.get("/", async (c) => {
 						and(
 							eq(
 								userCollectionItems.targetType,
-								targetType as "track" | "release" | "circle",
+								targetType as "track" | "release" | "circle" | "artist",
 							),
 							eq(userCollectionItems.targetId, targetId),
 						),
 					),
+			);
+
+			// targetType に一致する itemType のコレクションのみ表示（Liked は除外済み、itemType=null の場合も含む）
+			conditions.push(
+				sql`(${userCollections.itemType} IS NULL OR ${userCollections.itemType} = ${targetType})`,
 			);
 
 			const rows = await db
@@ -80,6 +87,7 @@ collectionsUserRouter.get("/", async (c) => {
 					visibility: userCollections.visibility,
 					ordered: userCollections.ordered,
 					isDefaultLiked: userCollections.isDefaultLiked,
+					itemType: userCollections.itemType,
 					shortId: userCollections.shortId,
 					coverImageUrl: userCollections.coverImageUrl,
 					createdAt: userCollections.createdAt,
@@ -110,6 +118,7 @@ collectionsUserRouter.get("/", async (c) => {
 				visibility: userCollections.visibility,
 				ordered: userCollections.ordered,
 				isDefaultLiked: userCollections.isDefaultLiked,
+				itemType: userCollections.itemType,
 				shortId: userCollections.shortId,
 				coverImageUrl: userCollections.coverImageUrl,
 				createdAt: userCollections.createdAt,
@@ -164,7 +173,8 @@ collectionsUserRouter.post("/", async (c) => {
 			);
 		}
 
-		const { name, description, kind, visibility, ordered } = parsed.data;
+		const { name, description, kind, visibility, ordered, itemType } =
+			parsed.data;
 		const shortId =
 			visibility === "unlisted" || visibility === "public" ? nanoid(8) : null;
 
@@ -178,6 +188,7 @@ collectionsUserRouter.post("/", async (c) => {
 				kind: kind ?? "collection",
 				visibility: visibility ?? "private",
 				ordered: ordered ?? false,
+				itemType: itemType ?? null,
 				shortId,
 			})
 			.returning();
@@ -417,7 +428,10 @@ collectionsUserRouter.post("/:id/items", async (c) => {
 
 		// コレクション存在 & 所有確認
 		const collectionRows = await db
-			.select({ ordered: userCollections.ordered })
+			.select({
+				ordered: userCollections.ordered,
+				itemType: userCollections.itemType,
+			})
 			.from(userCollections)
 			.where(
 				and(
@@ -445,6 +459,20 @@ collectionsUserRouter.post("/:id/items", async (c) => {
 					code: "NOT_FOUND",
 				},
 				404,
+			);
+		}
+
+		// itemType 整合性チェック（itemType=null の場合は全種別 OK）
+		if (
+			collectionMeta.itemType !== null &&
+			collectionMeta.itemType !== parsed.data.targetType
+		) {
+			return c.json(
+				{
+					error: `このコレクションには ${collectionMeta.itemType} 種別のアイテムのみ追加できます`,
+					code: "VALIDATION_ERROR",
+				},
+				400,
 			);
 		}
 
@@ -492,6 +520,15 @@ collectionsUserRouter.post("/:id/items", async (c) => {
 					.select({ id: circles.id })
 					.from(circles)
 					.where(eq(circles.id, targetId))
+					.limit(1);
+				exists = r.length > 0;
+				break;
+			}
+			case "artist": {
+				const r = await db
+					.select({ id: artists.id })
+					.from(artists)
+					.where(eq(artists.id, targetId))
 					.limit(1);
 				exists = r.length > 0;
 				break;

--- a/apps/server/src/routes/user/collections.ts
+++ b/apps/server/src/routes/user/collections.ts
@@ -1,0 +1,740 @@
+import {
+	addUserCollectionItemSchema,
+	and,
+	asc,
+	circles,
+	count,
+	createId,
+	createUserCollectionSchema,
+	db,
+	desc,
+	eq,
+	inArray,
+	max,
+	releases,
+	reorderUserCollectionItemsSchema,
+	tracks,
+	updateUserCollectionSchema,
+	userCollectionItems,
+	userCollections,
+} from "@thac/db";
+import { Hono } from "hono";
+import { nanoid } from "nanoid";
+import { ERROR_MESSAGES } from "../../constants/error-messages";
+import type { UserAuthContext } from "../../middleware/user-auth";
+import { handleDbError } from "../../utils/api-error";
+
+const collectionsUserRouter = new Hono<UserAuthContext>();
+
+// 自分のコレクション一覧取得（kindフィルタ可、アイテム数を含む）
+collectionsUserRouter.get("/", async (c) => {
+	try {
+		const user = c.get("user");
+		const kindParam = c.req.query("kind");
+
+		const conditions = [eq(userCollections.userId, user.id)];
+		if (kindParam === "collection" || kindParam === "playlist") {
+			conditions.push(eq(userCollections.kind, kindParam));
+		}
+
+		const rows = await db
+			.select({
+				id: userCollections.id,
+				kind: userCollections.kind,
+				name: userCollections.name,
+				description: userCollections.description,
+				visibility: userCollections.visibility,
+				ordered: userCollections.ordered,
+				isDefaultLiked: userCollections.isDefaultLiked,
+				shortId: userCollections.shortId,
+				coverImageUrl: userCollections.coverImageUrl,
+				createdAt: userCollections.createdAt,
+				updatedAt: userCollections.updatedAt,
+				itemCount: count(userCollectionItems.id),
+			})
+			.from(userCollections)
+			.leftJoin(
+				userCollectionItems,
+				eq(userCollectionItems.collectionId, userCollections.id),
+			)
+			.where(and(...conditions))
+			.groupBy(userCollections.id)
+			.orderBy(desc(userCollections.createdAt));
+
+		return c.json({ items: rows });
+	} catch (error) {
+		return handleDbError(c, error, "GET /user/collections");
+	}
+});
+
+// コレクション新規作成（最大100件/ユーザーチェック）
+collectionsUserRouter.post("/", async (c) => {
+	try {
+		const body = await c.req.json();
+		const parsed = createUserCollectionSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					code: "VALIDATION_ERROR",
+					details: parsed.error.flatten(),
+				},
+				400,
+			);
+		}
+
+		const user = c.get("user");
+
+		const existing = await db
+			.select({ count: count() })
+			.from(userCollections)
+			.where(eq(userCollections.userId, user.id));
+		const total = Number(existing[0]?.count ?? 0);
+		if (total >= 100) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_LIMIT_EXCEEDED,
+					code: "VALIDATION_ERROR",
+				},
+				422,
+			);
+		}
+
+		const { name, description, kind, visibility, ordered } = parsed.data;
+		const shortId =
+			visibility === "unlisted" || visibility === "public" ? nanoid(8) : null;
+
+		const inserted = await db
+			.insert(userCollections)
+			.values({
+				id: createId.userCollection(),
+				userId: user.id,
+				name,
+				description: description ?? null,
+				kind: kind ?? "collection",
+				visibility: visibility ?? "private",
+				ordered: ordered ?? false,
+				shortId,
+			})
+			.returning();
+
+		return c.json(inserted[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /user/collections");
+	}
+});
+
+// コレクション詳細取得（アイテム一覧 + target エンティティ付き）
+collectionsUserRouter.get("/:id", async (c) => {
+	try {
+		const user = c.get("user");
+		const collectionId = c.req.param("id");
+
+		const collectionRows = await db
+			.select()
+			.from(userCollections)
+			.where(
+				and(
+					eq(userCollections.id, collectionId),
+					eq(userCollections.userId, user.id),
+				),
+			)
+			.limit(1);
+
+		if (collectionRows.length === 0) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		const collection = collectionRows[0];
+
+		const items = await db
+			.select()
+			.from(userCollectionItems)
+			.where(eq(userCollectionItems.collectionId, collectionId))
+			.orderBy(
+				asc(userCollectionItems.position),
+				desc(userCollectionItems.addedAt),
+			);
+
+		const trackIds = items
+			.filter((i) => i.targetType === "track")
+			.map((i) => i.targetId);
+		const releaseIds = items
+			.filter((i) => i.targetType === "release")
+			.map((i) => i.targetId);
+		const circleIds = items
+			.filter((i) => i.targetType === "circle")
+			.map((i) => i.targetId);
+
+		const [trackRows, releaseRows, circleRows] = await Promise.all([
+			trackIds.length > 0
+				? db
+						.select({
+							id: tracks.id,
+							name: tracks.name,
+							nameJa: tracks.nameJa,
+							nameEn: tracks.nameEn,
+							releaseId: tracks.releaseId,
+						})
+						.from(tracks)
+						.where(inArray(tracks.id, trackIds))
+				: Promise.resolve([]),
+			releaseIds.length > 0
+				? db
+						.select({
+							id: releases.id,
+							name: releases.name,
+							nameJa: releases.nameJa,
+							nameEn: releases.nameEn,
+							releaseDate: releases.releaseDate,
+						})
+						.from(releases)
+						.where(inArray(releases.id, releaseIds))
+				: Promise.resolve([]),
+			circleIds.length > 0
+				? db
+						.select({
+							id: circles.id,
+							name: circles.name,
+							nameJa: circles.nameJa,
+							nameEn: circles.nameEn,
+						})
+						.from(circles)
+						.where(inArray(circles.id, circleIds))
+				: Promise.resolve([]),
+		]);
+
+		const trackMap = new Map(trackRows.map((r) => [r.id, r]));
+		const releaseMap = new Map(releaseRows.map((r) => [r.id, r]));
+		const circleMap = new Map(circleRows.map((r) => [r.id, r]));
+
+		const itemsWithTarget = items.map((item) => {
+			let target: unknown = null;
+			if (item.targetType === "track") {
+				target = trackMap.get(item.targetId) ?? null;
+			} else if (item.targetType === "release") {
+				target = releaseMap.get(item.targetId) ?? null;
+			} else if (item.targetType === "circle") {
+				target = circleMap.get(item.targetId) ?? null;
+			}
+			return { ...item, target };
+		});
+
+		return c.json({ ...collection, items: itemsWithTarget });
+	} catch (error) {
+		return handleDbError(c, error, "GET /user/collections/:id");
+	}
+});
+
+// コレクション更新（name/description/visibility/ordered）
+collectionsUserRouter.patch("/:id", async (c) => {
+	try {
+		const user = c.get("user");
+		const collectionId = c.req.param("id");
+
+		const body = await c.req.json();
+		const parsed = updateUserCollectionSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					code: "VALIDATION_ERROR",
+					details: parsed.error.flatten(),
+				},
+				400,
+			);
+		}
+
+		const collectionRows = await db
+			.select({
+				visibility: userCollections.visibility,
+				shortId: userCollections.shortId,
+			})
+			.from(userCollections)
+			.where(
+				and(
+					eq(userCollections.id, collectionId),
+					eq(userCollections.userId, user.id),
+				),
+			)
+			.limit(1);
+
+		if (collectionRows.length === 0) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		const current = collectionRows[0];
+		if (!current) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		const newVisibility = parsed.data.visibility;
+
+		// visibility が unlisted/public に変わる時に shortId を採番（最大5回リトライ）
+		let shortId = current.shortId;
+		if (
+			newVisibility &&
+			newVisibility !== "private" &&
+			current.shortId === null
+		) {
+			let attempts = 0;
+			while (shortId === null && attempts < 5) {
+				attempts++;
+				shortId = nanoid(8);
+			}
+		}
+
+		const updateValues: Record<string, unknown> = {};
+		if (parsed.data.name !== undefined) updateValues.name = parsed.data.name;
+		if (parsed.data.description !== undefined)
+			updateValues.description = parsed.data.description;
+		if (parsed.data.visibility !== undefined)
+			updateValues.visibility = parsed.data.visibility;
+		if (parsed.data.ordered !== undefined)
+			updateValues.ordered = parsed.data.ordered;
+		if (shortId !== current.shortId) updateValues.shortId = shortId;
+
+		const updated = await db
+			.update(userCollections)
+			.set(updateValues)
+			.where(
+				and(
+					eq(userCollections.id, collectionId),
+					eq(userCollections.userId, user.id),
+				),
+			)
+			.returning();
+
+		const result = updated[0];
+		if (!result) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		return c.json(result);
+	} catch (error) {
+		return handleDbError(c, error, "PATCH /user/collections/:id");
+	}
+});
+
+// コレクション削除（is_default_liked=true は 403）
+collectionsUserRouter.delete("/:id", async (c) => {
+	try {
+		const user = c.get("user");
+		const collectionId = c.req.param("id");
+
+		const collectionRows = await db
+			.select({ isDefaultLiked: userCollections.isDefaultLiked })
+			.from(userCollections)
+			.where(
+				and(
+					eq(userCollections.id, collectionId),
+					eq(userCollections.userId, user.id),
+				),
+			)
+			.limit(1);
+
+		if (collectionRows.length === 0) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		const collection = collectionRows[0];
+		if (!collection) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		if (collection.isDefaultLiked) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_DEFAULT_LIKED_DELETE_FORBIDDEN,
+					code: "FORBIDDEN",
+				},
+				403,
+			);
+		}
+
+		await db
+			.delete(userCollections)
+			.where(
+				and(
+					eq(userCollections.id, collectionId),
+					eq(userCollections.userId, user.id),
+				),
+			);
+
+		return c.body(null, 204);
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /user/collections/:id");
+	}
+});
+
+// アイテム追加（最大1000件/コレクション、target 存在検証）
+collectionsUserRouter.post("/:id/items", async (c) => {
+	try {
+		const user = c.get("user");
+		const collectionId = c.req.param("id");
+
+		const body = await c.req.json();
+		const parsed = addUserCollectionItemSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					code: "VALIDATION_ERROR",
+					details: parsed.error.flatten(),
+				},
+				400,
+			);
+		}
+
+		// コレクション存在 & 所有確認
+		const collectionRows = await db
+			.select({ ordered: userCollections.ordered })
+			.from(userCollections)
+			.where(
+				and(
+					eq(userCollections.id, collectionId),
+					eq(userCollections.userId, user.id),
+				),
+			)
+			.limit(1);
+
+		if (collectionRows.length === 0) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		const collectionMeta = collectionRows[0];
+		if (!collectionMeta) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		// アイテム数上限チェック
+		const existingItems = await db
+			.select({ count: count() })
+			.from(userCollectionItems)
+			.where(eq(userCollectionItems.collectionId, collectionId));
+		const itemTotal = Number(existingItems[0]?.count ?? 0);
+		if (itemTotal >= 1000) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_ITEM_LIMIT_EXCEEDED,
+					code: "VALIDATION_ERROR",
+				},
+				422,
+			);
+		}
+
+		// target 存在検証
+		const { targetType, targetId, note } = parsed.data;
+		let exists = false;
+
+		switch (targetType) {
+			case "track": {
+				const r = await db
+					.select({ id: tracks.id })
+					.from(tracks)
+					.where(eq(tracks.id, targetId))
+					.limit(1);
+				exists = r.length > 0;
+				break;
+			}
+			case "release": {
+				const r = await db
+					.select({ id: releases.id })
+					.from(releases)
+					.where(eq(releases.id, targetId))
+					.limit(1);
+				exists = r.length > 0;
+				break;
+			}
+			case "circle": {
+				const r = await db
+					.select({ id: circles.id })
+					.from(circles)
+					.where(eq(circles.id, targetId))
+					.limit(1);
+				exists = r.length > 0;
+				break;
+			}
+		}
+
+		if (!exists) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_TARGET_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		// ordered=true の場合、末尾 position を採番（max+1）
+		let position: number | null = null;
+		if (collectionMeta.ordered) {
+			const maxResult = await db
+				.select({ maxPosition: max(userCollectionItems.position) })
+				.from(userCollectionItems)
+				.where(eq(userCollectionItems.collectionId, collectionId));
+			const maxPos = maxResult[0]?.maxPosition;
+			position = maxPos !== null && maxPos !== undefined ? maxPos + 1 : 0;
+		}
+
+		const inserted = await db
+			.insert(userCollectionItems)
+			.values({
+				id: createId.userCollectionItem(),
+				collectionId,
+				targetType,
+				targetId,
+				note: note ?? null,
+				position,
+			})
+			.returning();
+
+		return c.json(inserted[0], 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /user/collections/:id/items");
+	}
+});
+
+// アイテム削除
+collectionsUserRouter.delete("/:id/items/:itemId", async (c) => {
+	try {
+		const user = c.get("user");
+		const collectionId = c.req.param("id");
+		const itemId = c.req.param("itemId");
+
+		// コレクション所有確認
+		const collectionRows = await db
+			.select({ id: userCollections.id })
+			.from(userCollections)
+			.where(
+				and(
+					eq(userCollections.id, collectionId),
+					eq(userCollections.userId, user.id),
+				),
+			)
+			.limit(1);
+
+		if (collectionRows.length === 0) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		// アイテム存在確認
+		const itemRows = await db
+			.select({ id: userCollectionItems.id })
+			.from(userCollectionItems)
+			.where(
+				and(
+					eq(userCollectionItems.id, itemId),
+					eq(userCollectionItems.collectionId, collectionId),
+				),
+			)
+			.limit(1);
+
+		if (itemRows.length === 0) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_ITEM_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		await db
+			.delete(userCollectionItems)
+			.where(
+				and(
+					eq(userCollectionItems.id, itemId),
+					eq(userCollectionItems.collectionId, collectionId),
+				),
+			);
+
+		return c.body(null, 204);
+	} catch (error) {
+		return handleDbError(
+			c,
+			error,
+			"DELETE /user/collections/:id/items/:itemId",
+		);
+	}
+});
+
+// アイテム並び替え一括更新
+collectionsUserRouter.patch("/:id/items/reorder", async (c) => {
+	try {
+		const user = c.get("user");
+		const collectionId = c.req.param("id");
+
+		const body = await c.req.json();
+		const parsed = reorderUserCollectionItemsSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					code: "VALIDATION_ERROR",
+					details: parsed.error.flatten(),
+				},
+				400,
+			);
+		}
+
+		// コレクション存在 & 所有確認
+		const collectionRows = await db
+			.select({ ordered: userCollections.ordered })
+			.from(userCollections)
+			.where(
+				and(
+					eq(userCollections.id, collectionId),
+					eq(userCollections.userId, user.id),
+				),
+			)
+			.limit(1);
+
+		if (collectionRows.length === 0) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		const collectionMeta = collectionRows[0];
+		if (!collectionMeta) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		if (!collectionMeta.ordered) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_REORDER_NOT_ORDERED,
+					code: "VALIDATION_ERROR",
+				},
+				422,
+			);
+		}
+
+		// 既存アイテム全件取得して検証
+		const existingItems = await db
+			.select({ id: userCollectionItems.id })
+			.from(userCollectionItems)
+			.where(eq(userCollectionItems.collectionId, collectionId));
+
+		const existingIds = existingItems.map((i) => i.id).sort();
+		const requestedIds = parsed.data.items.map((i) => i.itemId).sort();
+
+		// itemId 集合が一致するか検証
+		const idsMatch =
+			existingIds.length === requestedIds.length &&
+			existingIds.every((id, idx) => id === requestedIds[idx]);
+
+		if (!idsMatch) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_REORDER_INVALID,
+					code: "VALIDATION_ERROR",
+				},
+				422,
+			);
+		}
+
+		// position が 0 から N-1 の連番で重複なしか検証
+		const positions = parsed.data.items
+			.map((i) => i.position)
+			.sort((a, b) => a - b);
+		const isValidPositions = positions.every((pos, idx) => pos === idx);
+
+		if (!isValidPositions) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.COLLECTION_REORDER_INVALID,
+					code: "VALIDATION_ERROR",
+				},
+				422,
+			);
+		}
+
+		// トランザクション内で一括更新
+		await db.transaction(async (tx) => {
+			for (const { itemId, position } of parsed.data.items) {
+				await tx
+					.update(userCollectionItems)
+					.set({ position })
+					.where(
+						and(
+							eq(userCollectionItems.id, itemId),
+							eq(userCollectionItems.collectionId, collectionId),
+						),
+					);
+			}
+		});
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleDbError(c, error, "PATCH /user/collections/:id/items/reorder");
+	}
+});
+
+export { collectionsUserRouter };

--- a/apps/server/src/routes/user/collections.ts
+++ b/apps/server/src/routes/user/collections.ts
@@ -259,6 +259,8 @@ collectionsUserRouter.patch("/:id", async (c) => {
 			.select({
 				visibility: userCollections.visibility,
 				shortId: userCollections.shortId,
+				isDefaultLiked: userCollections.isDefaultLiked,
+				itemType: userCollections.itemType,
 			})
 			.from(userCollections)
 			.where(
@@ -290,6 +292,28 @@ collectionsUserRouter.patch("/:id", async (c) => {
 			);
 		}
 
+		// itemType 更新ガード
+		if (parsed.data.itemType !== undefined) {
+			if (current.isDefaultLiked) {
+				return c.json(
+					{
+						error: "Liked コレクションには itemType を設定できません",
+						code: "VALIDATION_ERROR",
+					},
+					400,
+				);
+			}
+			if (current.itemType !== null) {
+				return c.json(
+					{
+						error: "itemType は変更できません",
+						code: "VALIDATION_ERROR",
+					},
+					400,
+				);
+			}
+		}
+
 		const newVisibility = parsed.data.visibility;
 
 		// visibility が unlisted/public に変わる時に shortId を採番（最大5回リトライ）
@@ -314,6 +338,8 @@ collectionsUserRouter.patch("/:id", async (c) => {
 			updateValues.visibility = parsed.data.visibility;
 		if (parsed.data.ordered !== undefined)
 			updateValues.ordered = parsed.data.ordered;
+		if (parsed.data.itemType !== undefined)
+			updateValues.itemType = parsed.data.itemType;
 		if (shortId !== current.shortId) updateValues.shortId = shortId;
 
 		const updated = await db

--- a/apps/server/src/routes/user/collections.ts
+++ b/apps/server/src/routes/user/collections.ts
@@ -11,6 +11,7 @@ import {
 	max,
 	releases,
 	reorderUserCollectionItemsSchema,
+	sql,
 	tracks,
 	updateUserCollectionSchema,
 	userCollectionItems,
@@ -26,14 +27,78 @@ import { loadCollectionItemsWithTargets } from "../../utils/collection-items-loa
 const collectionsUserRouter = new Hono<UserAuthContext>();
 
 // 自分のコレクション一覧取得（kindフィルタ可、アイテム数を含む）
+// targetType + targetId を指定した場合、各コレクションに containsTarget / containsItemId を追加
 collectionsUserRouter.get("/", async (c) => {
 	try {
 		const user = c.get("user");
 		const kindParam = c.req.query("kind");
+		const targetType = c.req.query("targetType");
+		const targetId = c.req.query("targetId");
+		const hasTarget =
+			(targetType === "track" ||
+				targetType === "release" ||
+				targetType === "circle") &&
+			!!targetId;
+
+		const excludeDefaultLiked = c.req.query("excludeDefaultLiked") === "true";
 
 		const conditions = [eq(userCollections.userId, user.id)];
 		if (kindParam === "collection" || kindParam === "playlist") {
 			conditions.push(eq(userCollections.kind, kindParam));
+		}
+		if (excludeDefaultLiked) {
+			conditions.push(eq(userCollections.isDefaultLiked, false));
+		}
+
+		if (hasTarget) {
+			// target の含有判定: 専用エイリアスで left join
+			const targetItems = db.$with("target_items").as(
+				db
+					.select({
+						collectionId: userCollectionItems.collectionId,
+						itemId: userCollectionItems.id,
+					})
+					.from(userCollectionItems)
+					.where(
+						and(
+							eq(
+								userCollectionItems.targetType,
+								targetType as "track" | "release" | "circle",
+							),
+							eq(userCollectionItems.targetId, targetId),
+						),
+					),
+			);
+
+			const rows = await db
+				.with(targetItems)
+				.select({
+					id: userCollections.id,
+					kind: userCollections.kind,
+					name: userCollections.name,
+					description: userCollections.description,
+					visibility: userCollections.visibility,
+					ordered: userCollections.ordered,
+					isDefaultLiked: userCollections.isDefaultLiked,
+					shortId: userCollections.shortId,
+					coverImageUrl: userCollections.coverImageUrl,
+					createdAt: userCollections.createdAt,
+					updatedAt: userCollections.updatedAt,
+					itemCount: count(userCollectionItems.id),
+					containsTarget: sql<boolean>`${targetItems.itemId} IS NOT NULL`,
+					containsItemId: targetItems.itemId,
+				})
+				.from(userCollections)
+				.leftJoin(
+					userCollectionItems,
+					eq(userCollectionItems.collectionId, userCollections.id),
+				)
+				.leftJoin(targetItems, eq(targetItems.collectionId, userCollections.id))
+				.where(and(...conditions))
+				.groupBy(userCollections.id, targetItems.itemId)
+				.orderBy(desc(userCollections.createdAt));
+
+			return c.json({ items: rows });
 		}
 
 		const rows = await db

--- a/apps/server/src/routes/user/index.ts
+++ b/apps/server/src/routes/user/index.ts
@@ -6,6 +6,7 @@ import {
 } from "../../middleware/user-auth";
 import { albumRequestsUserRouter } from "./album-requests";
 import { collectionsUserRouter } from "./collections";
+import { likesUserRouter } from "./likes";
 
 const userRouter = new Hono<UserAuthContext>();
 
@@ -20,5 +21,8 @@ userRouter.route("/album-requests", albumRequestsUserRouter);
 
 // コレクションルート
 userRouter.route("/collections", collectionsUserRouter);
+
+// お気に入りルート
+userRouter.route("/likes", likesUserRouter);
 
 export { userRouter };

--- a/apps/server/src/routes/user/index.ts
+++ b/apps/server/src/routes/user/index.ts
@@ -5,6 +5,7 @@ import {
 	type UserAuthContext,
 } from "../../middleware/user-auth";
 import { albumRequestsUserRouter } from "./album-requests";
+import { collectionsUserRouter } from "./collections";
 
 const userRouter = new Hono<UserAuthContext>();
 
@@ -16,5 +17,8 @@ userRouter.use("/*", methodRateLimiter);
 
 // アルバム申請ルート
 userRouter.route("/album-requests", albumRequestsUserRouter);
+
+// コレクションルート
+userRouter.route("/collections", collectionsUserRouter);
 
 export { userRouter };

--- a/apps/server/src/routes/user/likes.ts
+++ b/apps/server/src/routes/user/likes.ts
@@ -1,5 +1,6 @@
 import {
 	and,
+	artists,
 	COLLECTION_ITEM_TARGET_TYPES,
 	circles,
 	createId,
@@ -50,6 +51,14 @@ async function targetEntityExists(
 				.select({ id: circles.id })
 				.from(circles)
 				.where(eq(circles.id, id))
+				.limit(1);
+			return r.length > 0;
+		}
+		case "artist": {
+			const r = await db
+				.select({ id: artists.id })
+				.from(artists)
+				.where(eq(artists.id, id))
 				.limit(1);
 			return r.length > 0;
 		}
@@ -130,6 +139,7 @@ likesUserRouter.get("/check", async (c) => {
 			.filter((i) => i.type === "release")
 			.map((i) => i.id);
 		const circleIds = items.filter((i) => i.type === "circle").map((i) => i.id);
+		const artistIds = items.filter((i) => i.type === "artist").map((i) => i.id);
 
 		const conditions = [];
 		if (trackIds.length > 0) {
@@ -153,6 +163,14 @@ likesUserRouter.get("/check", async (c) => {
 				and(
 					eq(userCollectionItems.targetType, "circle"),
 					inArray(userCollectionItems.targetId, circleIds),
+				),
+			);
+		}
+		if (artistIds.length > 0) {
+			conditions.push(
+				and(
+					eq(userCollectionItems.targetType, "artist"),
+					inArray(userCollectionItems.targetId, artistIds),
 				),
 			);
 		}

--- a/apps/server/src/routes/user/likes.ts
+++ b/apps/server/src/routes/user/likes.ts
@@ -1,0 +1,353 @@
+import {
+	and,
+	COLLECTION_ITEM_TARGET_TYPES,
+	circles,
+	createId,
+	db,
+	eq,
+	inArray,
+	likeTargetSchema,
+	or,
+	releases,
+	tracks,
+	userCollectionItems,
+	userCollections,
+} from "@thac/db";
+import { Hono } from "hono";
+import { z } from "zod";
+import { ERROR_MESSAGES } from "../../constants/error-messages";
+import type { UserAuthContext } from "../../middleware/user-auth";
+import { handleDbError } from "../../utils/api-error";
+
+const likesUserRouter = new Hono<UserAuthContext>();
+
+/**
+ * target エンティティが存在するか検証する
+ */
+async function targetEntityExists(
+	type: (typeof COLLECTION_ITEM_TARGET_TYPES)[number],
+	id: string,
+): Promise<boolean> {
+	switch (type) {
+		case "track": {
+			const r = await db
+				.select({ id: tracks.id })
+				.from(tracks)
+				.where(eq(tracks.id, id))
+				.limit(1);
+			return r.length > 0;
+		}
+		case "release": {
+			const r = await db
+				.select({ id: releases.id })
+				.from(releases)
+				.where(eq(releases.id, id))
+				.limit(1);
+			return r.length > 0;
+		}
+		case "circle": {
+			const r = await db
+				.select({ id: circles.id })
+				.from(circles)
+				.where(eq(circles.id, id))
+				.limit(1);
+			return r.length > 0;
+		}
+	}
+}
+
+const checkQuerySchema = z.object({
+	items: z
+		.string()
+		.trim()
+		.min(1)
+		.transform((s) =>
+			s.split(",").map((entry) => {
+				const [type, id] = entry.split(":");
+				return { type, id };
+			}),
+		)
+		.pipe(
+			z
+				.array(
+					z.object({
+						type: z.enum(COLLECTION_ITEM_TARGET_TYPES),
+						id: z.string().min(1),
+					}),
+				)
+				.min(1)
+				.max(200),
+		),
+});
+
+// 一括 like チェック（GET /check は GET / より前に定義）
+likesUserRouter.get("/check", async (c) => {
+	try {
+		const queryParse = checkQuerySchema.safeParse({
+			items: c.req.query("items") ?? "",
+		});
+		if (!queryParse.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					code: "VALIDATION_ERROR",
+					details: queryParse.error.flatten(),
+				},
+				400,
+			);
+		}
+
+		const user = c.get("user");
+		const items = queryParse.data.items;
+
+		// default_liked を引く（無ければ全部 false）
+		const liked = await db
+			.select({ id: userCollections.id })
+			.from(userCollections)
+			.where(
+				and(
+					eq(userCollections.userId, user.id),
+					eq(userCollections.isDefaultLiked, true),
+				),
+			)
+			.limit(1);
+
+		if (liked.length === 0) {
+			return c.json({
+				results: items.map(({ type, id }) => ({
+					targetType: type,
+					targetId: id,
+					liked: false,
+				})),
+			});
+		}
+
+		const likedCollectionId = liked[0]?.id ?? "";
+
+		// targetType 別に inArray でフェッチ
+		const trackIds = items.filter((i) => i.type === "track").map((i) => i.id);
+		const releaseIds = items
+			.filter((i) => i.type === "release")
+			.map((i) => i.id);
+		const circleIds = items.filter((i) => i.type === "circle").map((i) => i.id);
+
+		const conditions = [];
+		if (trackIds.length > 0) {
+			conditions.push(
+				and(
+					eq(userCollectionItems.targetType, "track"),
+					inArray(userCollectionItems.targetId, trackIds),
+				),
+			);
+		}
+		if (releaseIds.length > 0) {
+			conditions.push(
+				and(
+					eq(userCollectionItems.targetType, "release"),
+					inArray(userCollectionItems.targetId, releaseIds),
+				),
+			);
+		}
+		if (circleIds.length > 0) {
+			conditions.push(
+				and(
+					eq(userCollectionItems.targetType, "circle"),
+					inArray(userCollectionItems.targetId, circleIds),
+				),
+			);
+		}
+
+		const likedRows =
+			conditions.length > 0
+				? await db
+						.select({
+							targetType: userCollectionItems.targetType,
+							targetId: userCollectionItems.targetId,
+						})
+						.from(userCollectionItems)
+						.where(
+							and(
+								eq(userCollectionItems.collectionId, likedCollectionId),
+								or(...conditions),
+							),
+						)
+				: [];
+
+		const likedSet = new Set(
+			likedRows.map((r) => `${r.targetType}:${r.targetId}`),
+		);
+
+		return c.json({
+			results: items.map(({ type, id }) => ({
+				targetType: type,
+				targetId: id,
+				liked: likedSet.has(`${type}:${id}`),
+			})),
+		});
+	} catch (error) {
+		return handleDbError(c, error, "GET /user/likes/check");
+	}
+});
+
+// ♥ 追加: default_liked コレクションへ追加（lazy 作成 + idempotent）
+likesUserRouter.post("/", async (c) => {
+	try {
+		const body = await c.req.json();
+		const parsed = likeTargetSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					code: "VALIDATION_ERROR",
+					details: parsed.error.flatten(),
+				},
+				400,
+			);
+		}
+
+		const user = c.get("user");
+		const { targetType, targetId } = parsed.data;
+
+		// target 存在検証
+		const exists = await targetEntityExists(targetType, targetId);
+		if (!exists) {
+			return c.json(
+				{
+					error: ERROR_MESSAGES.LIKE_TARGET_NOT_FOUND,
+					code: "NOT_FOUND",
+				},
+				404,
+			);
+		}
+
+		const item = await db.transaction(async (tx) => {
+			// default_liked を取得（行ロック）または作成
+			let likedRows = await tx
+				.select()
+				.from(userCollections)
+				.where(
+					and(
+						eq(userCollections.userId, user.id),
+						eq(userCollections.isDefaultLiked, true),
+					),
+				)
+				.for("update")
+				.limit(1);
+
+			if (likedRows.length === 0) {
+				const inserted = await tx
+					.insert(userCollections)
+					.values({
+						id: createId.userCollection(),
+						userId: user.id,
+						kind: "collection",
+						name: "Liked",
+						visibility: "private",
+						ordered: false,
+						isDefaultLiked: true,
+					})
+					.returning();
+				likedRows = inserted;
+			}
+
+			const collectionId = likedRows[0]?.id ?? "";
+
+			// アイテム追加（重複時は ON CONFLICT DO NOTHING で idempotent 化）
+			const result = await tx
+				.insert(userCollectionItems)
+				.values({
+					id: createId.userCollectionItem(),
+					collectionId,
+					targetType,
+					targetId,
+					position: null,
+				})
+				.onConflictDoNothing({
+					target: [
+						userCollectionItems.collectionId,
+						userCollectionItems.targetType,
+						userCollectionItems.targetId,
+					],
+				})
+				.returning();
+
+			// onConflictDoNothing が NOOP（既に存在）の場合は既存行を SELECT して返す
+			if (result.length === 0) {
+				const existing = await tx
+					.select()
+					.from(userCollectionItems)
+					.where(
+						and(
+							eq(userCollectionItems.collectionId, collectionId),
+							eq(userCollectionItems.targetType, targetType),
+							eq(userCollectionItems.targetId, targetId),
+						),
+					)
+					.limit(1);
+				return { collection: likedRows[0], item: existing[0] };
+			}
+
+			return { collection: likedRows[0], item: result[0] };
+		});
+
+		return c.json(item, 201);
+	} catch (error) {
+		return handleDbError(c, error, "POST /user/likes");
+	}
+});
+
+// ♥ 解除: default_liked から削除（idempotent）
+likesUserRouter.delete("/", async (c) => {
+	try {
+		const body = await c.req.json();
+		const parsed = likeTargetSchema.safeParse(body);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: "Validation failed",
+					code: "VALIDATION_ERROR",
+					details: parsed.error.flatten(),
+				},
+				400,
+			);
+		}
+
+		const user = c.get("user");
+		const { targetType, targetId } = parsed.data;
+
+		// default_liked を引く
+		const liked = await db
+			.select({ id: userCollections.id })
+			.from(userCollections)
+			.where(
+				and(
+					eq(userCollections.userId, user.id),
+					eq(userCollections.isDefaultLiked, true),
+				),
+			)
+			.limit(1);
+
+		if (liked.length === 0) {
+			// default_liked 自体ないので削除対象もない → 204 で返す（idempotent）
+			return c.body(null, 204);
+		}
+
+		const likedCollectionId = liked[0]?.id ?? "";
+
+		await db
+			.delete(userCollectionItems)
+			.where(
+				and(
+					eq(userCollectionItems.collectionId, likedCollectionId),
+					eq(userCollectionItems.targetType, targetType),
+					eq(userCollectionItems.targetId, targetId),
+				),
+			);
+
+		return c.body(null, 204);
+	} catch (error) {
+		return handleDbError(c, error, "DELETE /user/likes");
+	}
+});
+
+export { likesUserRouter };

--- a/apps/server/src/utils/collection-items-loader.ts
+++ b/apps/server/src/utils/collection-items-loader.ts
@@ -1,0 +1,117 @@
+import {
+	asc,
+	circles,
+	db,
+	desc,
+	eq,
+	inArray,
+	releases,
+	tracks,
+	userCollectionItems,
+} from "@thac/db";
+
+type CollectionItem = typeof userCollectionItems.$inferSelect;
+
+type TrackRow = {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+	releaseId: string;
+};
+
+type ReleaseRow = {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+	releaseDate: string | null;
+};
+
+type CircleRow = {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+};
+
+type Target = TrackRow | ReleaseRow | CircleRow | null;
+
+export type CollectionItemWithTarget = CollectionItem & { target: Target };
+
+export async function loadCollectionItemsWithTargets(
+	collectionId: string,
+): Promise<CollectionItemWithTarget[]> {
+	const items = await db
+		.select()
+		.from(userCollectionItems)
+		.where(eq(userCollectionItems.collectionId, collectionId))
+		.orderBy(
+			asc(userCollectionItems.position),
+			desc(userCollectionItems.addedAt),
+		);
+
+	const trackIds = items
+		.filter((i) => i.targetType === "track")
+		.map((i) => i.targetId);
+	const releaseIds = items
+		.filter((i) => i.targetType === "release")
+		.map((i) => i.targetId);
+	const circleIds = items
+		.filter((i) => i.targetType === "circle")
+		.map((i) => i.targetId);
+
+	const [trackRows, releaseRows, circleRows] = await Promise.all([
+		trackIds.length > 0
+			? db
+					.select({
+						id: tracks.id,
+						name: tracks.name,
+						nameJa: tracks.nameJa,
+						nameEn: tracks.nameEn,
+						releaseId: tracks.releaseId,
+					})
+					.from(tracks)
+					.where(inArray(tracks.id, trackIds))
+			: Promise.resolve([] as TrackRow[]),
+		releaseIds.length > 0
+			? db
+					.select({
+						id: releases.id,
+						name: releases.name,
+						nameJa: releases.nameJa,
+						nameEn: releases.nameEn,
+						releaseDate: releases.releaseDate,
+					})
+					.from(releases)
+					.where(inArray(releases.id, releaseIds))
+			: Promise.resolve([] as ReleaseRow[]),
+		circleIds.length > 0
+			? db
+					.select({
+						id: circles.id,
+						name: circles.name,
+						nameJa: circles.nameJa,
+						nameEn: circles.nameEn,
+					})
+					.from(circles)
+					.where(inArray(circles.id, circleIds))
+			: Promise.resolve([] as CircleRow[]),
+	]);
+
+	const trackMap = new Map(trackRows.map((r) => [r.id, r]));
+	const releaseMap = new Map(releaseRows.map((r) => [r.id, r]));
+	const circleMap = new Map(circleRows.map((r) => [r.id, r]));
+
+	return items.map((item) => {
+		let target: Target = null;
+		if (item.targetType === "track") {
+			target = trackMap.get(item.targetId) ?? null;
+		} else if (item.targetType === "release") {
+			target = releaseMap.get(item.targetId) ?? null;
+		} else if (item.targetType === "circle") {
+			target = circleMap.get(item.targetId) ?? null;
+		}
+		return { ...item, target };
+	});
+}

--- a/apps/server/src/utils/collection-items-loader.ts
+++ b/apps/server/src/utils/collection-items-loader.ts
@@ -1,4 +1,5 @@
 import {
+	artists,
 	asc,
 	circles,
 	db,
@@ -35,7 +36,14 @@ type CircleRow = {
 	nameEn: string | null;
 };
 
-type Target = TrackRow | ReleaseRow | CircleRow | null;
+type ArtistRow = {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+};
+
+type Target = TrackRow | ReleaseRow | CircleRow | ArtistRow | null;
 
 export type CollectionItemWithTarget = CollectionItem & { target: Target };
 
@@ -60,8 +68,11 @@ export async function loadCollectionItemsWithTargets(
 	const circleIds = items
 		.filter((i) => i.targetType === "circle")
 		.map((i) => i.targetId);
+	const artistIds = items
+		.filter((i) => i.targetType === "artist")
+		.map((i) => i.targetId);
 
-	const [trackRows, releaseRows, circleRows] = await Promise.all([
+	const [trackRows, releaseRows, circleRows, artistRows] = await Promise.all([
 		trackIds.length > 0
 			? db
 					.select({
@@ -97,11 +108,23 @@ export async function loadCollectionItemsWithTargets(
 					.from(circles)
 					.where(inArray(circles.id, circleIds))
 			: Promise.resolve([] as CircleRow[]),
+		artistIds.length > 0
+			? db
+					.select({
+						id: artists.id,
+						name: artists.name,
+						nameJa: artists.nameJa,
+						nameEn: artists.nameEn,
+					})
+					.from(artists)
+					.where(inArray(artists.id, artistIds))
+			: Promise.resolve([] as ArtistRow[]),
 	]);
 
 	const trackMap = new Map(trackRows.map((r) => [r.id, r]));
 	const releaseMap = new Map(releaseRows.map((r) => [r.id, r]));
 	const circleMap = new Map(circleRows.map((r) => [r.id, r]));
+	const artistMap = new Map(artistRows.map((r) => [r.id, r]));
 
 	return items.map((item) => {
 		let target: Target = null;
@@ -111,6 +134,8 @@ export async function loadCollectionItemsWithTargets(
 			target = releaseMap.get(item.targetId) ?? null;
 		} else if (item.targetType === "circle") {
 			target = circleMap.get(item.targetId) ?? null;
+		} else if (item.targetType === "artist") {
+			target = artistMap.get(item.targetId) ?? null;
 		}
 		return { ...item, target };
 	});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,9 @@
 		"test": "vitest run --config ../../vitest.config.ts apps/web"
 	},
 	"dependencies": {
+		"@dnd-kit/core": "catalog:",
+		"@dnd-kit/sortable": "catalog:",
+		"@dnd-kit/utilities": "catalog:",
 		"@nivo/bar": "^0.99.0",
 		"date-fns": "^4.1.0",
 		"@nivo/core": "^0.99.0",

--- a/apps/web/src/components/admin/data-table-action-bar.tsx
+++ b/apps/web/src/components/admin/data-table-action-bar.tsx
@@ -161,12 +161,12 @@ function DataTableActionBar({
 									key={action.label}
 									onClick={action.onClick}
 									disabled={action.disabled}
-									className="flex items-center whitespace-nowrap"
+									className="whitespace-nowrap"
 								>
 									{action.icon && (
 										<span className="shrink-0">{action.icon}</span>
 									)}
-									<span>{action.label}</span>
+									{action.label}
 								</DropdownMenuItem>
 							))}
 						</DropdownMenuContent>

--- a/apps/web/src/components/public/entity-detail-header.tsx
+++ b/apps/web/src/components/public/entity-detail-header.tsx
@@ -37,6 +37,11 @@ export interface EntityDetailHeaderProps {
 	 * ヘッダー右側に表示される
 	 */
 	children?: ReactNode;
+	/**
+	 * カード内右下に配置するアクション要素（LikeButton、コレクション追加ボタンなど）
+	 * absolute 配置でカード右下に表示される
+	 */
+	actions?: ReactNode;
 }
 
 /**
@@ -90,12 +95,15 @@ export function EntityDetailHeader({
 	subtitle,
 	badges,
 	children,
+	actions,
 }: EntityDetailHeaderProps) {
 	const containerClass = gradientClass
-		? `${gradientClass} rounded-2xl shadow-sm transition-shadow duration-300 hover:shadow-lg`
-		: "rounded-2xl bg-base-100 shadow-sm transition-shadow duration-300 hover:shadow-lg";
+		? `relative ${gradientClass} rounded-2xl shadow-sm transition-shadow duration-300 hover:shadow-lg`
+		: "relative rounded-2xl bg-base-100 shadow-sm transition-shadow duration-300 hover:shadow-lg";
 
-	const innerClass = gradientClass ? "glass-card-light rounded-2xl p-6" : "p-6";
+	const innerClass = gradientClass
+		? "glass-card-light rounded-2xl p-6 pb-16"
+		: "p-6 pb-16";
 
 	return (
 		<div className={containerClass}>
@@ -132,6 +140,13 @@ export function EntityDetailHeader({
 					)}
 				</div>
 			</div>
+
+			{/* カード内右下アクション */}
+			{actions && (
+				<div className="absolute right-4 bottom-4 z-10 sm:right-6 sm:bottom-4">
+					{actions}
+				</div>
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/components/public/public-header.tsx
+++ b/apps/web/src/components/public/public-header.tsx
@@ -2,8 +2,10 @@ import { Link, useLocation } from "@tanstack/react-router";
 import {
 	BarChart3,
 	Calendar,
+	Heart,
 	Home,
 	Info,
+	Library,
 	Menu,
 	Music,
 	Search,
@@ -12,6 +14,7 @@ import {
 	X,
 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { authClient } from "@/lib/auth-client";
 import { ThemeSwitcher } from "../theme-switcher";
 import UserMenu from "../user-menu";
 
@@ -27,6 +30,7 @@ export function PublicHeader() {
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 	const [isScrolled, setIsScrolled] = useState(false);
 	const location = useLocation();
+	const { data: session } = authClient.useSession();
 
 	const isActive = (path: string) => location.pathname.startsWith(path);
 
@@ -65,11 +69,24 @@ export function PublicHeader() {
 				>
 					東方編曲録
 				</Link>
+				<div className="hidden lg:flex">
+					<ThemeSwitcher />
+				</div>
 			</div>
 
 			{/* Desktop navigation */}
 			<nav className="navbar-center hidden lg:flex">
 				<ul className="menu menu-horizontal gap-1 px-1">
+					<li>
+						<Link
+							to="/search"
+							preload="render"
+							className="btn btn-ghost btn-circle"
+							aria-label="検索"
+						>
+							<Search className="size-5" />
+						</Link>
+					</li>
 					{navLinks.map(({ to, label }) => (
 						<li key={to}>
 							<Link
@@ -90,15 +107,29 @@ export function PublicHeader() {
 
 			{/* Right side */}
 			<div className="navbar-end gap-1">
-				<Link
-					to="/search"
-					preload="render"
-					className="btn btn-ghost btn-circle"
-					aria-label="検索"
-				>
-					<Search className="size-5" />
-				</Link>
-				<ThemeSwitcher />
+				{session && (
+					<>
+						<Link
+							to="/user/collections"
+							preload="render"
+							className="btn btn-ghost btn-circle hidden lg:flex"
+							aria-label="コレクション"
+						>
+							<Library className="size-5" />
+						</Link>
+						<Link
+							to="/user/likes"
+							preload="render"
+							className="btn btn-ghost btn-circle hidden lg:flex"
+							aria-label="お気に入り"
+						>
+							<Heart className="size-5" />
+						</Link>
+					</>
+				)}
+				<div className="lg:hidden">
+					<ThemeSwitcher />
+				</div>
 				<UserMenu />
 			</div>
 
@@ -166,6 +197,40 @@ export function PublicHeader() {
 									</Link>
 								</li>
 							))}
+							{session && (
+								<>
+									<li className="mt-4 border-base-content/10 border-t pt-4">
+										<Link
+											to="/user/collections"
+											preload="render"
+											className={`flex items-center gap-3 transition-all duration-300 ${
+												isActive("/user/collections")
+													? "bg-primary font-semibold text-primary-content"
+													: "text-base-content/70 hover:bg-base-200/60 hover:text-base-content"
+											}`}
+											onClick={() => setIsDrawerOpen(false)}
+										>
+											<Library className="size-5" />
+											コレクション
+										</Link>
+									</li>
+									<li>
+										<Link
+											to="/user/likes"
+											preload="render"
+											className={`flex items-center gap-3 transition-all duration-300 ${
+												isActive("/user/likes")
+													? "bg-primary font-semibold text-primary-content"
+													: "text-base-content/70 hover:bg-base-200/60 hover:text-base-content"
+											}`}
+											onClick={() => setIsDrawerOpen(false)}
+										>
+											<Heart className="size-5" />
+											お気に入り
+										</Link>
+									</li>
+								</>
+							)}
 							<li className="mt-4 border-base-content/10 border-t pt-4">
 								<Link
 									to="/about"

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -143,11 +143,13 @@ function DropdownMenuTrigger({
 
 interface DropdownMenuContentProps extends React.ComponentProps<"ul"> {
 	align?: "start" | "end";
+	side?: "top" | "bottom";
 }
 
 function DropdownMenuContent({
 	className,
 	align = "end",
+	side = "bottom",
 	children,
 	...props
 }: DropdownMenuContentProps) {
@@ -160,7 +162,8 @@ function DropdownMenuContent({
 			data-slot="dropdown-menu-content"
 			role="menu"
 			className={cn(
-				"absolute z-50 mt-1 w-52 rounded-box bg-base-100 p-2 shadow-lg",
+				"absolute z-50 w-52 rounded-box bg-base-100 p-2 shadow-lg",
+				side === "top" ? "bottom-full mb-1" : "mt-1",
 				align === "end" ? "right-0" : "left-0",
 				className,
 			)}
@@ -202,7 +205,7 @@ function DropdownMenuItem({
 			tabIndex={disabled ? -1 : 0}
 			onClick={handleClick}
 			className={cn(
-				"flex cursor-pointer items-center rounded-box px-3 py-2 text-sm hover:bg-base-200 focus:bg-base-200 focus:outline-none",
+				"flex cursor-pointer items-center gap-2 rounded-box px-3 py-2 text-sm hover:bg-base-200 focus:bg-base-200 focus:outline-none",
 				inset && "pl-8",
 				disabled && "cursor-not-allowed opacity-50",
 				className,

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -1,0 +1,138 @@
+import { AlertCircle, CheckCircle, Info, X } from "lucide-react";
+import type * as React from "react";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+
+// ===== 型定義 =====
+
+type ToastVariant = "success" | "error" | "info";
+
+interface Toast {
+	id: string;
+	variant: ToastVariant;
+	message: string;
+}
+
+interface ToastContextValue {
+	showToast: (variant: ToastVariant, message: string) => void;
+}
+
+// ===== Context =====
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+// ===== プロバイダー・コンポーネント =====
+
+const TOAST_DURATION_MS = 3000;
+const FADE_DURATION_MS = 300;
+
+const variantConfig: Record<
+	ToastVariant,
+	{
+		alertClass: string;
+		icon: React.ComponentType<{ className?: string }>;
+	}
+> = {
+	success: { alertClass: "alert-success", icon: CheckCircle },
+	error: { alertClass: "alert-error", icon: AlertCircle },
+	info: { alertClass: "alert-info", icon: Info },
+};
+
+interface ToastItemProps {
+	toast: Toast;
+	onRemove: (id: string) => void;
+}
+
+function ToastItem({ toast, onRemove }: ToastItemProps) {
+	const [isFadingOut, setIsFadingOut] = useState(false);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const dismiss = useCallback(() => {
+		if (timerRef.current) clearTimeout(timerRef.current);
+		if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+		setIsFadingOut(true);
+		fadeTimerRef.current = setTimeout(() => {
+			onRemove(toast.id);
+		}, FADE_DURATION_MS);
+	}, [toast.id, onRemove]);
+
+	useEffect(() => {
+		timerRef.current = setTimeout(() => {
+			dismiss();
+		}, TOAST_DURATION_MS);
+
+		return () => {
+			if (timerRef.current) clearTimeout(timerRef.current);
+			if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+		};
+	}, [dismiss]);
+
+	const config = variantConfig[toast.variant];
+	const Icon = config.icon;
+
+	return (
+		<div
+			role="alert"
+			aria-live={toast.variant === "error" ? "assertive" : "polite"}
+			className={`alert ${config.alertClass} shadow-lg transition-opacity duration-300 ${isFadingOut ? "opacity-0" : "opacity-100"}`}
+		>
+			<Icon className="h-5 w-5 shrink-0" />
+			<span className="flex-1">{toast.message}</span>
+			<button
+				type="button"
+				onClick={dismiss}
+				className="btn btn-ghost btn-sm btn-circle"
+				aria-label="閉じる"
+			>
+				<X className="h-4 w-4" />
+			</button>
+		</div>
+	);
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+	const [toasts, setToasts] = useState<Toast[]>([]);
+
+	const showToast = useCallback((variant: ToastVariant, message: string) => {
+		const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		setToasts((prev) => [...prev, { id, variant, message }]);
+	}, []);
+
+	const removeToast = useCallback((id: string) => {
+		setToasts((prev) => prev.filter((t) => t.id !== id));
+	}, []);
+
+	return (
+		<ToastContext value={{ showToast }}>
+			{children}
+			{toasts.length > 0 && (
+				<div className="toast toast-top toast-center pointer-events-none z-50">
+					<div className="pointer-events-auto flex flex-col gap-2">
+						{toasts.map((t) => (
+							<ToastItem key={t.id} toast={t} onRemove={removeToast} />
+						))}
+					</div>
+				</div>
+			)}
+		</ToastContext>
+	);
+}
+
+// ===== フック =====
+
+export function useToast(): ToastContextValue {
+	const ctx = useContext(ToastContext);
+	if (!ctx) {
+		throw new Error("useToast must be used within a ToastProvider");
+	}
+	return ctx;
+}
+
+export type { ToastVariant };

--- a/apps/web/src/components/user-menu.tsx
+++ b/apps/web/src/components/user-menu.tsx
@@ -63,6 +63,12 @@ export default function UserMenu() {
 				<li>
 					<Link to="/user/album-requests">アルバム情報の提供</Link>
 				</li>
+				<li>
+					<Link to="/user/collections">コレクション</Link>
+				</li>
+				<li>
+					<Link to="/user/likes">お気に入り</Link>
+				</li>
 				<div className="divider my-0" />
 				<li>
 					<button type="button" onClick={handleSignOut} className="text-error">

--- a/apps/web/src/components/user/add-to-collection-dropdown.tsx
+++ b/apps/web/src/components/user/add-to-collection-dropdown.tsx
@@ -1,8 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { Plus } from "lucide-react";
-import { useState } from "react";
-import { Banner } from "@/components/ui/banner";
+import { Check, Plus, Square } from "lucide-react";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -11,6 +9,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useToast } from "@/components/ui/toast";
 import { authClient } from "@/lib/auth-client";
 import {
 	userCollectionMutations,
@@ -21,6 +20,8 @@ interface AddToCollectionDropdownProps {
 	targetType: "track" | "release" | "circle";
 	targetId: string;
 	currentPath?: string;
+	/** ドロップダウンを上方向に展開する（FABとして使用する場合） */
+	dropUp?: boolean;
 	/** 「新規コレクションを作成」クリック時の処理。省略時はナビゲーションなし */
 	onNavigateToNew?: () => void;
 }
@@ -29,19 +30,20 @@ export function AddToCollectionDropdown({
 	targetType,
 	targetId,
 	currentPath,
+	dropUp = false,
 	onNavigateToNew,
 }: AddToCollectionDropdownProps) {
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
 	const { data: session } = authClient.useSession();
-
-	const [feedback, setFeedback] = useState<{
-		variant: "success" | "error";
-		message: string;
-	} | null>(null);
+	const { showToast } = useToast();
 
 	const collectionsQuery = useQuery({
-		...userCollectionsListQueryOptions({ kind: "collection" }),
+		...userCollectionsListQueryOptions({
+			kind: "collection",
+			target: { type: targetType, id: targetId },
+			excludeDefaultLiked: true,
+		}),
 		enabled: !!session?.user,
 	});
 
@@ -49,19 +51,38 @@ export function AddToCollectionDropdown({
 		userCollectionMutations.addItem(queryClient),
 	);
 
-	const handleAdd = async (collectionId: string, collectionName: string) => {
-		try {
-			await addItemMutation.mutateAsync({
-				id: collectionId,
-				input: { targetType, targetId },
-			});
-			setFeedback({
-				variant: "success",
-				message: `「${collectionName}」に追加しました`,
-			});
-		} catch (e) {
-			const message = e instanceof Error ? e.message : "追加に失敗しました";
-			setFeedback({ variant: "error", message });
+	const removeItemMutation = useMutation(
+		userCollectionMutations.removeItem(queryClient),
+	);
+
+	const handleToggle = async (
+		collectionId: string,
+		collectionName: string,
+		containsTarget: boolean,
+		containsItemId: string | null | undefined,
+	) => {
+		if (containsTarget && containsItemId) {
+			try {
+				await removeItemMutation.mutateAsync({
+					id: collectionId,
+					itemId: containsItemId,
+				});
+				showToast("success", `「${collectionName}」から削除しました`);
+			} catch (e) {
+				const message = e instanceof Error ? e.message : "削除に失敗しました";
+				showToast("error", message);
+			}
+		} else {
+			try {
+				await addItemMutation.mutateAsync({
+					id: collectionId,
+					input: { targetType, targetId },
+				});
+				showToast("success", `「${collectionName}」に追加しました`);
+			} catch (e) {
+				const message = e instanceof Error ? e.message : "追加に失敗しました";
+				showToast("error", message);
+			}
 		}
 	};
 
@@ -81,55 +102,60 @@ export function AddToCollectionDropdown({
 		);
 	}
 
+	const isPending = addItemMutation.isPending || removeItemMutation.isPending;
+
 	return (
-		<>
-			<DropdownMenu>
-				<DropdownMenuTrigger>
-					<button type="button" className="btn btn-ghost btn-sm gap-1">
+		<DropdownMenu>
+			<DropdownMenuTrigger>
+				<button type="button" className="btn btn-ghost btn-sm gap-1">
+					<Plus className="size-4" />
+					コレクションに追加
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				align="end"
+				side={dropUp ? "top" : "bottom"}
+				className="w-64"
+			>
+				<DropdownMenuLabel>追加先を選択</DropdownMenuLabel>
+				<DropdownMenuSeparator />
+				{collectionsQuery.isLoading ? (
+					<DropdownMenuItem disabled>読み込み中...</DropdownMenuItem>
+				) : collectionsQuery.data?.items.length === 0 ? (
+					<DropdownMenuItem disabled>
+						コレクションがまだありません
+					</DropdownMenuItem>
+				) : (
+					collectionsQuery.data?.items.map((c) => (
+						<DropdownMenuItem
+							key={c.id}
+							onClick={() =>
+								handleToggle(
+									c.id,
+									c.name,
+									c.containsTarget ?? false,
+									c.containsItemId,
+								)
+							}
+							disabled={isPending}
+						>
+							{c.containsTarget ? (
+								<Check className="size-4 shrink-0 text-success" />
+							) : (
+								<Square className="size-4 shrink-0 text-base-content/30" />
+							)}
+							<span className="flex-1 truncate">{c.name}</span>
+						</DropdownMenuItem>
+					))
+				)}
+				<DropdownMenuSeparator />
+				{onNavigateToNew && (
+					<DropdownMenuItem onClick={onNavigateToNew}>
 						<Plus className="size-4" />
-						コレクションに追加
-					</button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent align="end" className="w-64">
-					<DropdownMenuLabel>追加先を選択</DropdownMenuLabel>
-					<DropdownMenuSeparator />
-					{collectionsQuery.isLoading ? (
-						<DropdownMenuItem disabled>読み込み中...</DropdownMenuItem>
-					) : collectionsQuery.data?.items.length === 0 ? (
-						<DropdownMenuItem disabled>
-							コレクションがまだありません
-						</DropdownMenuItem>
-					) : (
-						collectionsQuery.data?.items.map((c) => (
-							<DropdownMenuItem
-								key={c.id}
-								onClick={() => handleAdd(c.id, c.name)}
-								disabled={addItemMutation.isPending}
-							>
-								{c.name}
-							</DropdownMenuItem>
-						))
-					)}
-					<DropdownMenuSeparator />
-					{onNavigateToNew && (
-						<DropdownMenuItem onClick={onNavigateToNew}>
-							<Plus className="size-4" />
-							新規コレクションを作成
-						</DropdownMenuItem>
-					)}
-				</DropdownMenuContent>
-			</DropdownMenu>
-			{feedback && (
-				<Banner
-					variant={feedback.variant}
-					autoHideDuration={2000}
-					onAutoHide={() => setFeedback(null)}
-					dismissible
-					onDismiss={() => setFeedback(null)}
-				>
-					{feedback.message}
-				</Banner>
-			)}
-		</>
+						新規コレクションを作成
+					</DropdownMenuItem>
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }

--- a/apps/web/src/components/user/add-to-collection-dropdown.tsx
+++ b/apps/web/src/components/user/add-to-collection-dropdown.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/lib/user-collections-query-options";
 
 interface AddToCollectionDropdownProps {
-	targetType: "track" | "release" | "circle";
+	targetType: "track" | "release" | "circle" | "artist";
 	targetId: string;
 	currentPath?: string;
 	/** ドロップダウンを上方向に展開する（FABとして使用する場合） */

--- a/apps/web/src/components/user/add-to-collection-dropdown.tsx
+++ b/apps/web/src/components/user/add-to-collection-dropdown.tsx
@@ -1,0 +1,135 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { Banner } from "@/components/ui/banner";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { authClient } from "@/lib/auth-client";
+import {
+	userCollectionMutations,
+	userCollectionsListQueryOptions,
+} from "@/lib/user-collections-query-options";
+
+interface AddToCollectionDropdownProps {
+	targetType: "track" | "release" | "circle";
+	targetId: string;
+	currentPath?: string;
+	/** 「新規コレクションを作成」クリック時の処理。省略時はナビゲーションなし */
+	onNavigateToNew?: () => void;
+}
+
+export function AddToCollectionDropdown({
+	targetType,
+	targetId,
+	currentPath,
+	onNavigateToNew,
+}: AddToCollectionDropdownProps) {
+	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+	const { data: session } = authClient.useSession();
+
+	const [feedback, setFeedback] = useState<{
+		variant: "success" | "error";
+		message: string;
+	} | null>(null);
+
+	const collectionsQuery = useQuery({
+		...userCollectionsListQueryOptions({ kind: "collection" }),
+		enabled: !!session?.user,
+	});
+
+	const addItemMutation = useMutation(
+		userCollectionMutations.addItem(queryClient),
+	);
+
+	const handleAdd = async (collectionId: string, collectionName: string) => {
+		try {
+			await addItemMutation.mutateAsync({
+				id: collectionId,
+				input: { targetType, targetId },
+			});
+			setFeedback({
+				variant: "success",
+				message: `「${collectionName}」に追加しました`,
+			});
+		} catch (e) {
+			const message = e instanceof Error ? e.message : "追加に失敗しました";
+			setFeedback({ variant: "error", message });
+		}
+	};
+
+	// 未ログインの場合はログインページへ誘導するボタンを表示
+	if (!session?.user) {
+		return (
+			<button
+				type="button"
+				className="btn btn-ghost btn-sm gap-1"
+				onClick={() =>
+					navigate({ to: "/login", search: { returnTo: currentPath ?? "/" } })
+				}
+			>
+				<Plus className="size-4" />
+				コレクションに追加
+			</button>
+		);
+	}
+
+	return (
+		<>
+			<DropdownMenu>
+				<DropdownMenuTrigger>
+					<button type="button" className="btn btn-ghost btn-sm gap-1">
+						<Plus className="size-4" />
+						コレクションに追加
+					</button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end" className="w-64">
+					<DropdownMenuLabel>追加先を選択</DropdownMenuLabel>
+					<DropdownMenuSeparator />
+					{collectionsQuery.isLoading ? (
+						<DropdownMenuItem disabled>読み込み中...</DropdownMenuItem>
+					) : collectionsQuery.data?.items.length === 0 ? (
+						<DropdownMenuItem disabled>
+							コレクションがまだありません
+						</DropdownMenuItem>
+					) : (
+						collectionsQuery.data?.items.map((c) => (
+							<DropdownMenuItem
+								key={c.id}
+								onClick={() => handleAdd(c.id, c.name)}
+								disabled={addItemMutation.isPending}
+							>
+								{c.name}
+							</DropdownMenuItem>
+						))
+					)}
+					<DropdownMenuSeparator />
+					{onNavigateToNew && (
+						<DropdownMenuItem onClick={onNavigateToNew}>
+							<Plus className="size-4" />
+							新規コレクションを作成
+						</DropdownMenuItem>
+					)}
+				</DropdownMenuContent>
+			</DropdownMenu>
+			{feedback && (
+				<Banner
+					variant={feedback.variant}
+					autoHideDuration={2000}
+					onAutoHide={() => setFeedback(null)}
+					dismissible
+					onDismiss={() => setFeedback(null)}
+				>
+					{feedback.message}
+				</Banner>
+			)}
+		</>
+	);
+}

--- a/apps/web/src/components/user/collection-url-copy.tsx
+++ b/apps/web/src/components/user/collection-url-copy.tsx
@@ -1,0 +1,51 @@
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { useToast } from "@/components/ui/toast";
+
+interface CollectionUrlCopyProps {
+	shortId: string;
+}
+
+export function CollectionUrlCopy({
+	shortId,
+}: CollectionUrlCopyProps): React.ReactNode {
+	const { showToast } = useToast();
+	const [copied, setCopied] = useState(false);
+
+	const url =
+		typeof window !== "undefined"
+			? `${window.location.origin}/collections/${shortId}`
+			: `/collections/${shortId}`;
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(url);
+			setCopied(true);
+			showToast("success", "URLをコピーしました");
+			setTimeout(() => setCopied(false), 2000);
+		} catch {
+			showToast("error", "コピーに失敗しました");
+		}
+	};
+
+	return (
+		<div className="flex items-center gap-2">
+			<code className="break-all rounded-field bg-base-200 px-2 py-1 text-base-content/70 text-xs">
+				{url}
+			</code>
+			<button
+				type="button"
+				onClick={handleCopy}
+				className="btn btn-ghost btn-xs shrink-0"
+				aria-label="URLをコピー"
+				title="URLをコピー"
+			>
+				{copied ? (
+					<Check className="size-3.5 text-success" />
+				) : (
+					<Copy className="size-3.5" />
+				)}
+			</button>
+		</div>
+	);
+}

--- a/apps/web/src/components/user/floating-like-actions.tsx
+++ b/apps/web/src/components/user/floating-like-actions.tsx
@@ -5,17 +5,15 @@ import { userLikesCheckQueryOptions } from "@/lib/user-collections-query-options
 import { AddToCollectionDropdown } from "./add-to-collection-dropdown";
 import { LikeButton } from "./like-button";
 
-interface LikeActionsProps {
+interface FloatingLikeActionsProps {
 	targetType: "track" | "release" | "circle";
 	targetId: string;
-	size?: "sm" | "md" | "lg";
 }
 
-export function LikeActions({
+export function FloatingLikeActions({
 	targetType,
 	targetId,
-	size = "md",
-}: LikeActionsProps) {
+}: FloatingLikeActionsProps) {
 	const { data: session } = authClient.useSession();
 	const navigate = useNavigate();
 	const location = useLocation();
@@ -28,19 +26,24 @@ export function LikeActions({
 
 	const isLiked = checkQuery.data?.results[0]?.liked ?? false;
 
+	if (!session?.user) {
+		return null;
+	}
+
 	return (
 		<div className="flex items-center gap-2">
 			<LikeButton
 				targetType={targetType}
 				targetId={targetId}
 				isLiked={isLiked}
-				size={size}
+				size="md"
 				currentPath={currentPath}
 			/>
 			<AddToCollectionDropdown
 				targetType={targetType}
 				targetId={targetId}
 				currentPath={currentPath}
+				dropUp
 				onNavigateToNew={() => navigate({ to: "/user/collections/new" })}
 			/>
 		</div>

--- a/apps/web/src/components/user/floating-like-actions.tsx
+++ b/apps/web/src/components/user/floating-like-actions.tsx
@@ -6,7 +6,7 @@ import { AddToCollectionDropdown } from "./add-to-collection-dropdown";
 import { LikeButton } from "./like-button";
 
 interface FloatingLikeActionsProps {
-	targetType: "track" | "release" | "circle";
+	targetType: "track" | "release" | "circle" | "artist";
 	targetId: string;
 }
 

--- a/apps/web/src/components/user/item-type-badge.tsx
+++ b/apps/web/src/components/user/item-type-badge.tsx
@@ -41,7 +41,9 @@ export function ItemTypeBadge({
 	const sizeClass = size === "sm" ? "badge-sm" : "";
 
 	return (
-		<span className={`badge ${config.badgeClass} ${sizeClass} gap-1`}>
+		<span
+			className={`badge ${config.badgeClass} ${sizeClass} gap-1 whitespace-nowrap`}
+		>
 			<Icon className="size-3" />
 			{config.label}
 		</span>

--- a/apps/web/src/components/user/item-type-badge.tsx
+++ b/apps/web/src/components/user/item-type-badge.tsx
@@ -1,0 +1,49 @@
+import { Disc3, Music, UserRound, Users } from "lucide-react";
+import type { CollectionItemType } from "@/lib/api-client";
+
+interface ItemTypeBadgeProps {
+	itemType: CollectionItemType;
+	size?: "sm" | "md";
+}
+
+const ITEM_TYPE_CONFIG: Record<
+	CollectionItemType,
+	{ label: string; badgeClass: string; icon: typeof Music }
+> = {
+	track: {
+		label: "楽曲",
+		badgeClass: "badge-info",
+		icon: Music,
+	},
+	release: {
+		label: "アルバム",
+		badgeClass: "badge-secondary",
+		icon: Disc3,
+	},
+	circle: {
+		label: "サークル",
+		badgeClass: "badge-success",
+		icon: Users,
+	},
+	artist: {
+		label: "アーティスト",
+		badgeClass: "badge-accent",
+		icon: UserRound,
+	},
+};
+
+export function ItemTypeBadge({
+	itemType,
+	size = "sm",
+}: ItemTypeBadgeProps): React.ReactNode {
+	const config = ITEM_TYPE_CONFIG[itemType];
+	const Icon = config.icon;
+	const sizeClass = size === "sm" ? "badge-sm" : "";
+
+	return (
+		<span className={`badge ${config.badgeClass} ${sizeClass} gap-1`}>
+			<Icon className="size-3" />
+			{config.label}
+		</span>
+	);
+}

--- a/apps/web/src/components/user/like-actions.tsx
+++ b/apps/web/src/components/user/like-actions.tsx
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+import { useLocation, useNavigate } from "@tanstack/react-router";
+import { authClient } from "@/lib/auth-client";
+import { userLikesCheckQueryOptions } from "@/lib/user-collections-query-options";
+import { AddToCollectionDropdown } from "./add-to-collection-dropdown";
+import { LikeButton } from "./like-button";
+
+interface LikeActionsProps {
+	targetType: "track" | "release" | "circle";
+	targetId: string;
+	size?: "sm" | "md" | "lg";
+}
+
+export function LikeActions({
+	targetType,
+	targetId,
+	size = "md",
+}: LikeActionsProps) {
+	const { data: session } = authClient.useSession();
+	const navigate = useNavigate();
+	const location = useLocation();
+	const currentPath = location.pathname;
+
+	const checkQuery = useQuery({
+		...userLikesCheckQueryOptions([{ targetType, targetId }]),
+		enabled: !!session?.user,
+	});
+
+	const isLiked = checkQuery.data?.results[0]?.liked ?? false;
+
+	return (
+		<div className="flex items-center gap-2">
+			<LikeButton
+				targetType={targetType}
+				targetId={targetId}
+				isLiked={isLiked}
+				size={size}
+				currentPath={currentPath}
+			/>
+			<AddToCollectionDropdown
+				targetType={targetType}
+				targetId={targetId}
+				currentPath={currentPath}
+				onNavigateToNew={() => navigate({ to: "/user/collections/new" })}
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/components/user/like-button.tsx
+++ b/apps/web/src/components/user/like-button.tsx
@@ -25,10 +25,13 @@ export function LikeButton({
 	const navigate = useNavigate();
 	const { data: session } = authClient.useSession();
 
-	const [optimisticLiked, setOptimisticLiked] = useState(isLiked);
+	// ミューテーション中のみ楽観的な値を保持する。null のときは isLiked prop を使用する
+	const [pendingLiked, setPendingLiked] = useState<boolean | null>(null);
 
 	const addMutation = useMutation(userLikesMutations.add(queryClient));
 	const removeMutation = useMutation(userLikesMutations.remove(queryClient));
+
+	const displayLiked = pendingLiked !== null ? pendingLiked : isLiked;
 
 	const handleClick = async () => {
 		if (!session?.user) {
@@ -39,8 +42,8 @@ export function LikeButton({
 			return;
 		}
 
-		const willLike = !optimisticLiked;
-		setOptimisticLiked(willLike);
+		const willLike = !displayLiked;
+		setPendingLiked(willLike);
 
 		try {
 			if (willLike) {
@@ -48,8 +51,12 @@ export function LikeButton({
 			} else {
 				await removeMutation.mutateAsync({ targetType, targetId });
 			}
+			// ミューテーション成功後は isLiked prop がキャッシュ更新で正しい値になるため
+			// pendingLiked をクリアして prop に委譲する
+			setPendingLiked(null);
 		} catch {
-			setOptimisticLiked(!willLike);
+			// エラー時は楽観更新を元に戻す
+			setPendingLiked(null);
 		}
 	};
 
@@ -66,18 +73,18 @@ export function LikeButton({
 			type="button"
 			onClick={handleClick}
 			disabled={isPending}
-			aria-pressed={optimisticLiked}
-			aria-label={optimisticLiked ? "お気に入りから削除" : "お気に入りに追加"}
+			aria-pressed={displayLiked}
+			aria-label={displayLiked ? "お気に入りから削除" : "お気に入りに追加"}
 			className={cn(
 				"btn btn-ghost gap-1",
 				size === "sm" && "btn-sm",
 				size === "lg" && "btn-lg",
-				optimisticLiked && "text-error",
+				displayLiked && "text-error",
 			)}
 		>
 			<Heart
-				className={cn(iconSizeClass, optimisticLiked && "fill-current")}
-				strokeWidth={optimisticLiked ? 1.5 : 2}
+				className={cn(iconSizeClass, displayLiked && "fill-current")}
+				strokeWidth={displayLiked ? 1.5 : 2}
 			/>
 		</button>
 	);

--- a/apps/web/src/components/user/like-button.tsx
+++ b/apps/web/src/components/user/like-button.tsx
@@ -1,0 +1,84 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Heart } from "lucide-react";
+import { useState } from "react";
+import { authClient } from "@/lib/auth-client";
+import { userLikesMutations } from "@/lib/user-collections-query-options";
+import { cn } from "@/lib/utils";
+
+interface LikeButtonProps {
+	targetType: "track" | "release" | "circle";
+	targetId: string;
+	isLiked: boolean;
+	size?: "sm" | "md" | "lg";
+	currentPath?: string;
+}
+
+export function LikeButton({
+	targetType,
+	targetId,
+	isLiked,
+	size = "md",
+	currentPath,
+}: LikeButtonProps) {
+	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+	const { data: session } = authClient.useSession();
+
+	const [optimisticLiked, setOptimisticLiked] = useState(isLiked);
+
+	const addMutation = useMutation(userLikesMutations.add(queryClient));
+	const removeMutation = useMutation(userLikesMutations.remove(queryClient));
+
+	const handleClick = async () => {
+		if (!session?.user) {
+			navigate({
+				to: "/login",
+				search: { returnTo: currentPath ?? "/" },
+			});
+			return;
+		}
+
+		const willLike = !optimisticLiked;
+		setOptimisticLiked(willLike);
+
+		try {
+			if (willLike) {
+				await addMutation.mutateAsync({ targetType, targetId });
+			} else {
+				await removeMutation.mutateAsync({ targetType, targetId });
+			}
+		} catch {
+			setOptimisticLiked(!willLike);
+		}
+	};
+
+	const isPending = addMutation.isPending || removeMutation.isPending;
+
+	const iconSizeClass = cn(
+		size === "sm" && "size-4",
+		size === "md" && "size-5",
+		size === "lg" && "size-6",
+	);
+
+	return (
+		<button
+			type="button"
+			onClick={handleClick}
+			disabled={isPending}
+			aria-pressed={optimisticLiked}
+			aria-label={optimisticLiked ? "お気に入りから削除" : "お気に入りに追加"}
+			className={cn(
+				"btn btn-ghost gap-1",
+				size === "sm" && "btn-sm",
+				size === "lg" && "btn-lg",
+				optimisticLiked && "text-error",
+			)}
+		>
+			<Heart
+				className={cn(iconSizeClass, optimisticLiked && "fill-current")}
+				strokeWidth={optimisticLiked ? 1.5 : 2}
+			/>
+		</button>
+	);
+}

--- a/apps/web/src/components/user/like-button.tsx
+++ b/apps/web/src/components/user/like-button.tsx
@@ -7,7 +7,7 @@ import { userLikesMutations } from "@/lib/user-collections-query-options";
 import { cn } from "@/lib/utils";
 
 interface LikeButtonProps {
-	targetType: "track" | "release" | "circle";
+	targetType: "track" | "release" | "circle" | "artist";
 	targetId: string;
 	isLiked: boolean;
 	size?: "sm" | "md" | "lg";

--- a/apps/web/src/components/user/sortable-collection-items.tsx
+++ b/apps/web/src/components/user/sortable-collection-items.tsx
@@ -1,0 +1,120 @@
+import {
+	closestCenter,
+	DndContext,
+	type DragEndEvent,
+	KeyboardSensor,
+	PointerSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import {
+	arrayMove,
+	SortableContext,
+	sortableKeyboardCoordinates,
+	useSortable,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface SortableItem {
+	id: string;
+}
+
+interface SortableCollectionItemsProps<T extends SortableItem> {
+	items: T[];
+	renderItem: (item: T, index: number) => ReactNode;
+	onReorder: (newOrder: T[]) => void;
+	disabled?: boolean;
+}
+
+export function SortableCollectionItems<T extends SortableItem>({
+	items,
+	renderItem,
+	onReorder,
+	disabled = false,
+}: SortableCollectionItemsProps<T>) {
+	const sensors = useSensors(
+		useSensor(PointerSensor, {
+			activationConstraint: { distance: 5 },
+		}),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		}),
+	);
+
+	const handleDragEnd = (event: DragEndEvent) => {
+		const { active, over } = event;
+		if (!over || active.id === over.id) return;
+
+		const oldIndex = items.findIndex((i) => i.id === active.id);
+		const newIndex = items.findIndex((i) => i.id === over.id);
+		if (oldIndex === -1 || newIndex === -1) return;
+
+		onReorder(arrayMove(items, oldIndex, newIndex));
+	};
+
+	if (disabled) {
+		return (
+			<ul className="space-y-2">
+				{items.map((item, idx) => (
+					<li key={item.id}>{renderItem(item, idx)}</li>
+				))}
+			</ul>
+		);
+	}
+
+	return (
+		<DndContext
+			sensors={sensors}
+			collisionDetection={closestCenter}
+			onDragEnd={handleDragEnd}
+		>
+			<SortableContext
+				items={items.map((i) => i.id)}
+				strategy={verticalListSortingStrategy}
+			>
+				<ul className="space-y-2">
+					{items.map((item, index) => (
+						<SortableRow key={item.id} id={item.id}>
+							{renderItem(item, index)}
+						</SortableRow>
+					))}
+				</ul>
+			</SortableContext>
+		</DndContext>
+	);
+}
+
+function SortableRow({ id, children }: { id: string; children: ReactNode }) {
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable({ id });
+
+	const style = {
+		transform: CSS.Transform.toString(transform),
+		transition,
+		opacity: isDragging ? 0.5 : 1,
+	};
+
+	return (
+		<li ref={setNodeRef} style={style} className="flex items-center gap-2">
+			<button
+				type="button"
+				aria-label="並び替えハンドル"
+				className="btn btn-ghost btn-sm cursor-grab touch-none active:cursor-grabbing"
+				{...attributes}
+				{...listeners}
+			>
+				<GripVertical className="size-4 opacity-60" />
+			</button>
+			<div className="flex-1">{children}</div>
+		</li>
+	);
+}

--- a/apps/web/src/components/user/visibility-badge.tsx
+++ b/apps/web/src/components/user/visibility-badge.tsx
@@ -36,7 +36,9 @@ export function VisibilityBadge({
 	const sizeClass = size === "sm" ? "badge-sm" : "";
 
 	return (
-		<span className={`badge ${config.badgeClass} ${sizeClass} gap-1`}>
+		<span
+			className={`badge ${config.badgeClass} ${sizeClass} gap-1 whitespace-nowrap`}
+		>
 			<Icon className="size-3" />
 			{config.label}
 		</span>

--- a/apps/web/src/components/user/visibility-badge.tsx
+++ b/apps/web/src/components/user/visibility-badge.tsx
@@ -1,0 +1,44 @@
+import { Globe, Link, Lock } from "lucide-react";
+import type { UserCollectionVisibility } from "@/lib/api-client";
+
+interface VisibilityBadgeProps {
+	visibility: UserCollectionVisibility;
+	size?: "sm" | "md";
+}
+
+const VISIBILITY_CONFIG: Record<
+	UserCollectionVisibility,
+	{ label: string; badgeClass: string; icon: typeof Lock }
+> = {
+	private: {
+		label: "非公開",
+		badgeClass: "badge-ghost",
+		icon: Lock,
+	},
+	unlisted: {
+		label: "限定公開",
+		badgeClass: "badge-info",
+		icon: Link,
+	},
+	public: {
+		label: "公開",
+		badgeClass: "badge-success",
+		icon: Globe,
+	},
+};
+
+export function VisibilityBadge({
+	visibility,
+	size = "sm",
+}: VisibilityBadgeProps): React.ReactNode {
+	const config = VISIBILITY_CONFIG[visibility];
+	const Icon = config.icon;
+	const sizeClass = size === "sm" ? "badge-sm" : "";
+
+	return (
+		<span className={`badge ${config.badgeClass} ${sizeClass} gap-1`}>
+			<Icon className="size-3" />
+			{config.label}
+		</span>
+	);
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -3319,6 +3319,7 @@ export interface UserCollectionUpdateInput {
 	description?: string | null;
 	visibility?: UserCollectionVisibility;
 	ordered?: boolean;
+	itemType?: CollectionItemType | null;
 }
 
 export interface CollectionItemAddInput {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -199,6 +199,11 @@ async function fetchWithAuth<T>(
 		throw new Error(errorData.error || `HTTP ${res.status}`);
 	}
 
+	// 204 No Content や空レスポンスはボディが存在しないためパースしない
+	if (res.status === 204 || res.headers.get("content-length") === "0") {
+		return undefined as T;
+	}
+
 	return res.json();
 }
 
@@ -3008,7 +3013,7 @@ export const tagsApi = {
 		const searchParams = new URLSearchParams();
 		if (force) searchParams.set("force", "true");
 		const query = searchParams.toString();
-		return fetchWithAuth<{ success: boolean; id: string }>(
+		return fetchWithAuth<void>(
 			`/api/admin/tags/${id}${query ? `?${query}` : ""}`,
 			{
 				method: "DELETE",
@@ -3237,6 +3242,10 @@ export interface UserCollectionListItem {
 	createdAt: string;
 	updatedAt: string;
 	itemCount: number;
+	/** targetType/targetId を指定してフェッチした場合のみ含まれる */
+	containsTarget?: boolean;
+	/** containsTarget=true の場合、削除に使用するアイテムID */
+	containsItemId?: string | null;
 }
 
 export interface TrackTarget {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -3227,7 +3227,12 @@ export const albumRequestsApi = {
 
 export type UserCollectionKind = "collection" | "playlist";
 export type UserCollectionVisibility = "private" | "unlisted" | "public";
-export type CollectionItemTargetType = "track" | "release" | "circle";
+export type CollectionItemTargetType =
+	| "track"
+	| "release"
+	| "circle"
+	| "artist";
+export type CollectionItemType = "track" | "release" | "circle" | "artist";
 
 export interface UserCollectionListItem {
 	id: string;
@@ -3237,6 +3242,7 @@ export interface UserCollectionListItem {
 	visibility: UserCollectionVisibility;
 	ordered: boolean;
 	isDefaultLiked: boolean;
+	itemType: CollectionItemType | null;
 	shortId: string | null;
 	coverImageUrl: string | null;
 	createdAt: string;
@@ -3271,7 +3277,18 @@ export interface CircleTarget {
 	nameEn: string | null;
 }
 
-export type CollectionItemTarget = TrackTarget | ReleaseTarget | CircleTarget;
+export interface ArtistTarget {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+}
+
+export type CollectionItemTarget =
+	| TrackTarget
+	| ReleaseTarget
+	| CircleTarget
+	| ArtistTarget;
 
 export interface UserCollectionItem {
 	id: string;
@@ -3294,6 +3311,7 @@ export interface UserCollectionCreateInput {
 	kind?: UserCollectionKind;
 	visibility?: UserCollectionVisibility;
 	ordered?: boolean;
+	itemType?: CollectionItemType | null;
 }
 
 export interface UserCollectionUpdateInput {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -3217,3 +3217,154 @@ export const albumRequestsApi = {
 			body: JSON.stringify(data),
 		}),
 };
+
+// ===== ユーザーコレクション =====
+
+export type UserCollectionKind = "collection" | "playlist";
+export type UserCollectionVisibility = "private" | "unlisted" | "public";
+export type CollectionItemTargetType = "track" | "release" | "circle";
+
+export interface UserCollectionListItem {
+	id: string;
+	kind: UserCollectionKind;
+	name: string;
+	description: string | null;
+	visibility: UserCollectionVisibility;
+	ordered: boolean;
+	isDefaultLiked: boolean;
+	shortId: string | null;
+	coverImageUrl: string | null;
+	createdAt: string;
+	updatedAt: string;
+	itemCount: number;
+}
+
+export interface TrackTarget {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+	releaseId: string;
+}
+
+export interface ReleaseTarget {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+	releaseDate: string | null;
+}
+
+export interface CircleTarget {
+	id: string;
+	name: string;
+	nameJa: string | null;
+	nameEn: string | null;
+}
+
+export type CollectionItemTarget = TrackTarget | ReleaseTarget | CircleTarget;
+
+export interface UserCollectionItem {
+	id: string;
+	collectionId: string;
+	targetType: CollectionItemTargetType;
+	targetId: string;
+	position: number | null;
+	note: string | null;
+	addedAt: string;
+	target: CollectionItemTarget | null;
+}
+
+export interface UserCollectionDetail extends UserCollectionListItem {
+	items: UserCollectionItem[];
+}
+
+export interface UserCollectionCreateInput {
+	name: string;
+	description?: string | null;
+	kind?: UserCollectionKind;
+	visibility?: UserCollectionVisibility;
+	ordered?: boolean;
+}
+
+export interface UserCollectionUpdateInput {
+	name?: string;
+	description?: string | null;
+	visibility?: UserCollectionVisibility;
+	ordered?: boolean;
+}
+
+export interface CollectionItemAddInput {
+	targetType: CollectionItemTargetType;
+	targetId: string;
+	note?: string | null;
+}
+
+export interface CollectionItemReorderInput {
+	items: Array<{ itemId: string; position: number }>;
+}
+
+export type LikeTarget = {
+	targetType: CollectionItemTargetType;
+	targetId: string;
+};
+
+export type LikeCheckResult = {
+	targetType: CollectionItemTargetType;
+	targetId: string;
+	liked: boolean;
+};
+
+export const userCollectionsApi = {
+	create: (input: UserCollectionCreateInput) =>
+		fetchWithAuth<UserCollectionListItem>("/api/user/collections", {
+			method: "POST",
+			body: JSON.stringify(input),
+		}),
+
+	update: (id: string, input: UserCollectionUpdateInput) =>
+		fetchWithAuth<UserCollectionListItem>(`/api/user/collections/${id}`, {
+			method: "PATCH",
+			body: JSON.stringify(input),
+		}),
+
+	delete: (id: string) =>
+		fetchWithAuth<void>(`/api/user/collections/${id}`, { method: "DELETE" }),
+
+	addItem: (id: string, input: CollectionItemAddInput) =>
+		fetchWithAuth<UserCollectionItem>(`/api/user/collections/${id}/items`, {
+			method: "POST",
+			body: JSON.stringify(input),
+		}),
+
+	removeItem: (id: string, itemId: string) =>
+		fetchWithAuth<void>(`/api/user/collections/${id}/items/${itemId}`, {
+			method: "DELETE",
+		}),
+
+	reorderItems: (id: string, input: CollectionItemReorderInput) =>
+		fetchWithAuth<{ success: boolean }>(
+			`/api/user/collections/${id}/items/reorder`,
+			{
+				method: "PATCH",
+				body: JSON.stringify(input),
+			},
+		),
+} as const;
+
+export const userLikesApi = {
+	add: (input: LikeTarget) =>
+		fetchWithAuth<{
+			collection: UserCollectionListItem;
+			item: UserCollectionItem;
+		}>("/api/user/likes", {
+			method: "POST",
+			body: JSON.stringify(input),
+		}),
+
+	remove: (input: LikeTarget) =>
+		fetchWithAuth<void>("/api/user/likes", {
+			method: "DELETE",
+			body: JSON.stringify(input),
+		}),
+} as const;

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -585,6 +585,52 @@ export interface PublicTagCloudItem {
 	weight: number;
 }
 
+/** 公開コレクションのオーナー情報 */
+export interface PublicCollectionOwner {
+	id: string;
+	name: string;
+}
+
+/** 公開コレクション詳細 */
+export interface PublicCollectionDetail {
+	id: string;
+	shortId: string;
+	name: string;
+	description: string | null;
+	kind: "collection" | "playlist";
+	visibility: "public" | "unlisted";
+	ordered: boolean;
+	owner: PublicCollectionOwner;
+	createdAt: string;
+	updatedAt: string;
+	items: PublicCollectionItem[];
+}
+
+/** 公開コレクションのアイテム */
+export interface PublicCollectionItem {
+	id: string;
+	collectionId: string;
+	targetType: "track" | "release" | "circle";
+	targetId: string;
+	position: number | null;
+	note: string | null;
+	addedAt: string;
+	target: {
+		id: string;
+		name: string;
+		nameJa: string | null;
+		nameEn: string | null;
+		releaseId?: string;
+		releaseDate?: string | null;
+	} | null;
+}
+
+/** 公開コレクション API レスポンス */
+interface PublicCollectionResponse {
+	collection: Omit<PublicCollectionDetail, "items">;
+	items: PublicCollectionItem[];
+}
+
 /** ジャンルマスタ項目 */
 export interface PublicGenreItem {
 	code: string;
@@ -1197,6 +1243,16 @@ export const publicApi = {
 			return publicFetch<{ data: PublicTagCloudItem[] }>(
 				`/api/public/tags/cloud${query ? `?${query}` : ""}`,
 			);
+		},
+	},
+
+	collections: {
+		/** 公開コレクション詳細を shortId で取得 */
+		getByShortId: async (shortId: string): Promise<PublicCollectionDetail> => {
+			const res = await publicFetch<PublicCollectionResponse>(
+				`/api/public/collections/${shortId}`,
+			);
+			return { ...res.collection, items: res.items };
 		},
 	},
 };

--- a/apps/web/src/lib/public-api.ts
+++ b/apps/web/src/lib/public-api.ts
@@ -600,6 +600,7 @@ export interface PublicCollectionDetail {
 	kind: "collection" | "playlist";
 	visibility: "public" | "unlisted";
 	ordered: boolean;
+	itemType: "track" | "release" | "circle" | "artist" | null;
 	owner: PublicCollectionOwner;
 	createdAt: string;
 	updatedAt: string;
@@ -610,7 +611,7 @@ export interface PublicCollectionDetail {
 export interface PublicCollectionItem {
 	id: string;
 	collectionId: string;
-	targetType: "track" | "release" | "circle";
+	targetType: "track" | "release" | "circle" | "artist";
 	targetId: string;
 	position: number | null;
 	note: string | null;

--- a/apps/web/src/lib/public-collections-query-options.ts
+++ b/apps/web/src/lib/public-collections-query-options.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from "@tanstack/react-query";
+import type { PublicCollectionDetail } from "@/lib/public-api";
+import { publicApi } from "@/lib/public-api";
+
+export type { PublicCollectionDetail };
+
+const STALE_TIME_COLLECTION = 60_000; // 1分
+
+export function publicCollectionDetailQueryOptions(shortId: string) {
+	return queryOptions({
+		queryKey: ["public", "collections", "detail", shortId] as const,
+		queryFn: (): Promise<PublicCollectionDetail> =>
+			publicApi.collections.getByShortId(shortId),
+		staleTime: STALE_TIME_COLLECTION,
+	});
+}

--- a/apps/web/src/lib/user-collections-query-options.ts
+++ b/apps/web/src/lib/user-collections-query-options.ts
@@ -20,6 +20,7 @@ import type {
 	CollectionItemAddInput,
 	CollectionItemReorderInput,
 	CollectionItemTargetType,
+	CollectionItemType,
 	LikeTarget,
 	UserCollectionDetail,
 	UserCollectionKind,
@@ -35,6 +36,7 @@ export function userCollectionsListQueryOptions(params?: {
 	kind?: UserCollectionKind;
 	target?: { type: CollectionItemTargetType; id: string };
 	excludeDefaultLiked?: boolean;
+	itemType?: CollectionItemType;
 }) {
 	const searchParams = new URLSearchParams();
 	if (params?.kind) searchParams.set("kind", params.kind);
@@ -44,6 +46,9 @@ export function userCollectionsListQueryOptions(params?: {
 	}
 	if (params?.excludeDefaultLiked) {
 		searchParams.set("excludeDefaultLiked", "true");
+	}
+	if (params?.itemType) {
+		searchParams.set("itemType", params.itemType);
 	}
 	const query = searchParams.toString();
 	const endpoint = query
@@ -67,7 +72,7 @@ export function userCollectionDetailQueryOptions(id: string) {
 
 export function userLikesCheckQueryOptions(
 	items: Array<{
-		targetType: "track" | "release" | "circle";
+		targetType: CollectionItemTargetType;
 		targetId: string;
 	}>,
 ) {
@@ -77,7 +82,7 @@ export function userLikesCheckQueryOptions(
 		queryFn: () =>
 			ssrFetch<{
 				results: Array<{
-					targetType: "track" | "release" | "circle";
+					targetType: CollectionItemTargetType;
 					targetId: string;
 					liked: boolean;
 				}>;

--- a/apps/web/src/lib/user-collections-query-options.ts
+++ b/apps/web/src/lib/user-collections-query-options.ts
@@ -1,0 +1,182 @@
+/**
+ * ユーザーコレクション / お気に入り機能の TanStack Query ファクトリ
+ *
+ * GET 系はSSR対応の ssrFetch を使用し、ローダーでのプリフェッチも可能。
+ * 書き込み系ミューテーションはキャッシュ無効化を自動で行う。
+ *
+ * @example
+ * // ルートのloader
+ * loader: ({ context }) =>
+ *   context.queryClient.ensureQueryData(userCollectionsListQueryOptions())
+ *
+ * // コンポーネント
+ * const { data } = useQuery(userCollectionsListQueryOptions())
+ * const queryClient = useQueryClient();
+ * const createMutation = useMutation(userCollectionMutations.create(queryClient));
+ */
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { ssrFetch } from "@/functions/ssr-fetcher";
+import type {
+	CollectionItemAddInput,
+	CollectionItemReorderInput,
+	LikeTarget,
+	UserCollectionDetail,
+	UserCollectionKind,
+	UserCollectionListItem,
+	UserCollectionUpdateInput,
+} from "@/lib/api-client";
+import { userCollectionsApi, userLikesApi } from "@/lib/api-client";
+import { STALE_TIME } from "@/lib/query-options";
+
+// ===== クエリオプション =====
+
+export function userCollectionsListQueryOptions(params?: {
+	kind?: UserCollectionKind;
+}) {
+	const endpoint = params?.kind
+		? `/api/user/collections?kind=${params.kind}`
+		: "/api/user/collections";
+	return queryOptions({
+		queryKey: ["user", "collections", "list", params ?? null] as const,
+		queryFn: () => ssrFetch<{ items: UserCollectionListItem[] }>(endpoint),
+		staleTime: STALE_TIME.SHORT,
+	});
+}
+
+export function userCollectionDetailQueryOptions(id: string) {
+	return queryOptions({
+		queryKey: ["user", "collections", "detail", id] as const,
+		queryFn: () =>
+			ssrFetch<UserCollectionDetail>(`/api/user/collections/${id}`),
+		staleTime: STALE_TIME.SHORT,
+	});
+}
+
+export function userLikesCheckQueryOptions(
+	items: Array<{
+		targetType: "track" | "release" | "circle";
+		targetId: string;
+	}>,
+) {
+	const query = items.map((i) => `${i.targetType}:${i.targetId}`).join(",");
+	return queryOptions({
+		queryKey: ["user", "likes", "check", items] as const,
+		queryFn: () =>
+			ssrFetch<{
+				results: Array<{
+					targetType: "track" | "release" | "circle";
+					targetId: string;
+					liked: boolean;
+				}>;
+			}>(`/api/user/likes/check?items=${encodeURIComponent(query)}`),
+		enabled: items.length > 0,
+		staleTime: STALE_TIME.SHORT,
+	});
+}
+
+// ===== ミューテーション =====
+
+export const userCollectionMutations = {
+	create: (queryClient: QueryClient) => ({
+		mutationFn: (input: Parameters<typeof userCollectionsApi.create>[0]) =>
+			userCollectionsApi.create(input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["user", "collections"] });
+		},
+	}),
+
+	update: (queryClient: QueryClient) => ({
+		mutationFn: ({
+			id,
+			input,
+		}: {
+			id: string;
+			input: UserCollectionUpdateInput;
+		}) => userCollectionsApi.update(id, input),
+		onSuccess: (
+			_data: UserCollectionListItem,
+			variables: { id: string; input: UserCollectionUpdateInput },
+		) => {
+			queryClient.invalidateQueries({ queryKey: ["user", "collections"] });
+			queryClient.invalidateQueries({
+				queryKey: ["user", "collections", "detail", variables.id],
+			});
+		},
+	}),
+
+	delete: (queryClient: QueryClient) => ({
+		mutationFn: (id: string) => userCollectionsApi.delete(id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["user", "collections"] });
+		},
+	}),
+
+	addItem: (queryClient: QueryClient) => ({
+		mutationFn: ({
+			id,
+			input,
+		}: {
+			id: string;
+			input: CollectionItemAddInput;
+		}) => userCollectionsApi.addItem(id, input),
+		onSuccess: (
+			_data: unknown,
+			variables: { id: string; input: CollectionItemAddInput },
+		) => {
+			queryClient.invalidateQueries({
+				queryKey: ["user", "collections", "detail", variables.id],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["user", "collections", "list"],
+			});
+			queryClient.invalidateQueries({ queryKey: ["user", "likes"] });
+		},
+	}),
+
+	removeItem: (queryClient: QueryClient) => ({
+		mutationFn: ({ id, itemId }: { id: string; itemId: string }) =>
+			userCollectionsApi.removeItem(id, itemId),
+		onSuccess: (_data: unknown, variables: { id: string; itemId: string }) => {
+			queryClient.invalidateQueries({
+				queryKey: ["user", "collections", "detail", variables.id],
+			});
+			queryClient.invalidateQueries({ queryKey: ["user", "likes"] });
+		},
+	}),
+
+	reorderItems: (queryClient: QueryClient) => ({
+		mutationFn: ({
+			id,
+			input,
+		}: {
+			id: string;
+			input: CollectionItemReorderInput;
+		}) => userCollectionsApi.reorderItems(id, input),
+		onSuccess: (
+			_data: unknown,
+			variables: { id: string; input: CollectionItemReorderInput },
+		) => {
+			queryClient.invalidateQueries({
+				queryKey: ["user", "collections", "detail", variables.id],
+			});
+		},
+	}),
+} as const;
+
+export const userLikesMutations = {
+	add: (queryClient: QueryClient) => ({
+		mutationFn: (input: LikeTarget) => userLikesApi.add(input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["user", "likes"] });
+			queryClient.invalidateQueries({ queryKey: ["user", "collections"] });
+		},
+	}),
+
+	remove: (queryClient: QueryClient) => ({
+		mutationFn: (input: LikeTarget) => userLikesApi.remove(input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["user", "likes"] });
+			queryClient.invalidateQueries({ queryKey: ["user", "collections"] });
+		},
+	}),
+} as const;

--- a/apps/web/src/lib/user-collections-query-options.ts
+++ b/apps/web/src/lib/user-collections-query-options.ts
@@ -19,6 +19,7 @@ import { ssrFetch } from "@/functions/ssr-fetcher";
 import type {
 	CollectionItemAddInput,
 	CollectionItemReorderInput,
+	CollectionItemTargetType,
 	LikeTarget,
 	UserCollectionDetail,
 	UserCollectionKind,
@@ -32,9 +33,21 @@ import { STALE_TIME } from "@/lib/query-options";
 
 export function userCollectionsListQueryOptions(params?: {
 	kind?: UserCollectionKind;
+	target?: { type: CollectionItemTargetType; id: string };
+	excludeDefaultLiked?: boolean;
 }) {
-	const endpoint = params?.kind
-		? `/api/user/collections?kind=${params.kind}`
+	const searchParams = new URLSearchParams();
+	if (params?.kind) searchParams.set("kind", params.kind);
+	if (params?.target) {
+		searchParams.set("targetType", params.target.type);
+		searchParams.set("targetId", params.target.id);
+	}
+	if (params?.excludeDefaultLiked) {
+		searchParams.set("excludeDefaultLiked", "true");
+	}
+	const query = searchParams.toString();
+	const endpoint = query
+		? `/api/user/collections?${query}`
 		: "/api/user/collections";
 	return queryOptions({
 		queryKey: ["user", "collections", "list", params ?? null] as const,
@@ -139,6 +152,9 @@ export const userCollectionMutations = {
 		onSuccess: (_data: unknown, variables: { id: string; itemId: string }) => {
 			queryClient.invalidateQueries({
 				queryKey: ["user", "collections", "detail", variables.id],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["user", "collections", "list"],
 			});
 			queryClient.invalidateQueries({ queryKey: ["user", "likes"] });
 		},

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
 	Scripts,
 } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import { ToastProvider } from "@/components/ui/toast";
 import { APP_NAME } from "@/lib/head";
 import { ThemeProvider } from "@/lib/theme";
 import appCss from "../index.css?url";
@@ -68,9 +69,11 @@ function RootDocument() {
 			</head>
 			<body>
 				<QueryClientProvider client={queryClient}>
-					<ThemeProvider>
-						<Outlet />
-					</ThemeProvider>
+					<ToastProvider>
+						<ThemeProvider>
+							<Outlet />
+						</ThemeProvider>
+					</ToastProvider>
 				</QueryClientProvider>
 				<TanStackRouterDevtools position="bottom-left" />
 				<Scripts />

--- a/apps/web/src/routes/_public/artists_.$id.tsx
+++ b/apps/web/src/routes/_public/artists_.$id.tsx
@@ -16,6 +16,7 @@ import {
 	WorkStatsSection,
 	WorkStatsSkeleton,
 } from "@/components/public";
+import { FloatingLikeActions } from "@/components/user/floating-like-actions";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import {
 	type ArtistDetailTab,
@@ -205,6 +206,7 @@ function ArtistDetailPage() {
 						{role.label}
 					</span>
 				))}
+				actions={<FloatingLikeActions targetType="artist" targetId={id} />}
 			/>
 
 			{/* 統計カード */}

--- a/apps/web/src/routes/_public/circles_.$id.tsx
+++ b/apps/web/src/routes/_public/circles_.$id.tsx
@@ -26,6 +26,7 @@ import {
 	WorkStatsSection,
 	WorkStatsSkeleton,
 } from "@/components/public";
+import { LikeActions } from "@/components/user/like-actions";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import {
 	type CircleDetailTab,
@@ -255,6 +256,9 @@ function CircleDetailPage() {
 						: undefined
 				}
 			>
+				{/* ♥ボタン + コレクション追加 */}
+				<LikeActions targetType="circle" targetId={circle.id} />
+
 				{circle.links.length > 0 &&
 					circle.links.map((link) => (
 						<ExternalLink

--- a/apps/web/src/routes/_public/circles_.$id.tsx
+++ b/apps/web/src/routes/_public/circles_.$id.tsx
@@ -26,7 +26,7 @@ import {
 	WorkStatsSection,
 	WorkStatsSkeleton,
 } from "@/components/public";
-import { LikeActions } from "@/components/user/like-actions";
+import { FloatingLikeActions } from "@/components/user/floating-like-actions";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import {
 	type CircleDetailTab,
@@ -255,10 +255,10 @@ function CircleDetailPage() {
 							]
 						: undefined
 				}
+				actions={
+					<FloatingLikeActions targetType="circle" targetId={circle.id} />
+				}
 			>
-				{/* ♥ボタン + コレクション追加 */}
-				<LikeActions targetType="circle" targetId={circle.id} />
-
 				{circle.links.length > 0 &&
 					circle.links.map((link) => (
 						<ExternalLink

--- a/apps/web/src/routes/_public/collections_.$shortId.tsx
+++ b/apps/web/src/routes/_public/collections_.$shortId.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { BookOpen, Disc3, Music, User } from "lucide-react";
+import { BookOpen, Disc3, Music, User, UserRound } from "lucide-react";
 import { PublicBreadcrumb } from "@/components/public";
 import { VisibilityBadge } from "@/components/user/visibility-badge";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
@@ -84,6 +84,9 @@ function CollectionHeader({ collection }: CollectionHeaderProps) {
 					)}
 					<div className="flex flex-wrap items-center gap-2 text-sm">
 						<VisibilityBadge visibility={collection.visibility} />
+						{collection.itemType && (
+							<ItemTypeBadge itemType={collection.itemType} />
+						)}
 						<span className="text-base-content/50">
 							{collection.items.length} 件
 						</span>
@@ -158,29 +161,61 @@ function PublicCollectionItemRow({ item }: PublicCollectionItemRowProps) {
 	);
 }
 
-function getItemMeta(targetType: "track" | "release" | "circle"): {
+type ItemTypeLiteral = "track" | "release" | "circle" | "artist";
+
+const ITEM_TYPE_META_PUBLIC: Record<
+	ItemTypeLiteral,
+	{
+		label: string;
+		to: "/tracks/$id" | "/releases/$id" | "/circles/$id" | "/artists/$id";
+		icon: React.ReactNode;
+		badgeClass: string;
+	}
+> = {
+	track: {
+		label: "楽曲",
+		to: "/tracks/$id",
+		icon: <Music className="size-3" />,
+		badgeClass: "badge-primary",
+	},
+	release: {
+		label: "アルバム",
+		to: "/releases/$id",
+		icon: <Disc3 className="size-3" />,
+		badgeClass: "badge-secondary",
+	},
+	circle: {
+		label: "サークル",
+		to: "/circles/$id",
+		icon: <BookOpen className="size-3" />,
+		badgeClass: "badge-accent",
+	},
+	artist: {
+		label: "アーティスト",
+		to: "/artists/$id",
+		icon: <UserRound className="size-3" />,
+		badgeClass: "badge-info",
+	},
+};
+
+interface ItemTypeBadgeProps {
+	itemType: ItemTypeLiteral;
+}
+
+function ItemTypeBadge({ itemType }: ItemTypeBadgeProps) {
+	const { label, icon, badgeClass } = ITEM_TYPE_META_PUBLIC[itemType];
+	return (
+		<span className={`badge badge-outline badge-xs gap-1 ${badgeClass}`}>
+			{icon}
+			{label}
+		</span>
+	);
+}
+
+function getItemMeta(targetType: ItemTypeLiteral): {
 	label: string;
-	to: "/tracks/$id" | "/releases/$id" | "/circles/$id";
+	to: "/tracks/$id" | "/releases/$id" | "/circles/$id" | "/artists/$id";
 	icon: React.ReactNode;
 } {
-	switch (targetType) {
-		case "track":
-			return {
-				label: "トラック",
-				to: "/tracks/$id",
-				icon: <Music className="size-3" />,
-			};
-		case "release":
-			return {
-				label: "アルバム",
-				to: "/releases/$id",
-				icon: <Disc3 className="size-3" />,
-			};
-		case "circle":
-			return {
-				label: "サークル",
-				to: "/circles/$id",
-				icon: <BookOpen className="size-3" />,
-			};
-	}
+	return ITEM_TYPE_META_PUBLIC[targetType];
 }

--- a/apps/web/src/routes/_public/collections_.$shortId.tsx
+++ b/apps/web/src/routes/_public/collections_.$shortId.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { BookOpen, Disc3, Music, User, UserRound } from "lucide-react";
+import { Disc3, Music, User, UserRound, Users } from "lucide-react";
 import { PublicBreadcrumb } from "@/components/public";
+import { ItemTypeBadge } from "@/components/user/item-type-badge";
 import { VisibilityBadge } from "@/components/user/visibility-badge";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { APP_NAME } from "@/lib/head";
@@ -163,59 +164,40 @@ function PublicCollectionItemRow({ item }: PublicCollectionItemRowProps) {
 
 type ItemTypeLiteral = "track" | "release" | "circle" | "artist";
 
-const ITEM_TYPE_META_PUBLIC: Record<
+const ITEM_ROUTE_META: Record<
 	ItemTypeLiteral,
 	{
 		label: string;
 		to: "/tracks/$id" | "/releases/$id" | "/circles/$id" | "/artists/$id";
 		icon: React.ReactNode;
-		badgeClass: string;
 	}
 > = {
 	track: {
 		label: "楽曲",
 		to: "/tracks/$id",
 		icon: <Music className="size-3" />,
-		badgeClass: "badge-primary",
 	},
 	release: {
 		label: "アルバム",
 		to: "/releases/$id",
 		icon: <Disc3 className="size-3" />,
-		badgeClass: "badge-secondary",
 	},
 	circle: {
 		label: "サークル",
 		to: "/circles/$id",
-		icon: <BookOpen className="size-3" />,
-		badgeClass: "badge-accent",
+		icon: <Users className="size-3" />,
 	},
 	artist: {
 		label: "アーティスト",
 		to: "/artists/$id",
 		icon: <UserRound className="size-3" />,
-		badgeClass: "badge-info",
 	},
 };
-
-interface ItemTypeBadgeProps {
-	itemType: ItemTypeLiteral;
-}
-
-function ItemTypeBadge({ itemType }: ItemTypeBadgeProps) {
-	const { label, icon, badgeClass } = ITEM_TYPE_META_PUBLIC[itemType];
-	return (
-		<span className={`badge badge-outline badge-xs gap-1 ${badgeClass}`}>
-			{icon}
-			{label}
-		</span>
-	);
-}
 
 function getItemMeta(targetType: ItemTypeLiteral): {
 	label: string;
 	to: "/tracks/$id" | "/releases/$id" | "/circles/$id" | "/artists/$id";
 	icon: React.ReactNode;
 } {
-	return ITEM_TYPE_META_PUBLIC[targetType];
+	return ITEM_ROUTE_META[targetType];
 }

--- a/apps/web/src/routes/_public/collections_.$shortId.tsx
+++ b/apps/web/src/routes/_public/collections_.$shortId.tsx
@@ -1,0 +1,186 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { BookOpen, Disc3, Music, User } from "lucide-react";
+import { PublicBreadcrumb } from "@/components/public";
+import { VisibilityBadge } from "@/components/user/visibility-badge";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
+import { APP_NAME } from "@/lib/head";
+import { type PublicCollectionDetail, publicApi } from "@/lib/public-api";
+
+export const Route = createFileRoute("/_public/collections_/$shortId")({
+	loader: async ({ params }) => {
+		try {
+			const collection = await publicApi.collections.getByShortId(
+				params.shortId,
+			);
+			return { collection };
+		} catch {
+			return { collection: null };
+		}
+	},
+	head: ({ loaderData }) => {
+		const collection = loaderData?.collection;
+		if (!collection) {
+			return { meta: [{ title: `コレクション | ${APP_NAME}` }] };
+		}
+		const meta = [
+			{ title: `${collection.name} | ${APP_NAME}` },
+			{
+				name: "description",
+				content:
+					collection.description ?? `${collection.owner.name}のコレクション`,
+			},
+		];
+		if (collection.visibility === "unlisted") {
+			meta.push({ name: "robots", content: "noindex" });
+		}
+		return { meta };
+	},
+	headers: () => CACHE_HEADERS.PUBLIC_DETAIL,
+	component: PublicCollectionDetailPage,
+});
+
+function PublicCollectionDetailPage() {
+	const { collection } = Route.useLoaderData();
+
+	if (!collection) {
+		return (
+			<div className="space-y-6">
+				<PublicBreadcrumb items={[{ label: "コレクション" }]} />
+				<div className="rounded-2xl bg-base-100 p-8 text-center shadow-sm">
+					<h1 className="font-bold text-2xl">コレクションが見つかりません</h1>
+					<p className="mt-2 text-base-content/70">
+						このURLのコレクションは存在しないか、非公開になっています
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-6">
+			<PublicBreadcrumb
+				items={[{ label: "コレクション" }, { label: collection.name }]}
+			/>
+
+			<CollectionHeader collection={collection} />
+
+			<CollectionItemList collection={collection} />
+		</div>
+	);
+}
+
+interface CollectionHeaderProps {
+	collection: PublicCollectionDetail;
+}
+
+function CollectionHeader({ collection }: CollectionHeaderProps) {
+	return (
+		<div className="rounded-2xl bg-base-100 p-6 shadow-sm">
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div className="space-y-2">
+					<h1 className="font-bold text-2xl">{collection.name}</h1>
+					{collection.description && (
+						<p className="text-base-content/60">{collection.description}</p>
+					)}
+					<div className="flex flex-wrap items-center gap-2 text-sm">
+						<VisibilityBadge visibility={collection.visibility} />
+						<span className="text-base-content/50">
+							{collection.items.length} 件
+						</span>
+					</div>
+					<div className="flex items-center gap-1 text-base-content/50 text-sm">
+						<User className="size-3.5" />
+						<span>{collection.owner.name}</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface CollectionItemListProps {
+	collection: PublicCollectionDetail;
+}
+
+function CollectionItemList({ collection }: CollectionItemListProps) {
+	if (collection.items.length === 0) {
+		return (
+			<div className="rounded-2xl bg-base-100 p-12 text-center shadow-sm">
+				<p className="text-base-content/60">
+					このコレクションにはアイテムがありません
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-2">
+			{collection.items.map((item) => (
+				<PublicCollectionItemRow key={item.id} item={item} />
+			))}
+		</div>
+	);
+}
+
+type PublicCollectionItem = PublicCollectionDetail["items"][number];
+
+interface PublicCollectionItemRowProps {
+	item: PublicCollectionItem;
+}
+
+function PublicCollectionItemRow({ item }: PublicCollectionItemRowProps) {
+	const { label, to, icon } = getItemMeta(item.targetType);
+
+	const displayName =
+		(item.target as { name?: string; title?: string } | null)?.name ??
+		(item.target as { title?: string } | null)?.title ??
+		"（削除されたアイテム）";
+
+	return (
+		<div className="flex items-center gap-4 rounded-field bg-base-100 p-3 shadow-sm">
+			<div className="min-w-0 flex-1">
+				<Link
+					to={to}
+					params={{ id: item.targetId }}
+					className="font-medium hover:underline"
+				>
+					{displayName}
+				</Link>
+				<div className="flex items-center gap-1 text-base-content/50 text-xs">
+					{icon}
+					<span>{label}</span>
+				</div>
+				{item.note && (
+					<p className="mt-1 text-base-content/60 text-sm">{item.note}</p>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function getItemMeta(targetType: "track" | "release" | "circle"): {
+	label: string;
+	to: "/tracks/$id" | "/releases/$id" | "/circles/$id";
+	icon: React.ReactNode;
+} {
+	switch (targetType) {
+		case "track":
+			return {
+				label: "トラック",
+				to: "/tracks/$id",
+				icon: <Music className="size-3" />,
+			};
+		case "release":
+			return {
+				label: "アルバム",
+				to: "/releases/$id",
+				icon: <Disc3 className="size-3" />,
+			};
+		case "circle":
+			return {
+				label: "サークル",
+				to: "/circles/$id",
+				icon: <BookOpen className="size-3" />,
+			};
+	}
+}

--- a/apps/web/src/routes/_public/releases_.$id.tsx
+++ b/apps/web/src/routes/_public/releases_.$id.tsx
@@ -11,7 +11,7 @@ import {
 	StatsCardGrid,
 	TagBadgeList,
 } from "@/components/public";
-import { LikeActions } from "@/components/user/like-actions";
+import { FloatingLikeActions } from "@/components/user/floating-like-actions";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPublicReleaseHead } from "@/lib/head";
 import { type PublicReleaseDetail, publicApi } from "@/lib/public-api";
@@ -126,10 +126,10 @@ function ReleaseDetailPage() {
 							]
 						: undefined
 				}
+				actions={
+					<FloatingLikeActions targetType="release" targetId={release.id} />
+				}
 			>
-				{/* ♥ボタン + コレクション追加 */}
-				<LikeActions targetType="release" targetId={release.id} />
-
 				{/* サークル一覧 */}
 				{release.circles.length > 0 && (
 					<div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/routes/_public/releases_.$id.tsx
+++ b/apps/web/src/routes/_public/releases_.$id.tsx
@@ -11,6 +11,7 @@ import {
 	StatsCardGrid,
 	TagBadgeList,
 } from "@/components/public";
+import { LikeActions } from "@/components/user/like-actions";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPublicReleaseHead } from "@/lib/head";
 import { type PublicReleaseDetail, publicApi } from "@/lib/public-api";
@@ -126,6 +127,9 @@ function ReleaseDetailPage() {
 						: undefined
 				}
 			>
+				{/* ♥ボタン + コレクション追加 */}
+				<LikeActions targetType="release" targetId={release.id} />
+
 				{/* サークル一覧 */}
 				{release.circles.length > 0 && (
 					<div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/routes/_public/tracks_.$id.tsx
+++ b/apps/web/src/routes/_public/tracks_.$id.tsx
@@ -15,7 +15,7 @@ import {
 	PublicBreadcrumb,
 	TagBadgeList,
 } from "@/components/public";
-import { LikeActions } from "@/components/user/like-actions";
+import { FloatingLikeActions } from "@/components/user/floating-like-actions";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPublicTrackHead } from "@/lib/head";
 import { type PublicTrackDetail, publicApi } from "@/lib/public-api";
@@ -150,10 +150,8 @@ function TrackDetailPage() {
 							))
 						: []),
 				]}
+				actions={<FloatingLikeActions targetType="track" targetId={track.id} />}
 			>
-				{/* ♥ボタン + コレクション追加 */}
-				<LikeActions targetType="track" targetId={track.id} />
-
 				{/* タグ */}
 				{track.tags && track.tags.length > 0 && (
 					<TagBadgeList tags={track.tags} />

--- a/apps/web/src/routes/_public/tracks_.$id.tsx
+++ b/apps/web/src/routes/_public/tracks_.$id.tsx
@@ -15,6 +15,7 @@ import {
 	PublicBreadcrumb,
 	TagBadgeList,
 } from "@/components/public";
+import { LikeActions } from "@/components/user/like-actions";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPublicTrackHead } from "@/lib/head";
 import { type PublicTrackDetail, publicApi } from "@/lib/public-api";
@@ -150,6 +151,9 @@ function TrackDetailPage() {
 						: []),
 				]}
 			>
+				{/* ♥ボタン + コレクション追加 */}
+				<LikeActions targetType="track" targetId={track.id} />
+
 				{/* タグ */}
 				{track.tags && track.tags.length > 0 && (
 					<TagBadgeList tags={track.tags} />

--- a/apps/web/src/routes/user/_user.tsx
+++ b/apps/web/src/routes/user/_user.tsx
@@ -4,7 +4,7 @@ import {
 	Outlet,
 	redirect,
 } from "@tanstack/react-router";
-import { Settings, User } from "lucide-react";
+import { FolderHeart, Heart, Settings, User } from "lucide-react";
 import { ThemeSwitcher } from "@/components/theme-switcher";
 import UserMenu from "@/components/user-menu";
 import { getUser } from "@/functions/get-user";
@@ -74,6 +74,22 @@ function UserLayout() {
 										設定
 									</NavLink>
 								</li>
+								<li>
+									<NavLink
+										to="/user/collections"
+										icon={<FolderHeart className="h-5 w-5" />}
+									>
+										コレクション
+									</NavLink>
+								</li>
+								<li>
+									<NavLink
+										to="/user/likes"
+										icon={<Heart className="h-5 w-5" />}
+									>
+										お気に入り
+									</NavLink>
+								</li>
 							</ul>
 						</nav>
 
@@ -104,7 +120,7 @@ function NavLink({ to, icon, children }: NavLinkProps) {
 		<Link
 			to={to}
 			className={cn("flex items-center gap-2")}
-			activeProps={{ className: "active" }}
+			activeProps={{ className: "menu-active" }}
 		>
 			{icon}
 			{children}

--- a/apps/web/src/routes/user/_user.tsx
+++ b/apps/web/src/routes/user/_user.tsx
@@ -13,7 +13,7 @@ import { createPageHead } from "@/lib/head";
 import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/user/_user")({
-	head: () => createPageHead("ユーザー設定"),
+	head: () => createPageHead("マイページ"),
 	headers: () => CACHE_HEADERS.PRIVATE,
 	beforeLoad: async () => {
 		const session = await getUser();
@@ -50,7 +50,7 @@ function UserLayout() {
 				<div className="mx-auto max-w-4xl p-4 lg:p-6">
 					{/* Header */}
 					<div className="mb-6">
-						<h1 className="font-bold text-2xl">アカウント設定</h1>
+						<h1 className="font-bold text-2xl">マイページ</h1>
 						<p className="text-base-content/70 text-sm">{user.email}</p>
 					</div>
 

--- a/apps/web/src/routes/user/_user.tsx
+++ b/apps/web/src/routes/user/_user.tsx
@@ -47,7 +47,7 @@ function UserLayout() {
 				</div>
 			</header>
 			<main className="flex-1 bg-base-200/30">
-				<div className="mx-auto max-w-4xl p-4 lg:p-6">
+				<div className="mx-auto max-w-7xl p-4 lg:p-6">
 					{/* Header */}
 					<div className="mb-6">
 						<h1 className="font-bold text-2xl">マイページ</h1>

--- a/apps/web/src/routes/user/_user/collections.tsx
+++ b/apps/web/src/routes/user/_user/collections.tsx
@@ -1,11 +1,29 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { Plus } from "lucide-react";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { Plus, X } from "lucide-react";
+import { useMemo } from "react";
 import { ItemTypeBadge } from "@/components/user/item-type-badge";
 import { VisibilityBadge } from "@/components/user/visibility-badge";
+import type {
+	CollectionItemType,
+	UserCollectionVisibility,
+} from "@/lib/api-client";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPageHead } from "@/lib/head";
 import { userCollectionsListQueryOptions } from "@/lib/user-collections-query-options";
+
+// =============================================================================
+// URL パラメータの定義と検証
+// =============================================================================
+
+type ItemTypeFilter = CollectionItemType | "none";
+type VisibilityFilter = UserCollectionVisibility;
+
+interface CollectionsSearchParams {
+	type?: ItemTypeFilter;
+	visibility?: VisibilityFilter;
+	q?: string;
+}
 
 export const Route = createFileRoute("/user/_user/collections")({
 	head: () => createPageHead("マイコレクション"),
@@ -17,16 +35,123 @@ export const Route = createFileRoute("/user/_user/collections")({
 				excludeDefaultLiked: true,
 			}),
 		),
+	validateSearch: (
+		search: Record<string, unknown>,
+	): CollectionsSearchParams => {
+		const validItemTypes: ItemTypeFilter[] = [
+			"track",
+			"release",
+			"circle",
+			"artist",
+			"none",
+		];
+		const validVisibilities: VisibilityFilter[] = [
+			"private",
+			"unlisted",
+			"public",
+		];
+		return {
+			type:
+				typeof search.type === "string" &&
+				validItemTypes.includes(search.type as ItemTypeFilter)
+					? (search.type as ItemTypeFilter)
+					: undefined,
+			visibility:
+				typeof search.visibility === "string" &&
+				validVisibilities.includes(search.visibility as VisibilityFilter)
+					? (search.visibility as VisibilityFilter)
+					: undefined,
+			q: typeof search.q === "string" && search.q !== "" ? search.q : undefined,
+		};
+	},
 	component: CollectionsListPage,
 });
 
-function CollectionsListPage() {
+// =============================================================================
+// コンポーネント
+// =============================================================================
+
+function CollectionsListPage(): React.ReactNode {
+	const {
+		type: typeFilter,
+		visibility: visibilityFilter,
+		q,
+	} = Route.useSearch();
+	const navigate = useNavigate();
+
 	const { data } = useSuspenseQuery(
 		userCollectionsListQueryOptions({
 			kind: "collection",
 			excludeDefaultLiked: true,
 		}),
 	);
+
+	const hasFilter =
+		typeFilter !== undefined ||
+		visibilityFilter !== undefined ||
+		(q !== undefined && q !== "");
+
+	const filtered = useMemo(() => {
+		return data.items.filter((c) => {
+			if (typeFilter === "none" && c.itemType !== null) return false;
+			if (typeFilter && typeFilter !== "none" && c.itemType !== typeFilter)
+				return false;
+			if (visibilityFilter && c.visibility !== visibilityFilter) return false;
+			if (q?.trim()) {
+				const needle = q.trim().toLowerCase();
+				const matchName = c.name.toLowerCase().includes(needle);
+				const matchDesc =
+					c.description?.toLowerCase().includes(needle) ?? false;
+				if (!matchName && !matchDesc) return false;
+			}
+			return true;
+		});
+	}, [data.items, typeFilter, visibilityFilter, q]);
+
+	function handleClearFilters(): void {
+		navigate({ to: "/user/collections", search: {} });
+	}
+
+	function handleTypeChange(e: React.ChangeEvent<HTMLSelectElement>): void {
+		const value = e.target.value;
+		navigate({
+			to: "/user/collections",
+			search: {
+				type: value !== "" ? (value as ItemTypeFilter) : undefined,
+				visibility: visibilityFilter,
+				q,
+			},
+			replace: true,
+		});
+	}
+
+	function handleVisibilityChange(
+		e: React.ChangeEvent<HTMLSelectElement>,
+	): void {
+		const value = e.target.value;
+		navigate({
+			to: "/user/collections",
+			search: {
+				type: typeFilter,
+				visibility: value !== "" ? (value as VisibilityFilter) : undefined,
+				q,
+			},
+			replace: true,
+		});
+	}
+
+	function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>): void {
+		const value = e.target.value;
+		navigate({
+			to: "/user/collections",
+			search: {
+				type: typeFilter,
+				visibility: visibilityFilter,
+				q: value !== "" ? value : undefined,
+			},
+			replace: true,
+		});
+	}
 
 	return (
 		<div className="space-y-6">
@@ -38,15 +163,73 @@ function CollectionsListPage() {
 				</Link>
 			</div>
 
+			{/* フィルター行 */}
+			<div className="flex flex-wrap items-center gap-2">
+				<select
+					className="select select-bordered select-sm w-full sm:w-44"
+					value={typeFilter ?? ""}
+					onChange={handleTypeChange}
+					aria-label="種別で絞り込み"
+				>
+					<option value="">全て（種別）</option>
+					<option value="track">楽曲</option>
+					<option value="release">アルバム</option>
+					<option value="circle">サークル</option>
+					<option value="artist">アーティスト</option>
+					<option value="none">未設定</option>
+				</select>
+
+				<select
+					className="select select-bordered select-sm w-full sm:w-44"
+					value={visibilityFilter ?? ""}
+					onChange={handleVisibilityChange}
+					aria-label="公開状態で絞り込み"
+				>
+					<option value="">全て（公開状態）</option>
+					<option value="private">非公開</option>
+					<option value="unlisted">限定公開</option>
+					<option value="public">公開</option>
+				</select>
+
+				<div className="relative flex-1 sm:flex-none">
+					<input
+						type="search"
+						className="input input-bordered input-sm w-full sm:min-w-48"
+						placeholder="名前・説明文で検索..."
+						value={q ?? ""}
+						onChange={handleSearchChange}
+						aria-label="コレクション名または説明文で検索"
+					/>
+				</div>
+
+				{hasFilter && (
+					<button
+						type="button"
+						className="btn btn-ghost btn-sm gap-1"
+						onClick={handleClearFilters}
+						aria-label="フィルターをクリア"
+					>
+						<X className="size-4" />
+						クリア
+					</button>
+				)}
+			</div>
+
 			{data.items.length === 0 ? (
 				<div className="rounded-field bg-base-100 p-12 text-center shadow-sm">
 					<p className="text-base-content/60">
 						コレクションがまだありません。新規作成してお気に入りの楽曲・アルバム・サークル・アーティストをまとめましょう。
 					</p>
 				</div>
+			) : filtered.length === 0 ? (
+				<div className="rounded-field bg-base-100 p-12 text-center shadow-sm">
+					<p className="text-base-content/60">
+						条件に一致するコレクションがありません。
+					</p>
+				</div>
 			) : (
 				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{data.items.map((c) => (
+					{filtered.map((c) => (
 						<Link
 							key={c.id}
 							to="/user/collections/$id"
@@ -60,9 +243,11 @@ function CollectionsListPage() {
 										{c.description}
 									</p>
 								)}
-								<div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-base-content/50 text-xs">
-									<span>{c.itemCount} 件</span>
-									{c.ordered && <span>・並び替え可</span>}
+								<div className="text-base-content/50 text-xs">
+									{c.itemCount} 件
+									{c.ordered && <span className="ml-2">・並び替え可</span>}
+								</div>
+								<div className="flex flex-wrap items-center gap-2">
 									{c.itemType && (
 										<ItemTypeBadge itemType={c.itemType} size="sm" />
 									)}

--- a/apps/web/src/routes/user/_user/collections.tsx
+++ b/apps/web/src/routes/user/_user/collections.tsx
@@ -1,7 +1,8 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Plus } from "lucide-react";
+import { Disc3, Music, Plus, UserRound, Users } from "lucide-react";
 import { VisibilityBadge } from "@/components/user/visibility-badge";
+import type { CollectionItemType } from "@/lib/api-client";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPageHead } from "@/lib/head";
 import { userCollectionsListQueryOptions } from "@/lib/user-collections-query-options";
@@ -18,6 +19,32 @@ export const Route = createFileRoute("/user/_user/collections")({
 		),
 	component: CollectionsListPage,
 });
+
+const ITEM_TYPE_META: Record<
+	CollectionItemType,
+	{ label: string; icon: React.ReactNode; badgeClass: string }
+> = {
+	track: {
+		label: "楽曲",
+		icon: <Music className="size-3" />,
+		badgeClass: "badge-primary",
+	},
+	release: {
+		label: "アルバム",
+		icon: <Disc3 className="size-3" />,
+		badgeClass: "badge-secondary",
+	},
+	circle: {
+		label: "サークル",
+		icon: <Users className="size-3" />,
+		badgeClass: "badge-accent",
+	},
+	artist: {
+		label: "アーティスト",
+		icon: <UserRound className="size-3" />,
+		badgeClass: "badge-info",
+	},
+};
 
 function CollectionsListPage() {
 	const { data } = useSuspenseQuery(
@@ -62,6 +89,14 @@ function CollectionsListPage() {
 								<div className="flex items-center gap-2 text-base-content/50 text-xs">
 									<span>{c.itemCount} 件</span>
 									{c.ordered && <span>・並び替え可</span>}
+									{c.itemType && (
+										<span
+											className={`badge badge-outline badge-xs gap-1 ${ITEM_TYPE_META[c.itemType].badgeClass}`}
+										>
+											{ITEM_TYPE_META[c.itemType].icon}
+											{ITEM_TYPE_META[c.itemType].label}
+										</span>
+									)}
 									<VisibilityBadge visibility={c.visibility} />
 								</div>
 							</div>

--- a/apps/web/src/routes/user/_user/collections.tsx
+++ b/apps/web/src/routes/user/_user/collections.tsx
@@ -60,7 +60,7 @@ function CollectionsListPage() {
 										{c.description}
 									</p>
 								)}
-								<div className="flex items-center gap-2 text-base-content/50 text-xs">
+								<div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-base-content/50 text-xs">
 									<span>{c.itemCount} 件</span>
 									{c.ordered && <span>・並び替え可</span>}
 									{c.itemType && (

--- a/apps/web/src/routes/user/_user/collections.tsx
+++ b/apps/web/src/routes/user/_user/collections.tsx
@@ -1,8 +1,8 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Disc3, Music, Plus, UserRound, Users } from "lucide-react";
+import { Plus } from "lucide-react";
+import { ItemTypeBadge } from "@/components/user/item-type-badge";
 import { VisibilityBadge } from "@/components/user/visibility-badge";
-import type { CollectionItemType } from "@/lib/api-client";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPageHead } from "@/lib/head";
 import { userCollectionsListQueryOptions } from "@/lib/user-collections-query-options";
@@ -19,32 +19,6 @@ export const Route = createFileRoute("/user/_user/collections")({
 		),
 	component: CollectionsListPage,
 });
-
-const ITEM_TYPE_META: Record<
-	CollectionItemType,
-	{ label: string; icon: React.ReactNode; badgeClass: string }
-> = {
-	track: {
-		label: "楽曲",
-		icon: <Music className="size-3" />,
-		badgeClass: "badge-primary",
-	},
-	release: {
-		label: "アルバム",
-		icon: <Disc3 className="size-3" />,
-		badgeClass: "badge-secondary",
-	},
-	circle: {
-		label: "サークル",
-		icon: <Users className="size-3" />,
-		badgeClass: "badge-accent",
-	},
-	artist: {
-		label: "アーティスト",
-		icon: <UserRound className="size-3" />,
-		badgeClass: "badge-info",
-	},
-};
 
 function CollectionsListPage() {
 	const { data } = useSuspenseQuery(
@@ -67,7 +41,7 @@ function CollectionsListPage() {
 			{data.items.length === 0 ? (
 				<div className="rounded-field bg-base-100 p-12 text-center shadow-sm">
 					<p className="text-base-content/60">
-						コレクションがまだありません。新規作成してお気に入りの楽曲・アルバム・サークルをまとめましょう。
+						コレクションがまだありません。新規作成してお気に入りの楽曲・アルバム・サークル・アーティストをまとめましょう。
 					</p>
 				</div>
 			) : (
@@ -90,12 +64,7 @@ function CollectionsListPage() {
 									<span>{c.itemCount} 件</span>
 									{c.ordered && <span>・並び替え可</span>}
 									{c.itemType && (
-										<span
-											className={`badge badge-outline badge-xs gap-1 ${ITEM_TYPE_META[c.itemType].badgeClass}`}
-										>
-											{ITEM_TYPE_META[c.itemType].icon}
-											{ITEM_TYPE_META[c.itemType].label}
-										</span>
+										<ItemTypeBadge itemType={c.itemType} size="sm" />
 									)}
 									<VisibilityBadge visibility={c.visibility} />
 								</div>

--- a/apps/web/src/routes/user/_user/collections.tsx
+++ b/apps/web/src/routes/user/_user/collections.tsx
@@ -1,6 +1,7 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Plus } from "lucide-react";
+import { VisibilityBadge } from "@/components/user/visibility-badge";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPageHead } from "@/lib/head";
 import { userCollectionsListQueryOptions } from "@/lib/user-collections-query-options";
@@ -61,6 +62,7 @@ function CollectionsListPage() {
 								<div className="flex items-center gap-2 text-base-content/50 text-xs">
 									<span>{c.itemCount} 件</span>
 									{c.ordered && <span>・並び替え可</span>}
+									<VisibilityBadge visibility={c.visibility} />
 								</div>
 							</div>
 						</Link>

--- a/apps/web/src/routes/user/_user/collections.tsx
+++ b/apps/web/src/routes/user/_user/collections.tsx
@@ -10,14 +10,20 @@ export const Route = createFileRoute("/user/_user/collections")({
 	headers: () => CACHE_HEADERS.PRIVATE,
 	loader: ({ context }) =>
 		context.queryClient.ensureQueryData(
-			userCollectionsListQueryOptions({ kind: "collection" }),
+			userCollectionsListQueryOptions({
+				kind: "collection",
+				excludeDefaultLiked: true,
+			}),
 		),
 	component: CollectionsListPage,
 });
 
 function CollectionsListPage() {
 	const { data } = useSuspenseQuery(
-		userCollectionsListQueryOptions({ kind: "collection" }),
+		userCollectionsListQueryOptions({
+			kind: "collection",
+			excludeDefaultLiked: true,
+		}),
 	);
 
 	return (
@@ -46,12 +52,7 @@ function CollectionsListPage() {
 							className="card bg-base-100 shadow-sm transition-shadow hover:shadow-md"
 						>
 							<div className="card-body">
-								<h2 className="card-title text-lg">
-									{c.name}
-									{c.isDefaultLiked && (
-										<span className="badge badge-error badge-sm">♥ Liked</span>
-									)}
-								</h2>
+								<h2 className="card-title text-lg">{c.name}</h2>
 								{c.description && (
 									<p className="line-clamp-2 text-base-content/60 text-sm">
 										{c.description}

--- a/apps/web/src/routes/user/_user/collections.tsx
+++ b/apps/web/src/routes/user/_user/collections.tsx
@@ -1,0 +1,71 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Plus } from "lucide-react";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
+import { createPageHead } from "@/lib/head";
+import { userCollectionsListQueryOptions } from "@/lib/user-collections-query-options";
+
+export const Route = createFileRoute("/user/_user/collections")({
+	head: () => createPageHead("マイコレクション"),
+	headers: () => CACHE_HEADERS.PRIVATE,
+	loader: ({ context }) =>
+		context.queryClient.ensureQueryData(
+			userCollectionsListQueryOptions({ kind: "collection" }),
+		),
+	component: CollectionsListPage,
+});
+
+function CollectionsListPage() {
+	const { data } = useSuspenseQuery(
+		userCollectionsListQueryOptions({ kind: "collection" }),
+	);
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center justify-between">
+				<h1 className="font-bold text-2xl">マイコレクション</h1>
+				<Link to="/user/collections/new" className="btn btn-primary btn-sm">
+					<Plus className="size-4" />
+					新規作成
+				</Link>
+			</div>
+
+			{data.items.length === 0 ? (
+				<div className="rounded-field bg-base-100 p-12 text-center shadow-sm">
+					<p className="text-base-content/60">
+						コレクションがまだありません。新規作成してお気に入りの楽曲・アルバム・サークルをまとめましょう。
+					</p>
+				</div>
+			) : (
+				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					{data.items.map((c) => (
+						<Link
+							key={c.id}
+							to="/user/collections/$id"
+							params={{ id: c.id }}
+							className="card bg-base-100 shadow-sm transition-shadow hover:shadow-md"
+						>
+							<div className="card-body">
+								<h2 className="card-title text-lg">
+									{c.name}
+									{c.isDefaultLiked && (
+										<span className="badge badge-error badge-sm">♥ Liked</span>
+									)}
+								</h2>
+								{c.description && (
+									<p className="line-clamp-2 text-base-content/60 text-sm">
+										{c.description}
+									</p>
+								)}
+								<div className="flex items-center gap-2 text-base-content/50 text-xs">
+									<span>{c.itemCount} 件</span>
+									{c.ordered && <span>・並び替え可</span>}
+								</div>
+							</div>
+						</Link>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/routes/user/_user/collections_.$id.tsx
+++ b/apps/web/src/routes/user/_user/collections_.$id.tsx
@@ -4,7 +4,15 @@ import {
 	useSuspenseQuery,
 } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { ArrowLeft, Settings, Trash2 } from "lucide-react";
+import {
+	ArrowLeft,
+	Disc3,
+	Music,
+	Settings,
+	Trash2,
+	UserRound,
+	Users,
+} from "lucide-react";
 import { useState } from "react";
 import { Banner } from "@/components/ui/banner";
 import { CollectionUrlCopy } from "@/components/user/collection-url-copy";
@@ -12,6 +20,7 @@ import { ItemTypeBadge } from "@/components/user/item-type-badge";
 import { SortableCollectionItems } from "@/components/user/sortable-collection-items";
 import { VisibilityBadge } from "@/components/user/visibility-badge";
 import type {
+	CollectionItemType,
 	UserCollectionDetail,
 	UserCollectionItem,
 	UserCollectionUpdateInput,
@@ -333,6 +342,21 @@ function CollectionItemRow({
 	);
 }
 
+const ITEM_TYPE_OPTIONS: {
+	value: CollectionItemType;
+	label: string;
+	icon: React.ReactNode;
+}[] = [
+	{ value: "track", label: "楽曲", icon: <Music className="size-4" /> },
+	{ value: "release", label: "アルバム", icon: <Disc3 className="size-4" /> },
+	{ value: "circle", label: "サークル", icon: <Users className="size-4" /> },
+	{
+		value: "artist",
+		label: "アーティスト",
+		icon: <UserRound className="size-4" />,
+	},
+];
+
 interface EditCollectionDialogProps {
 	collection: UserCollectionDetail;
 	onClose: () => void;
@@ -349,17 +373,25 @@ function EditCollectionDialog({
 	const [visibility, setVisibility] = useState<UserCollectionVisibility>(
 		collection.visibility,
 	);
+	const [itemType, setItemType] = useState<CollectionItemType | null>(null);
 	const [submitting, setSubmitting] = useState(false);
+
+	const canSetItemType =
+		collection.itemType === null && !collection.isDefaultLiked;
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
 		setSubmitting(true);
 		try {
-			await onSubmit({
+			const input: UserCollectionUpdateInput = {
 				name: name.trim(),
 				description: description.trim() === "" ? null : description.trim(),
 				visibility,
-			});
+			};
+			if (canSetItemType && itemType !== null) {
+				input.itemType = itemType;
+			}
+			await onSubmit(input);
 		} finally {
 			setSubmitting(false);
 		}
@@ -421,6 +453,38 @@ function EditCollectionDialog({
 								<option value="unlisted">URLを知っている人のみ</option>
 								<option value="public">公開</option>
 							</select>
+						</div>
+					)}
+					{canSetItemType && (
+						<div>
+							<p className="label-text mb-2 font-medium">種別</p>
+							<div className="grid grid-cols-2 gap-2">
+								{ITEM_TYPE_OPTIONS.map((opt) => (
+									<label
+										key={opt.value}
+										className={`flex cursor-pointer items-center gap-2 rounded-field border-2 p-3 transition-colors ${
+											itemType === opt.value
+												? "border-primary bg-primary/10"
+												: "border-base-300 hover:border-primary/50"
+										} ${submitting ? "cursor-not-allowed opacity-50" : ""}`}
+									>
+										<input
+											type="radio"
+											className="sr-only"
+											name="edit-itemType"
+											value={opt.value}
+											checked={itemType === opt.value}
+											onChange={() => setItemType(opt.value)}
+											disabled={submitting}
+										/>
+										{opt.icon}
+										<span className="text-sm">{opt.label}</span>
+									</label>
+								))}
+							</div>
+							<p className="mt-1 text-base-content/50 text-xs">
+								※一度設定すると変更できません
+							</p>
 						</div>
 					)}
 					<div className="modal-action">

--- a/apps/web/src/routes/user/_user/collections_.$id.tsx
+++ b/apps/web/src/routes/user/_user/collections_.$id.tsx
@@ -7,7 +7,9 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, Settings, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Banner } from "@/components/ui/banner";
+import { CollectionUrlCopy } from "@/components/user/collection-url-copy";
 import { SortableCollectionItems } from "@/components/user/sortable-collection-items";
+import { VisibilityBadge } from "@/components/user/visibility-badge";
 import type {
 	UserCollectionDetail,
 	UserCollectionItem,
@@ -155,7 +157,18 @@ function CollectionDetailPage() {
 						{collection.isDefaultLiked && (
 							<span className="badge badge-error badge-sm">♥ Liked</span>
 						)}
+						{!collection.isDefaultLiked && (
+							<VisibilityBadge visibility={collection.visibility} />
+						)}
 					</div>
+					{!collection.isDefaultLiked &&
+						(collection.visibility === "unlisted" ||
+							collection.visibility === "public") &&
+						collection.shortId && (
+							<div className="mt-2">
+								<CollectionUrlCopy shortId={collection.shortId} />
+							</div>
+						)}
 				</div>
 				<div className="flex items-center gap-2">
 					<button

--- a/apps/web/src/routes/user/_user/collections_.$id.tsx
+++ b/apps/web/src/routes/user/_user/collections_.$id.tsx
@@ -4,13 +4,22 @@ import {
 	useSuspenseQuery,
 } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { ArrowLeft, Settings, Trash2 } from "lucide-react";
+import {
+	ArrowLeft,
+	Disc3,
+	Music,
+	Settings,
+	Trash2,
+	UserRound,
+	Users,
+} from "lucide-react";
 import { useState } from "react";
 import { Banner } from "@/components/ui/banner";
 import { CollectionUrlCopy } from "@/components/user/collection-url-copy";
 import { SortableCollectionItems } from "@/components/user/sortable-collection-items";
 import { VisibilityBadge } from "@/components/user/visibility-badge";
 import type {
+	CollectionItemType,
 	UserCollectionDetail,
 	UserCollectionItem,
 	UserCollectionUpdateInput,
@@ -158,7 +167,12 @@ function CollectionDetailPage() {
 							<span className="badge badge-error badge-sm">♥ Liked</span>
 						)}
 						{!collection.isDefaultLiked && (
-							<VisibilityBadge visibility={collection.visibility} />
+							<>
+								{collection.itemType && (
+									<ItemTypeBadge itemType={collection.itemType} />
+								)}
+								<VisibilityBadge visibility={collection.visibility} />
+							</>
 						)}
 					</div>
 					{!collection.isDefaultLiked &&
@@ -260,6 +274,46 @@ interface CollectionItemRowProps {
 	removing: boolean;
 }
 
+const ITEM_TYPE_LABELS: Record<
+	CollectionItemType,
+	{ label: string; badgeClass: string; icon: React.ReactNode }
+> = {
+	track: {
+		label: "楽曲",
+		badgeClass: "badge-primary",
+		icon: <Music className="size-3" />,
+	},
+	release: {
+		label: "アルバム",
+		badgeClass: "badge-secondary",
+		icon: <Disc3 className="size-3" />,
+	},
+	circle: {
+		label: "サークル",
+		badgeClass: "badge-accent",
+		icon: <Users className="size-3" />,
+	},
+	artist: {
+		label: "アーティスト",
+		badgeClass: "badge-info",
+		icon: <UserRound className="size-3" />,
+	},
+};
+
+interface ItemTypeBadgeProps {
+	itemType: CollectionItemType;
+}
+
+function ItemTypeBadge({ itemType }: ItemTypeBadgeProps) {
+	const { label, badgeClass, icon } = ITEM_TYPE_LABELS[itemType];
+	return (
+		<span className={`badge badge-outline badge-xs gap-1 ${badgeClass}`}>
+			{icon}
+			{label}
+		</span>
+	);
+}
+
 function CollectionItemRow({
 	item,
 	onRemove,
@@ -273,6 +327,8 @@ function CollectionItemRow({
 				return { label: "アルバム", to: "/releases/$id" };
 			case "circle":
 				return { label: "サークル", to: "/circles/$id" };
+			case "artist":
+				return { label: "アーティスト", to: "/artists/$id" };
 		}
 	})();
 

--- a/apps/web/src/routes/user/_user/collections_.$id.tsx
+++ b/apps/web/src/routes/user/_user/collections_.$id.tsx
@@ -4,22 +4,14 @@ import {
 	useSuspenseQuery,
 } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import {
-	ArrowLeft,
-	Disc3,
-	Music,
-	Settings,
-	Trash2,
-	UserRound,
-	Users,
-} from "lucide-react";
+import { ArrowLeft, Settings, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Banner } from "@/components/ui/banner";
 import { CollectionUrlCopy } from "@/components/user/collection-url-copy";
+import { ItemTypeBadge } from "@/components/user/item-type-badge";
 import { SortableCollectionItems } from "@/components/user/sortable-collection-items";
 import { VisibilityBadge } from "@/components/user/visibility-badge";
 import type {
-	CollectionItemType,
 	UserCollectionDetail,
 	UserCollectionItem,
 	UserCollectionUpdateInput,
@@ -55,6 +47,8 @@ function CollectionDetailPage() {
 	const { data: collection } = useSuspenseQuery(
 		userCollectionDetailQueryOptions(id),
 	);
+
+	const itemTypeLabel = getItemTypeLabel(collection.itemType);
 
 	const [feedback, setFeedback] = useState<Feedback | null>(null);
 	const [isEditing, setIsEditing] = useState(false);
@@ -235,7 +229,7 @@ function CollectionDetailPage() {
 			{collection.items.length === 0 ? (
 				<div className="rounded-field bg-base-100 p-12 text-center shadow-sm">
 					<p className="text-base-content/60">
-						アイテムがまだありません。楽曲・アルバム・サークルの詳細ページから追加してください。
+						{`アイテムがまだありません。${itemTypeLabel}の詳細ページから追加してください。`}
 					</p>
 				</div>
 			) : (
@@ -274,44 +268,18 @@ interface CollectionItemRowProps {
 	removing: boolean;
 }
 
-const ITEM_TYPE_LABELS: Record<
-	CollectionItemType,
-	{ label: string; badgeClass: string; icon: React.ReactNode }
-> = {
-	track: {
-		label: "楽曲",
-		badgeClass: "badge-primary",
-		icon: <Music className="size-3" />,
-	},
-	release: {
-		label: "アルバム",
-		badgeClass: "badge-secondary",
-		icon: <Disc3 className="size-3" />,
-	},
-	circle: {
-		label: "サークル",
-		badgeClass: "badge-accent",
-		icon: <Users className="size-3" />,
-	},
-	artist: {
-		label: "アーティスト",
-		badgeClass: "badge-info",
-		icon: <UserRound className="size-3" />,
-	},
+const ITEM_TYPE_LABEL_MAP: Record<string, string> = {
+	track: "楽曲",
+	release: "アルバム",
+	circle: "サークル",
+	artist: "アーティスト",
 };
 
-interface ItemTypeBadgeProps {
-	itemType: CollectionItemType;
-}
-
-function ItemTypeBadge({ itemType }: ItemTypeBadgeProps) {
-	const { label, badgeClass, icon } = ITEM_TYPE_LABELS[itemType];
-	return (
-		<span className={`badge badge-outline badge-xs gap-1 ${badgeClass}`}>
-			{icon}
-			{label}
-		</span>
-	);
+function getItemTypeLabel(itemType: string | null | undefined): string {
+	if (!itemType) {
+		return "楽曲・アルバム・サークル・アーティスト";
+	}
+	return ITEM_TYPE_LABEL_MAP[itemType] ?? itemType;
 }
 
 function CollectionItemRow({

--- a/apps/web/src/routes/user/_user/collections_.$id.tsx
+++ b/apps/web/src/routes/user/_user/collections_.$id.tsx
@@ -1,0 +1,416 @@
+import {
+	useMutation,
+	useQueryClient,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { ArrowLeft, Settings, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Banner } from "@/components/ui/banner";
+import { SortableCollectionItems } from "@/components/user/sortable-collection-items";
+import type {
+	UserCollectionDetail,
+	UserCollectionItem,
+	UserCollectionUpdateInput,
+	UserCollectionVisibility,
+} from "@/lib/api-client";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
+import { createPageHead } from "@/lib/head";
+import {
+	userCollectionDetailQueryOptions,
+	userCollectionMutations,
+} from "@/lib/user-collections-query-options";
+
+export const Route = createFileRoute("/user/_user/collections_/$id")({
+	head: () => createPageHead("コレクション詳細"),
+	headers: () => CACHE_HEADERS.PRIVATE,
+	loader: async ({ context, params }) => {
+		await context.queryClient.ensureQueryData(
+			userCollectionDetailQueryOptions(params.id),
+		);
+	},
+	component: CollectionDetailPage,
+});
+
+interface Feedback {
+	variant: "success" | "error";
+	message: string;
+}
+
+function CollectionDetailPage() {
+	const { id } = Route.useParams();
+	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+	const { data: collection } = useSuspenseQuery(
+		userCollectionDetailQueryOptions(id),
+	);
+
+	const [feedback, setFeedback] = useState<Feedback | null>(null);
+	const [isEditing, setIsEditing] = useState(false);
+
+	const reorderMutation = useMutation(
+		userCollectionMutations.reorderItems(queryClient),
+	);
+	const removeItemMutation = useMutation(
+		userCollectionMutations.removeItem(queryClient),
+	);
+	const updateMutation = useMutation(
+		userCollectionMutations.update(queryClient),
+	);
+	const deleteMutation = useMutation(
+		userCollectionMutations.delete(queryClient),
+	);
+
+	const handleReorder = async (newOrder: UserCollectionItem[]) => {
+		try {
+			await reorderMutation.mutateAsync({
+				id,
+				input: {
+					items: newOrder.map((it, idx) => ({
+						itemId: it.id,
+						position: idx,
+					})),
+				},
+			});
+		} catch (e) {
+			setFeedback({
+				variant: "error",
+				message: e instanceof Error ? e.message : "並び替えに失敗しました",
+			});
+		}
+	};
+
+	const handleToggleOrdered = async () => {
+		try {
+			await updateMutation.mutateAsync({
+				id,
+				input: { ordered: !collection.ordered },
+			});
+		} catch (e) {
+			setFeedback({
+				variant: "error",
+				message: e instanceof Error ? e.message : "更新に失敗しました",
+			});
+		}
+	};
+
+	const handleRemoveItem = async (itemId: string) => {
+		try {
+			await removeItemMutation.mutateAsync({ id, itemId });
+			setFeedback({ variant: "success", message: "アイテムを削除しました" });
+		} catch (e) {
+			setFeedback({
+				variant: "error",
+				message: e instanceof Error ? e.message : "削除に失敗しました",
+			});
+		}
+	};
+
+	const handleDeleteCollection = async () => {
+		try {
+			await deleteMutation.mutateAsync(id);
+			navigate({ to: "/user/collections" });
+		} catch (e) {
+			setFeedback({
+				variant: "error",
+				message:
+					e instanceof Error ? e.message : "コレクションの削除に失敗しました",
+			});
+		}
+	};
+
+	const handleEditSubmit = async (input: UserCollectionUpdateInput) => {
+		try {
+			await updateMutation.mutateAsync({ id, input });
+			setIsEditing(false);
+			setFeedback({ variant: "success", message: "更新しました" });
+		} catch (e) {
+			setFeedback({
+				variant: "error",
+				message: e instanceof Error ? e.message : "更新に失敗しました",
+			});
+		}
+	};
+
+	return (
+		<div className="space-y-6">
+			<Link
+				to="/user/collections"
+				className="inline-flex items-center gap-1 text-base-content/60 text-sm hover:text-base-content"
+			>
+				<ArrowLeft className="size-4" />
+				コレクション一覧へ
+			</Link>
+
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div>
+					<h1 className="font-bold text-2xl">{collection.name}</h1>
+					{collection.description && (
+						<p className="mt-2 text-base-content/60">
+							{collection.description}
+						</p>
+					)}
+					<div className="mt-2 flex items-center gap-2 text-base-content/50 text-xs">
+						<span>{collection.items.length} 件</span>
+						{collection.isDefaultLiked && (
+							<span className="badge badge-error badge-sm">♥ Liked</span>
+						)}
+					</div>
+				</div>
+				<div className="flex items-center gap-2">
+					<button
+						type="button"
+						onClick={() => setIsEditing(true)}
+						className="btn btn-ghost btn-sm"
+					>
+						<Settings className="size-4" />
+						編集
+					</button>
+					{!collection.isDefaultLiked && (
+						<button
+							type="button"
+							onClick={handleDeleteCollection}
+							disabled={deleteMutation.isPending}
+							className="btn btn-error btn-outline btn-sm"
+						>
+							削除
+						</button>
+					)}
+				</div>
+			</div>
+
+			{feedback && (
+				<Banner
+					variant={feedback.variant}
+					autoHideDuration={3000}
+					onAutoHide={() => setFeedback(null)}
+					dismissible
+					onDismiss={() => setFeedback(null)}
+				>
+					{feedback.message}
+				</Banner>
+			)}
+
+			<div className="form-control flex-row items-center gap-2">
+				<input
+					id="ordered-toggle"
+					type="checkbox"
+					className="toggle toggle-primary"
+					checked={collection.ordered}
+					onChange={handleToggleOrdered}
+					disabled={updateMutation.isPending}
+				/>
+				<label htmlFor="ordered-toggle" className="cursor-pointer text-sm">
+					並び替えモード（ドラッグで順序変更）
+				</label>
+			</div>
+
+			{collection.items.length === 0 ? (
+				<div className="rounded-field bg-base-100 p-12 text-center shadow-sm">
+					<p className="text-base-content/60">
+						アイテムがまだありません。楽曲・アルバム・サークルの詳細ページから追加してください。
+					</p>
+				</div>
+			) : (
+				<SortableCollectionItems
+					key={collection.updatedAt}
+					items={collection.items}
+					disabled={!collection.ordered}
+					onReorder={handleReorder}
+					renderItem={(item) => (
+						<CollectionItemRow
+							item={item}
+							onRemove={() => handleRemoveItem(item.id)}
+							removing={
+								removeItemMutation.isPending &&
+								removeItemMutation.variables?.itemId === item.id
+							}
+						/>
+					)}
+				/>
+			)}
+
+			{isEditing && (
+				<EditCollectionDialog
+					collection={collection}
+					onClose={() => setIsEditing(false)}
+					onSubmit={handleEditSubmit}
+				/>
+			)}
+		</div>
+	);
+}
+
+interface CollectionItemRowProps {
+	item: UserCollectionItem;
+	onRemove: () => void;
+	removing: boolean;
+}
+
+function CollectionItemRow({
+	item,
+	onRemove,
+	removing,
+}: CollectionItemRowProps) {
+	const { label, to } = (() => {
+		switch (item.targetType) {
+			case "track":
+				return { label: "トラック", to: "/tracks/$id" };
+			case "release":
+				return { label: "アルバム", to: "/releases/$id" };
+			case "circle":
+				return { label: "サークル", to: "/circles/$id" };
+		}
+	})();
+
+	const displayName =
+		(item.target as { name?: string; title?: string } | null)?.name ??
+		(item.target as { title?: string } | null)?.title ??
+		"（削除されたアイテム）";
+
+	return (
+		<div className="flex items-center justify-between gap-4 rounded-field bg-base-100 p-3 shadow-sm">
+			<div className="min-w-0 flex-1">
+				<Link
+					to={to}
+					params={{ id: item.targetId }}
+					className="font-medium hover:underline"
+				>
+					{displayName}
+				</Link>
+				<p className="text-base-content/50 text-xs">{label}</p>
+				{item.note && (
+					<p className="mt-1 text-base-content/60 text-sm">{item.note}</p>
+				)}
+			</div>
+			<button
+				type="button"
+				onClick={onRemove}
+				disabled={removing}
+				className="btn btn-ghost btn-sm"
+				aria-label="削除"
+			>
+				<Trash2 className="size-4" />
+			</button>
+		</div>
+	);
+}
+
+interface EditCollectionDialogProps {
+	collection: UserCollectionDetail;
+	onClose: () => void;
+	onSubmit: (input: UserCollectionUpdateInput) => Promise<void>;
+}
+
+function EditCollectionDialog({
+	collection,
+	onClose,
+	onSubmit,
+}: EditCollectionDialogProps) {
+	const [name, setName] = useState(collection.name);
+	const [description, setDescription] = useState(collection.description ?? "");
+	const [visibility, setVisibility] = useState<UserCollectionVisibility>(
+		collection.visibility,
+	);
+	const [submitting, setSubmitting] = useState(false);
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setSubmitting(true);
+		try {
+			await onSubmit({
+				name: name.trim(),
+				description: description.trim() === "" ? null : description.trim(),
+				visibility,
+			});
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<div className="modal modal-open">
+			<div className="modal-box">
+				<h3 className="font-bold text-lg">コレクションを編集</h3>
+				<form onSubmit={handleSubmit} className="mt-4 space-y-4">
+					<div>
+						<label className="label" htmlFor="edit-name">
+							<span className="label-text">名前</span>
+						</label>
+						<input
+							id="edit-name"
+							type="text"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							className="input input-bordered w-full"
+							maxLength={100}
+							required
+							autoComplete="off"
+							data-1p-ignore
+							data-lpignore="true"
+							data-form-type="other"
+							disabled={submitting}
+						/>
+					</div>
+					<div>
+						<label className="label" htmlFor="edit-description">
+							<span className="label-text">説明（任意）</span>
+						</label>
+						<textarea
+							id="edit-description"
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							className="textarea textarea-bordered w-full"
+							maxLength={500}
+							rows={3}
+							disabled={submitting}
+						/>
+					</div>
+					{!collection.isDefaultLiked && (
+						<div>
+							<label className="label" htmlFor="edit-visibility">
+								<span className="label-text">公開範囲</span>
+							</label>
+							<select
+								id="edit-visibility"
+								value={visibility}
+								onChange={(e) =>
+									setVisibility(e.target.value as UserCollectionVisibility)
+								}
+								className="select select-bordered w-full"
+								disabled={submitting}
+							>
+								<option value="private">非公開</option>
+								<option value="unlisted">URLを知っている人のみ</option>
+								<option value="public">公開</option>
+							</select>
+						</div>
+					)}
+					<div className="modal-action">
+						<button
+							type="button"
+							onClick={onClose}
+							className="btn btn-ghost"
+							disabled={submitting}
+						>
+							キャンセル
+						</button>
+						<button
+							type="submit"
+							className="btn btn-primary"
+							disabled={submitting}
+						>
+							{submitting ? "保存中..." : "保存"}
+						</button>
+					</div>
+				</form>
+			</div>
+			<button
+				type="button"
+				onClick={onClose}
+				className="modal-backdrop"
+				aria-label="閉じる"
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/routes/user/_user/collections_.$id.tsx
+++ b/apps/web/src/routes/user/_user/collections_.$id.tsx
@@ -191,7 +191,7 @@ function CollectionDetailPage() {
 				</Banner>
 			)}
 
-			<div className="form-control flex-row items-center gap-2">
+			<div className="flex items-center gap-3">
 				<input
 					id="ordered-toggle"
 					type="checkbox"

--- a/apps/web/src/routes/user/_user/collections_.new.tsx
+++ b/apps/web/src/routes/user/_user/collections_.new.tsx
@@ -1,0 +1,132 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+import { useState } from "react";
+import { Banner } from "@/components/ui/banner";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
+import { createPageHead } from "@/lib/head";
+import { userCollectionMutations } from "@/lib/user-collections-query-options";
+
+export const Route = createFileRoute("/user/_user/collections_/new")({
+	head: () => createPageHead("新規コレクション"),
+	headers: () => CACHE_HEADERS.PRIVATE,
+	component: CollectionNewPage,
+});
+
+function CollectionNewPage() {
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+	const createMutation = useMutation(
+		userCollectionMutations.create(queryClient),
+	);
+
+	const [name, setName] = useState("");
+	const [description, setDescription] = useState("");
+	const [ordered, setOrdered] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setError(null);
+
+		const trimmedName = name.trim();
+		if (trimmedName.length === 0) {
+			setError("コレクション名は必須です");
+			return;
+		}
+
+		try {
+			const created = await createMutation.mutateAsync({
+				name: trimmedName,
+				description: description.trim() || null,
+				ordered,
+				kind: "collection",
+				visibility: "private",
+			});
+			navigate({ to: "/user/collections/$id", params: { id: created.id } });
+		} catch (e) {
+			setError(
+				e instanceof Error ? e.message : "コレクションの作成に失敗しました",
+			);
+		}
+	};
+
+	return (
+		<div className="max-w-md space-y-4">
+			<Link
+				to="/user/collections"
+				className="inline-flex items-center gap-1 text-base-content/60 text-sm hover:text-base-content"
+			>
+				<ArrowLeft className="size-4" />
+				コレクション一覧へ
+			</Link>
+
+			<h1 className="font-bold text-2xl">新規コレクション</h1>
+
+			{error && (
+				<Banner variant="error" dismissible onDismiss={() => setError(null)}>
+					{error}
+				</Banner>
+			)}
+
+			<form onSubmit={handleSubmit} className="space-y-4">
+				<div>
+					<label className="label" htmlFor="new-name">
+						<span className="label-text">名前</span>
+					</label>
+					<input
+						id="new-name"
+						type="text"
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						className="input input-bordered w-full"
+						maxLength={100}
+						placeholder="例: 夏コミ買うリスト"
+						required
+						autoComplete="off"
+						data-1p-ignore
+						data-lpignore="true"
+						data-form-type="other"
+						disabled={createMutation.isPending}
+					/>
+				</div>
+				<div>
+					<label className="label" htmlFor="new-description">
+						<span className="label-text">説明（任意）</span>
+					</label>
+					<textarea
+						id="new-description"
+						value={description}
+						onChange={(e) => setDescription(e.target.value)}
+						className="textarea textarea-bordered w-full"
+						maxLength={500}
+						rows={3}
+						placeholder="このコレクションの説明（任意・最大 500 文字）"
+						disabled={createMutation.isPending}
+					/>
+				</div>
+				<div className="form-control">
+					<label className="label cursor-pointer justify-start gap-2">
+						<input
+							type="checkbox"
+							className="checkbox checkbox-primary"
+							checked={ordered}
+							onChange={(e) => setOrdered(e.target.checked)}
+							disabled={createMutation.isPending}
+						/>
+						<span className="label-text">
+							並び替えを有効にする（あとから変更可能）
+						</span>
+					</label>
+				</div>
+				<button
+					type="submit"
+					className="btn btn-primary w-full"
+					disabled={createMutation.isPending}
+				>
+					{createMutation.isPending ? "作成中..." : "作成"}
+				</button>
+			</form>
+		</div>
+	);
+}

--- a/apps/web/src/routes/user/_user/collections_.new.tsx
+++ b/apps/web/src/routes/user/_user/collections_.new.tsx
@@ -1,8 +1,9 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Disc3, Music, UserRound, Users } from "lucide-react";
 import { useState } from "react";
 import { Banner } from "@/components/ui/banner";
+import type { CollectionItemType } from "@/lib/api-client";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPageHead } from "@/lib/head";
 import { userCollectionMutations } from "@/lib/user-collections-query-options";
@@ -12,6 +13,21 @@ export const Route = createFileRoute("/user/_user/collections_/new")({
 	headers: () => CACHE_HEADERS.PRIVATE,
 	component: CollectionNewPage,
 });
+
+const ITEM_TYPE_OPTIONS: {
+	value: CollectionItemType;
+	label: string;
+	icon: React.ReactNode;
+}[] = [
+	{ value: "track", label: "楽曲", icon: <Music className="size-4" /> },
+	{ value: "release", label: "アルバム", icon: <Disc3 className="size-4" /> },
+	{ value: "circle", label: "サークル", icon: <Users className="size-4" /> },
+	{
+		value: "artist",
+		label: "アーティスト",
+		icon: <UserRound className="size-4" />,
+	},
+];
 
 function CollectionNewPage() {
 	const navigate = useNavigate();
@@ -23,6 +39,7 @@ function CollectionNewPage() {
 	const [name, setName] = useState("");
 	const [description, setDescription] = useState("");
 	const [ordered, setOrdered] = useState(false);
+	const [itemType, setItemType] = useState<CollectionItemType | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
 	const handleSubmit = async (e: React.FormEvent) => {
@@ -35,11 +52,17 @@ function CollectionNewPage() {
 			return;
 		}
 
+		if (!itemType) {
+			setError("種別を選択してください");
+			return;
+		}
+
 		try {
 			const created = await createMutation.mutateAsync({
 				name: trimmedName,
 				description: description.trim() || null,
 				ordered,
+				itemType,
 				kind: "collection",
 				visibility: "private",
 			});
@@ -90,6 +113,40 @@ function CollectionNewPage() {
 						disabled={createMutation.isPending}
 					/>
 				</div>
+
+				<div>
+					<p className="label-text mb-2 font-medium">
+						種別 <span className="text-error">*</span>
+					</p>
+					<div className="grid grid-cols-2 gap-2">
+						{ITEM_TYPE_OPTIONS.map((opt) => (
+							<label
+								key={opt.value}
+								className={`flex cursor-pointer items-center gap-2 rounded-field border-2 p-3 transition-colors ${
+									itemType === opt.value
+										? "border-primary bg-primary/10"
+										: "border-base-300 hover:border-primary/50"
+								} ${createMutation.isPending ? "cursor-not-allowed opacity-50" : ""}`}
+							>
+								<input
+									type="radio"
+									className="sr-only"
+									name="itemType"
+									value={opt.value}
+									checked={itemType === opt.value}
+									onChange={() => setItemType(opt.value)}
+									disabled={createMutation.isPending}
+								/>
+								{opt.icon}
+								<span className="text-sm">{opt.label}</span>
+							</label>
+						))}
+					</div>
+					<p className="mt-1 text-base-content/50 text-xs">
+						※コレクション作成後は変更できません
+					</p>
+				</div>
+
 				<div>
 					<label className="label" htmlFor="new-description">
 						<span className="label-text">説明（任意）</span>

--- a/apps/web/src/routes/user/_user/likes.tsx
+++ b/apps/web/src/routes/user/_user/likes.tsx
@@ -207,6 +207,8 @@ function LikesItemRow({ item, onRemove, removing }: LikesItemRowProps) {
 				return { label: "アルバム", to: "/releases/$id" };
 			case "circle":
 				return { label: "サークル", to: "/circles/$id" };
+			case "artist":
+				return { label: "アーティスト", to: "/artists/$id" };
 		}
 	})();
 

--- a/apps/web/src/routes/user/_user/likes.tsx
+++ b/apps/web/src/routes/user/_user/likes.tsx
@@ -186,7 +186,7 @@ function LikesEmptyPage() {
 			/>
 			<h1 className="font-bold text-xl">お気に入り</h1>
 			<p className="mt-2 text-base-content/60">
-				楽曲・アルバム・サークルの詳細ページにある♥ボタンを押すと、ここに自動で集まります。
+				楽曲・アルバム・サークル・アーティストの詳細ページにある♥ボタンを押すと、ここに自動で集まります。
 			</p>
 		</div>
 	);

--- a/apps/web/src/routes/user/_user/likes.tsx
+++ b/apps/web/src/routes/user/_user/likes.tsx
@@ -1,8 +1,21 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
-import { Heart } from "lucide-react";
+import {
+	useMutation,
+	useQueryClient,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Heart, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Banner } from "@/components/ui/banner";
+import { SortableCollectionItems } from "@/components/user/sortable-collection-items";
+import type { UserCollectionItem } from "@/lib/api-client";
 import { CACHE_HEADERS } from "@/lib/cache-headers";
 import { createPageHead } from "@/lib/head";
-import { userCollectionsListQueryOptions } from "@/lib/user-collections-query-options";
+import {
+	userCollectionDetailQueryOptions,
+	userCollectionMutations,
+	userCollectionsListQueryOptions,
+} from "@/lib/user-collections-query-options";
 
 export const Route = createFileRoute("/user/_user/likes")({
 	head: () => createPageHead("お気に入り"),
@@ -13,15 +26,156 @@ export const Route = createFileRoute("/user/_user/likes")({
 		);
 		const liked = list.items.find((c) => c.isDefaultLiked);
 		if (liked) {
-			throw redirect({
-				to: "/user/collections/$id",
-				params: { id: liked.id },
+			await context.queryClient.ensureQueryData(
+				userCollectionDetailQueryOptions(liked.id),
+			);
+			return { likedId: liked.id };
+		}
+		return { likedId: null };
+	},
+	component: LikesPage,
+});
+
+interface Feedback {
+	variant: "success" | "error";
+	message: string;
+}
+
+function LikesPage() {
+	const { likedId } = Route.useLoaderData();
+
+	if (!likedId) {
+		return <LikesEmptyPage />;
+	}
+
+	return <LikesCollectionPage id={likedId} />;
+}
+
+interface LikesCollectionPageProps {
+	id: string;
+}
+
+function LikesCollectionPage({ id }: LikesCollectionPageProps) {
+	const queryClient = useQueryClient();
+	const { data: collection } = useSuspenseQuery(
+		userCollectionDetailQueryOptions(id),
+	);
+
+	const [feedback, setFeedback] = useState<Feedback | null>(null);
+
+	const reorderMutation = useMutation(
+		userCollectionMutations.reorderItems(queryClient),
+	);
+	const removeItemMutation = useMutation(
+		userCollectionMutations.removeItem(queryClient),
+	);
+	const updateMutation = useMutation(
+		userCollectionMutations.update(queryClient),
+	);
+
+	const handleReorder = async (newOrder: UserCollectionItem[]) => {
+		try {
+			await reorderMutation.mutateAsync({
+				id,
+				input: {
+					items: newOrder.map((it, idx) => ({
+						itemId: it.id,
+						position: idx,
+					})),
+				},
+			});
+		} catch (e) {
+			setFeedback({
+				variant: "error",
+				message: e instanceof Error ? e.message : "並び替えに失敗しました",
 			});
 		}
-		return {};
-	},
-	component: LikesEmptyPage,
-});
+	};
+
+	const handleToggleOrdered = async () => {
+		try {
+			await updateMutation.mutateAsync({
+				id,
+				input: { ordered: !collection.ordered },
+			});
+		} catch (e) {
+			setFeedback({
+				variant: "error",
+				message: e instanceof Error ? e.message : "更新に失敗しました",
+			});
+		}
+	};
+
+	const handleRemoveItem = async (itemId: string) => {
+		try {
+			await removeItemMutation.mutateAsync({ id, itemId });
+			setFeedback({ variant: "success", message: "アイテムを削除しました" });
+		} catch (e) {
+			setFeedback({
+				variant: "error",
+				message: e instanceof Error ? e.message : "削除に失敗しました",
+			});
+		}
+	};
+
+	return (
+		<div className="space-y-6">
+			<div>
+				<h1 className="font-bold text-2xl">お気に入り</h1>
+				<div className="mt-2 flex items-center gap-2 text-base-content/50 text-xs">
+					<span>{collection.items.length} 件</span>
+				</div>
+			</div>
+
+			{feedback && (
+				<Banner
+					variant={feedback.variant}
+					autoHideDuration={3000}
+					onAutoHide={() => setFeedback(null)}
+					dismissible
+					onDismiss={() => setFeedback(null)}
+				>
+					{feedback.message}
+				</Banner>
+			)}
+
+			<div className="flex items-center gap-3">
+				<input
+					id="ordered-toggle"
+					type="checkbox"
+					className="toggle toggle-primary"
+					checked={collection.ordered}
+					onChange={handleToggleOrdered}
+					disabled={updateMutation.isPending}
+				/>
+				<label htmlFor="ordered-toggle" className="cursor-pointer text-sm">
+					並び替えモード（ドラッグで順序変更）
+				</label>
+			</div>
+
+			{collection.items.length === 0 ? (
+				<LikesEmptyPage />
+			) : (
+				<SortableCollectionItems
+					key={collection.updatedAt}
+					items={collection.items}
+					disabled={!collection.ordered}
+					onReorder={handleReorder}
+					renderItem={(item) => (
+						<LikesItemRow
+							item={item}
+							onRemove={() => handleRemoveItem(item.id)}
+							removing={
+								removeItemMutation.isPending &&
+								removeItemMutation.variables?.itemId === item.id
+							}
+						/>
+					)}
+				/>
+			)}
+		</div>
+	);
+}
 
 function LikesEmptyPage() {
 	return (
@@ -34,6 +188,57 @@ function LikesEmptyPage() {
 			<p className="mt-2 text-base-content/60">
 				楽曲・アルバム・サークルの詳細ページにある♥ボタンを押すと、ここに自動で集まります。
 			</p>
+		</div>
+	);
+}
+
+interface LikesItemRowProps {
+	item: UserCollectionItem;
+	onRemove: () => void;
+	removing: boolean;
+}
+
+function LikesItemRow({ item, onRemove, removing }: LikesItemRowProps) {
+	const { label, to } = (() => {
+		switch (item.targetType) {
+			case "track":
+				return { label: "トラック", to: "/tracks/$id" };
+			case "release":
+				return { label: "アルバム", to: "/releases/$id" };
+			case "circle":
+				return { label: "サークル", to: "/circles/$id" };
+		}
+	})();
+
+	const displayName =
+		(item.target as { name?: string; title?: string } | null)?.name ??
+		(item.target as { title?: string } | null)?.title ??
+		"（削除されたアイテム）";
+
+	return (
+		<div className="flex items-center justify-between gap-4 rounded-field bg-base-100 p-3 shadow-sm">
+			<div className="min-w-0 flex-1">
+				<Link
+					to={to}
+					params={{ id: item.targetId }}
+					className="font-medium hover:underline"
+				>
+					{displayName}
+				</Link>
+				<p className="text-base-content/50 text-xs">{label}</p>
+				{item.note && (
+					<p className="mt-1 text-base-content/60 text-sm">{item.note}</p>
+				)}
+			</div>
+			<button
+				type="button"
+				onClick={onRemove}
+				disabled={removing}
+				className="btn btn-ghost btn-sm"
+				aria-label="削除"
+			>
+				<Trash2 className="size-4" />
+			</button>
 		</div>
 	);
 }

--- a/apps/web/src/routes/user/_user/likes.tsx
+++ b/apps/web/src/routes/user/_user/likes.tsx
@@ -1,0 +1,39 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { Heart } from "lucide-react";
+import { CACHE_HEADERS } from "@/lib/cache-headers";
+import { createPageHead } from "@/lib/head";
+import { userCollectionsListQueryOptions } from "@/lib/user-collections-query-options";
+
+export const Route = createFileRoute("/user/_user/likes")({
+	head: () => createPageHead("お気に入り"),
+	headers: () => CACHE_HEADERS.PRIVATE,
+	loader: async ({ context }) => {
+		const list = await context.queryClient.ensureQueryData(
+			userCollectionsListQueryOptions({ kind: "collection" }),
+		);
+		const liked = list.items.find((c) => c.isDefaultLiked);
+		if (liked) {
+			throw redirect({
+				to: "/user/collections/$id",
+				params: { id: liked.id },
+			});
+		}
+		return {};
+	},
+	component: LikesEmptyPage,
+});
+
+function LikesEmptyPage() {
+	return (
+		<div className="rounded-field bg-base-100 p-12 text-center shadow-sm">
+			<Heart
+				className="mx-auto mb-4 size-10 text-base-content/30"
+				strokeWidth={1.5}
+			/>
+			<h1 className="font-bold text-xl">お気に入り</h1>
+			<p className="mt-2 text-base-content/60">
+				楽曲・アルバム・サークルの詳細ページにある♥ボタンを押すと、ここに自動で集まります。
+			</p>
+		</div>
+	);
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -40,6 +40,7 @@
 		"dotenv": "catalog:",
 		"drizzle-orm": "^0.45.2",
 		"drizzle-zod": "^0.8.3",
+		"nanoid": "catalog:",
 		"postgres": "catalog:",
 		"zod": "catalog:"
 	}

--- a/packages/db/src/migrations/0005_wakeful_clint_barton.sql
+++ b/packages/db/src/migrations/0005_wakeful_clint_barton.sql
@@ -1,0 +1,36 @@
+CREATE TABLE "user_collection_items" (
+	"id" text PRIMARY KEY NOT NULL,
+	"collection_id" text NOT NULL,
+	"target_type" text NOT NULL,
+	"target_id" text NOT NULL,
+	"position" integer,
+	"note" text,
+	"added_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "check_user_collection_items_target_type" CHECK ("target_type" IN ('circle','release','track'))
+);
+--> statement-breakpoint
+CREATE TABLE "user_collections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"kind" text DEFAULT 'collection' NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"visibility" text DEFAULT 'private' NOT NULL,
+	"ordered" boolean DEFAULT false NOT NULL,
+	"is_default_liked" boolean DEFAULT false NOT NULL,
+	"short_id" text,
+	"cover_image_url" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "check_user_collections_kind" CHECK ("kind" IN ('collection','playlist')),
+	CONSTRAINT "check_user_collections_visibility" CHECK ("visibility" IN ('private','unlisted','public'))
+);
+--> statement-breakpoint
+ALTER TABLE "user_collection_items" ADD CONSTRAINT "user_collection_items_collection_id_user_collections_id_fk" FOREIGN KEY ("collection_id") REFERENCES "public"."user_collections"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_collections" ADD CONSTRAINT "user_collections_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_user_collection_items_unique" ON "user_collection_items" USING btree ("collection_id","target_type","target_id");--> statement-breakpoint
+CREATE INDEX "idx_user_collection_items_target" ON "user_collection_items" USING btree ("target_type","target_id");--> statement-breakpoint
+CREATE INDEX "idx_user_collection_items_position" ON "user_collection_items" USING btree ("collection_id","position") WHERE "user_collection_items"."position" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_user_collections_user_kind" ON "user_collections" USING btree ("user_id","kind");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_user_collections_default_liked" ON "user_collections" USING btree ("user_id") WHERE "user_collections"."is_default_liked" = true;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_user_collections_short_id" ON "user_collections" USING btree ("short_id") WHERE "user_collections"."short_id" IS NOT NULL;

--- a/packages/db/src/migrations/0006_organic_epoch.sql
+++ b/packages/db/src/migrations/0006_organic_epoch.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "user_collection_items" DROP CONSTRAINT "check_user_collection_items_target_type";--> statement-breakpoint
+ALTER TABLE "user_collections" ADD COLUMN "item_type" text;--> statement-breakpoint
+ALTER TABLE "user_collection_items" ADD CONSTRAINT "check_user_collection_items_target_type" CHECK ("target_type" IN ('circle','release','track','artist'));--> statement-breakpoint
+ALTER TABLE "user_collections" ADD CONSTRAINT "check_user_collections_item_type" CHECK ("item_type" IS NULL OR "item_type" IN ('track','release','circle','artist'));--> statement-breakpoint
+-- 既存コレクションの itemType を最初のアイテムの targetType から推論
+UPDATE user_collections uc
+SET item_type = sub.target_type
+FROM (
+  SELECT DISTINCT ON (collection_id) collection_id, target_type
+  FROM user_collection_items
+  ORDER BY collection_id, added_at ASC
+) sub
+WHERE uc.id = sub.collection_id AND uc.is_default_liked = false;

--- a/packages/db/src/migrations/meta/0005_snapshot.json
+++ b/packages/db/src/migrations/meta/0005_snapshot.json
@@ -1,0 +1,5145 @@
+{
+	"id": "02e480e9-dec7-4933-9307-1178921cede0",
+	"prevId": "6955eeb6-48d8-46f7-a432-e495ca2295fa",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.album_requests": {
+			"name": "album_requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_type": {
+					"name": "request_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"existing_release_id": {
+					"name": "existing_release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"circle_name": {
+					"name": "circle_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_urls": {
+					"name": "reference_urls",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"reviewed_by_user_id": {
+					"name": "reviewed_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reviewer_notes": {
+					"name": "reviewer_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reviewed_at": {
+					"name": "reviewed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_album_requests_user": {
+					"name": "idx_album_requests_user",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_existing_release": {
+					"name": "idx_album_requests_existing_release",
+					"columns": [
+						{
+							"expression": "existing_release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_status": {
+					"name": "idx_album_requests_status",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_created_at": {
+					"name": "idx_album_requests_created_at",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_status_created_at": {
+					"name": "idx_album_requests_status_created_at",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_reviewed_by": {
+					"name": "idx_album_requests_reviewed_by",
+					"columns": [
+						{
+							"expression": "reviewed_by_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"album_requests_user_id_user_id_fk": {
+					"name": "album_requests_user_id_user_id_fk",
+					"tableFrom": "album_requests",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				},
+				"album_requests_existing_release_id_releases_id_fk": {
+					"name": "album_requests_existing_release_id_releases_id_fk",
+					"tableFrom": "album_requests",
+					"tableTo": "releases",
+					"columnsFrom": ["existing_release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"album_requests_reviewed_by_user_id_user_id_fk": {
+					"name": "album_requests_reviewed_by_user_id_user_id_fk",
+					"tableFrom": "album_requests",
+					"tableTo": "user",
+					"columnsFrom": ["reviewed_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_album_request_status": {
+					"name": "check_album_request_status",
+					"value": "status IN ('pending','approved','rejected')"
+				},
+				"check_album_request_type": {
+					"name": "check_album_request_type",
+					"value": "request_type IN ('new','existing')"
+				},
+				"check_album_request_type_consistency": {
+					"name": "check_album_request_type_consistency",
+					"value": "(request_type='existing' AND existing_release_id IS NOT NULL)\n        OR (request_type='new' AND album_name IS NOT NULL)"
+				},
+				"check_album_request_review_consistency": {
+					"name": "check_album_request_review_consistency",
+					"value": "(status='pending' AND reviewed_at IS NULL AND reviewed_by_user_id IS NULL)\n        OR (status<>'pending' AND reviewed_at IS NOT NULL AND reviewed_by_user_id IS NOT NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.artist_aliases": {
+			"name": "artist_aliases",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"alias_type_code": {
+					"name": "alias_type_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_initial": {
+					"name": "name_initial",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"initial_script": {
+					"name": "initial_script",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"period_from": {
+					"name": "period_from",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_to": {
+					"name": "period_to",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_artist_aliases_artist_id": {
+					"name": "idx_artist_aliases_artist_id",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artist_aliases_alias_type": {
+					"name": "idx_artist_aliases_alias_type",
+					"columns": [
+						{
+							"expression": "alias_type_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_artist_aliases_name": {
+					"name": "uq_artist_aliases_name",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artist_aliases_name_lower": {
+					"name": "idx_artist_aliases_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artist_aliases_name_trgm": {
+					"name": "idx_artist_aliases_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"artist_aliases_artist_id_artists_id_fk": {
+					"name": "artist_aliases_artist_id_artists_id_fk",
+					"tableFrom": "artist_aliases",
+					"tableTo": "artists",
+					"columnsFrom": ["artist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"artist_aliases_alias_type_code_alias_types_code_fk": {
+					"name": "artist_aliases_alias_type_code_alias_types_code_fk",
+					"tableFrom": "artist_aliases",
+					"tableTo": "alias_types",
+					"columnsFrom": ["alias_type_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.artists": {
+			"name": "artists",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_name": {
+					"name": "sort_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_initial": {
+					"name": "name_initial",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"initial_script": {
+					"name": "initial_script",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uq_artists_name": {
+					"name": "uq_artists_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_sort": {
+					"name": "idx_artists_sort",
+					"columns": [
+						{
+							"expression": "sort_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_initial": {
+					"name": "idx_artists_initial",
+					"columns": [
+						{
+							"expression": "name_initial",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "initial_script",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_name_lower": {
+					"name": "idx_artists_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_name_trgm": {
+					"name": "idx_artists_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.circle_links": {
+			"name": "circle_links",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"circle_id": {
+					"name": "circle_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_id": {
+					"name": "platform_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"handle": {
+					"name": "handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_official": {
+					"name": "is_official",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_circle_links_circle_id": {
+					"name": "idx_circle_links_circle_id",
+					"columns": [
+						{
+							"expression": "circle_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circle_links_platform": {
+					"name": "idx_circle_links_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_circle_links_circle_url": {
+					"name": "uq_circle_links_circle_url",
+					"columns": [
+						{
+							"expression": "circle_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"circle_links_circle_id_circles_id_fk": {
+					"name": "circle_links_circle_id_circles_id_fk",
+					"tableFrom": "circle_links",
+					"tableTo": "circles",
+					"columnsFrom": ["circle_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"circle_links_platform_code_platforms_code_fk": {
+					"name": "circle_links_platform_code_platforms_code_fk",
+					"tableFrom": "circle_links",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.circles": {
+			"name": "circles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_name": {
+					"name": "sort_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_initial": {
+					"name": "name_initial",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"initial_script": {
+					"name": "initial_script",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uq_circles_name": {
+					"name": "uq_circles_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circles_initial": {
+					"name": "idx_circles_initial",
+					"columns": [
+						{
+							"expression": "name_initial",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "initial_script",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circles_name_lower": {
+					"name": "idx_circles_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circles_name_trgm": {
+					"name": "idx_circles_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_circles_name_ja_trgm": {
+					"name": "idx_circles_name_ja_trgm",
+					"columns": [
+						{
+							"expression": "\"name_ja\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_circles_name_en_trgm": {
+					"name": "idx_circles_name_en_trgm",
+					"columns": [
+						{
+							"expression": "\"name_en\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"onboarding_completed": {
+					"name": "onboarding_completed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.event_days": {
+			"name": "event_days",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"event_id": {
+					"name": "event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"day_number": {
+					"name": "day_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_event_days_event_id": {
+					"name": "idx_event_days_event_id",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_days_date": {
+					"name": "idx_event_days_date",
+					"columns": [
+						{
+							"expression": "date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_event_days_event_day_number": {
+					"name": "uq_event_days_event_day_number",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "day_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_event_days_event_date": {
+					"name": "uq_event_days_event_date",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"event_days_event_id_events_id_fk": {
+					"name": "event_days_event_id_events_id_fk",
+					"tableFrom": "event_days",
+					"tableTo": "events",
+					"columnsFrom": ["event_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.event_series": {
+			"name": "event_series",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_event_series_name": {
+					"name": "idx_event_series_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_series_sort_order": {
+					"name": "idx_event_series_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_event_series_name": {
+					"name": "uq_event_series_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_series_name_lower": {
+					"name": "idx_event_series_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.events": {
+			"name": "events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"event_series_id": {
+					"name": "event_series_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"edition": {
+					"name": "edition",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_days": {
+					"name": "total_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"venue": {
+					"name": "venue",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_events_event_series_id": {
+					"name": "idx_events_event_series_id",
+					"columns": [
+						{
+							"expression": "event_series_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_events_edition": {
+					"name": "idx_events_edition",
+					"columns": [
+						{
+							"expression": "edition",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_events_start_date": {
+					"name": "idx_events_start_date",
+					"columns": [
+						{
+							"expression": "start_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_events_series_edition": {
+					"name": "uq_events_series_edition",
+					"columns": [
+						{
+							"expression": "event_series_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "edition",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"events_event_series_id_event_series_id_fk": {
+					"name": "events_event_series_id_event_series_id_fk",
+					"tableFrom": "events",
+					"tableTo": "event_series",
+					"columnsFrom": ["event_series_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.genres": {
+			"name": "genres",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"color": {
+					"name": "color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_genres_sort_order": {
+					"name": "idx_genres_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_genres": {
+			"name": "track_genres",
+			"schema": "",
+			"columns": {
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"genre_code": {
+					"name": "genre_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_genres_track": {
+					"name": "idx_track_genres_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_genres_genre": {
+					"name": "idx_track_genres_genre",
+					"columns": [
+						{
+							"expression": "genre_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_genres_track_position": {
+					"name": "idx_track_genres_track_position",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_genres_track_id_tracks_id_fk": {
+					"name": "track_genres_track_id_tracks_id_fk",
+					"tableFrom": "track_genres",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_genres_genre_code_genres_code_fk": {
+					"name": "track_genres_genre_code_genres_code_fk",
+					"tableFrom": "track_genres",
+					"tableTo": "genres",
+					"columnsFrom": ["genre_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"track_genres_track_id_genre_code_pk": {
+					"name": "track_genres_track_id_genre_code_pk",
+					"columns": ["track_id", "genre_code"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_track_genres_position": {
+					"name": "check_track_genres_position",
+					"value": "\"position\" >= 1 AND \"position\" <= 5"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.release_jan_codes": {
+			"name": "release_jan_codes",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"jan_code": {
+					"name": "jan_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"country_code": {
+					"name": "country_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_release_jan_codes_release": {
+					"name": "idx_release_jan_codes_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_release_jan_codes_jan": {
+					"name": "uq_release_jan_codes_jan",
+					"columns": [
+						{
+							"expression": "jan_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_release_jan_codes_primary": {
+					"name": "uq_release_jan_codes_primary",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"release_jan_codes\".\"is_primary\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"release_jan_codes_release_id_releases_id_fk": {
+					"name": "release_jan_codes_release_id_releases_id_fk",
+					"tableFrom": "release_jan_codes",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_isrcs": {
+			"name": "track_isrcs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"isrc": {
+					"name": "isrc",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_isrcs_track": {
+					"name": "idx_track_isrcs_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_isrcs": {
+					"name": "uq_track_isrcs",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "isrc",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_isrcs_primary": {
+					"name": "uq_track_isrcs_primary",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"track_isrcs\".\"is_primary\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_isrcs_track_id_tracks_id_fk": {
+					"name": "track_isrcs_track_id_tracks_id_fk",
+					"tableFrom": "track_isrcs",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.alias_types": {
+			"name": "alias_types",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_alias_types_sort_order": {
+					"name": "idx_alias_types_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.credit_roles": {
+			"name": "credit_roles",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_credit_roles_sort_order": {
+					"name": "idx_credit_roles_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_work_categories": {
+			"name": "official_work_categories",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_work_categories_sort_order": {
+					"name": "idx_official_work_categories_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.platforms": {
+			"name": "platforms",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url_pattern": {
+					"name": "url_pattern",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_platforms_category": {
+					"name": "idx_platforms_category",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_platforms_sort_order": {
+					"name": "idx_platforms_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_song_links": {
+			"name": "official_song_links",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"official_song_id": {
+					"name": "official_song_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_song_links_song_id": {
+					"name": "idx_official_song_links_song_id",
+					"columns": [
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_song_links_platform": {
+					"name": "idx_official_song_links_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_official_song_links_song_url": {
+					"name": "uq_official_song_links_song_url",
+					"columns": [
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_song_links_official_song_id_official_songs_id_fk": {
+					"name": "official_song_links_official_song_id_official_songs_id_fk",
+					"tableFrom": "official_song_links",
+					"tableTo": "official_songs",
+					"columnsFrom": ["official_song_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"official_song_links_platform_code_platforms_code_fk": {
+					"name": "official_song_links_platform_code_platforms_code_fk",
+					"tableFrom": "official_song_links",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_songs": {
+			"name": "official_songs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"official_work_id": {
+					"name": "official_work_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_number": {
+					"name": "track_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"composer_name": {
+					"name": "composer_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"arranger_name": {
+					"name": "arranger_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_original": {
+					"name": "is_original",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"source_song_id": {
+					"name": "source_song_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_songs_work": {
+					"name": "idx_official_songs_work",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_songs_source": {
+					"name": "idx_official_songs_source",
+					"columns": [
+						{
+							"expression": "source_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_songs_work_original": {
+					"name": "idx_official_songs_work_original",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "is_original",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_songs_official_work_id_official_works_id_fk": {
+					"name": "official_songs_official_work_id_official_works_id_fk",
+					"tableFrom": "official_songs",
+					"tableTo": "official_works",
+					"columnsFrom": ["official_work_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_work_links": {
+			"name": "official_work_links",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"official_work_id": {
+					"name": "official_work_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_work_links_work_id": {
+					"name": "idx_official_work_links_work_id",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_work_links_platform": {
+					"name": "idx_official_work_links_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_official_work_links_work_url": {
+					"name": "uq_official_work_links_work_url",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_work_links_official_work_id_official_works_id_fk": {
+					"name": "official_work_links_official_work_id_official_works_id_fk",
+					"tableFrom": "official_work_links",
+					"tableTo": "official_works",
+					"columnsFrom": ["official_work_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"official_work_links_platform_code_platforms_code_fk": {
+					"name": "official_work_links_platform_code_platforms_code_fk",
+					"tableFrom": "official_work_links",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_works": {
+			"name": "official_works",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"category_code": {
+					"name": "category_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"short_name_ja": {
+					"name": "short_name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"short_name_en": {
+					"name": "short_name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"number_in_series": {
+					"name": "number_in_series",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"official_organization": {
+					"name": "official_organization",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_works_category": {
+					"name": "idx_official_works_category",
+					"columns": [
+						{
+							"expression": "category_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_works_release_date": {
+					"name": "idx_official_works_release_date",
+					"columns": [
+						{
+							"expression": "release_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_works_position": {
+					"name": "idx_official_works_position",
+					"columns": [
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_works_category_code_official_work_categories_code_fk": {
+					"name": "official_works_category_code_official_work_categories_code_fk",
+					"tableFrom": "official_works",
+					"tableTo": "official_work_categories",
+					"columnsFrom": ["category_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.release_publications": {
+			"name": "release_publications",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_release_publications_release": {
+					"name": "idx_release_publications_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_release_publications_platform": {
+					"name": "idx_release_publications_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_release_publications_url": {
+					"name": "uq_release_publications_url",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"release_publications_release_id_releases_id_fk": {
+					"name": "release_publications_release_id_releases_id_fk",
+					"tableFrom": "release_publications",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"release_publications_platform_code_platforms_code_fk": {
+					"name": "release_publications_platform_code_platforms_code_fk",
+					"tableFrom": "release_publications",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_publications": {
+			"name": "track_publications",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_publications_track": {
+					"name": "idx_track_publications_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_publications_platform": {
+					"name": "idx_track_publications_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_publications_url": {
+					"name": "uq_track_publications_url",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_publications_track_id_tracks_id_fk": {
+					"name": "track_publications_track_id_tracks_id_fk",
+					"tableFrom": "track_publications",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_publications_platform_code_platforms_code_fk": {
+					"name": "track_publications_platform_code_platforms_code_fk",
+					"tableFrom": "track_publications",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.discs": {
+			"name": "discs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"disc_number": {
+					"name": "disc_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"disc_name": {
+					"name": "disc_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_discs_release": {
+					"name": "idx_discs_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_discs_release_number": {
+					"name": "uq_discs_release_number",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "disc_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"discs_release_id_releases_id_fk": {
+					"name": "discs_release_id_releases_id_fk",
+					"tableFrom": "discs",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.release_circles": {
+			"name": "release_circles",
+			"schema": "",
+			"columns": {
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"circle_id": {
+					"name": "circle_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"participation_type": {
+					"name": "participation_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 1
+				}
+			},
+			"indexes": {
+				"idx_release_circles_release": {
+					"name": "idx_release_circles_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_release_circles_circle": {
+					"name": "idx_release_circles_circle",
+					"columns": [
+						{
+							"expression": "circle_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_release_circles_release_participation": {
+					"name": "idx_release_circles_release_participation",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "participation_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"release_circles_release_id_releases_id_fk": {
+					"name": "release_circles_release_id_releases_id_fk",
+					"tableFrom": "release_circles",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"release_circles_circle_id_circles_id_fk": {
+					"name": "release_circles_circle_id_circles_id_fk",
+					"tableFrom": "release_circles",
+					"tableTo": "circles",
+					"columnsFrom": ["circle_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"release_circles_release_id_circle_id_participation_type_pk": {
+					"name": "release_circles_release_id_circle_id_participation_type_pk",
+					"columns": ["release_id", "circle_id", "participation_type"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.releases": {
+			"name": "releases",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_year": {
+					"name": "release_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_month": {
+					"name": "release_month",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_day": {
+					"name": "release_day",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_type": {
+					"name": "release_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_id": {
+					"name": "event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_day_id": {
+					"name": "event_day_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_releases_date": {
+					"name": "idx_releases_date",
+					"columns": [
+						{
+							"expression": "release_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_year": {
+					"name": "idx_releases_year",
+					"columns": [
+						{
+							"expression": "release_year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_year_month": {
+					"name": "idx_releases_year_month",
+					"columns": [
+						{
+							"expression": "release_year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "release_month",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_type": {
+					"name": "idx_releases_type",
+					"columns": [
+						{
+							"expression": "release_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_event": {
+					"name": "idx_releases_event",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_event_day": {
+					"name": "idx_releases_event_day",
+					"columns": [
+						{
+							"expression": "event_day_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_updated_at": {
+					"name": "idx_releases_updated_at",
+					"columns": [
+						{
+							"expression": "updated_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"releases_event_id_events_id_fk": {
+					"name": "releases_event_id_events_id_fk",
+					"tableFrom": "releases",
+					"tableTo": "events",
+					"columnsFrom": ["event_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"releases_event_day_id_event_days_id_fk": {
+					"name": "releases_event_day_id_event_days_id_fk",
+					"tableFrom": "releases",
+					"tableTo": "event_days",
+					"columnsFrom": ["event_day_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_release_year": {
+					"name": "check_release_year",
+					"value": "\"release_year\" >= 1900 AND \"release_year\" <= 2200"
+				},
+				"check_release_month": {
+					"name": "check_release_month",
+					"value": "\"release_month\" >= 1 AND \"release_month\" <= 12"
+				},
+				"check_release_day": {
+					"name": "check_release_day",
+					"value": "\"release_day\" >= 1 AND \"release_day\" <= 31"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.tags": {
+			"name": "tags",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attributes": {
+					"name": "attributes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_tags_attributes_gin": {
+					"name": "idx_tags_attributes_gin",
+					"columns": [
+						{
+							"expression": "attributes",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"tags_name_unique": {
+					"name": "tags_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_tags": {
+			"name": "track_tags",
+			"schema": "",
+			"columns": {
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tag_id": {
+					"name": "tag_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_locked": {
+					"name": "is_locked",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_tags_track": {
+					"name": "idx_track_tags_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_tags_tag": {
+					"name": "idx_track_tags_tag",
+					"columns": [
+						{
+							"expression": "tag_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_tags_track_locked_pos": {
+					"name": "idx_track_tags_track_locked_pos",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "is_locked",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_tags_track_id_tracks_id_fk": {
+					"name": "track_tags_track_id_tracks_id_fk",
+					"tableFrom": "track_tags",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_tags_tag_id_tags_id_fk": {
+					"name": "track_tags_tag_id_tags_id_fk",
+					"tableFrom": "track_tags",
+					"tableTo": "tags",
+					"columnsFrom": ["tag_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"track_tags_track_id_tag_id_pk": {
+					"name": "track_tags_track_id_tag_id_pk",
+					"columns": ["track_id", "tag_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_track_tags_position": {
+					"name": "check_track_tags_position",
+					"value": "\"position\" >= 1 AND \"position\" <= 15"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.track_credit_roles": {
+			"name": "track_credit_roles",
+			"schema": "",
+			"columns": {
+				"track_credit_id": {
+					"name": "track_credit_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role_code": {
+					"name": "role_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role_position": {
+					"name": "role_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				}
+			},
+			"indexes": {
+				"idx_track_credit_roles_credit": {
+					"name": "idx_track_credit_roles_credit",
+					"columns": [
+						{
+							"expression": "track_credit_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credit_roles_role": {
+					"name": "idx_track_credit_roles_role",
+					"columns": [
+						{
+							"expression": "role_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credit_roles_composite": {
+					"name": "idx_track_credit_roles_composite",
+					"columns": [
+						{
+							"expression": "track_credit_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "role_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_credit_roles_track_credit_id_track_credits_id_fk": {
+					"name": "track_credit_roles_track_credit_id_track_credits_id_fk",
+					"tableFrom": "track_credit_roles",
+					"tableTo": "track_credits",
+					"columnsFrom": ["track_credit_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_credit_roles_role_code_credit_roles_code_fk": {
+					"name": "track_credit_roles_role_code_credit_roles_code_fk",
+					"tableFrom": "track_credit_roles",
+					"tableTo": "credit_roles",
+					"columnsFrom": ["role_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"track_credit_roles_track_credit_id_role_code_role_position_pk": {
+					"name": "track_credit_roles_track_credit_id_role_code_role_position_pk",
+					"columns": ["track_credit_id", "role_code", "role_position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_credits": {
+			"name": "track_credits",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credit_name": {
+					"name": "credit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"alias_type_code": {
+					"name": "alias_type_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"credit_position": {
+					"name": "credit_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"artist_alias_id": {
+					"name": "artist_alias_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_credits_track": {
+					"name": "idx_track_credits_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_artist": {
+					"name": "idx_track_credits_artist",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_alias": {
+					"name": "idx_track_credits_alias",
+					"columns": [
+						{
+							"expression": "artist_alias_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_alias_type": {
+					"name": "idx_track_credits_alias_type",
+					"columns": [
+						{
+							"expression": "alias_type_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_track_artist": {
+					"name": "idx_track_credits_track_artist",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_artist_track": {
+					"name": "idx_track_credits_artist_track",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_credits_no_alias": {
+					"name": "uq_track_credits_no_alias",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"track_credits\".\"artist_alias_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_credits_with_alias": {
+					"name": "uq_track_credits_with_alias",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_alias_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"track_credits\".\"artist_alias_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_credits_track_id_tracks_id_fk": {
+					"name": "track_credits_track_id_tracks_id_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_credits_artist_id_artists_id_fk": {
+					"name": "track_credits_artist_id_artists_id_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "artists",
+					"columnsFrom": ["artist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				},
+				"track_credits_alias_type_code_alias_types_code_fk": {
+					"name": "track_credits_alias_type_code_alias_types_code_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "alias_types",
+					"columnsFrom": ["alias_type_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"track_credits_artist_alias_id_artist_aliases_id_fk": {
+					"name": "track_credits_artist_alias_id_artist_aliases_id_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "artist_aliases",
+					"columnsFrom": ["artist_alias_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracks": {
+			"name": "tracks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"disc_id": {
+					"name": "disc_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_number": {
+					"name": "track_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_year": {
+					"name": "release_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_month": {
+					"name": "release_month",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_day": {
+					"name": "release_day",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_id": {
+					"name": "event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_day_id": {
+					"name": "event_day_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_tracks_release": {
+					"name": "idx_tracks_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_disc": {
+					"name": "idx_tracks_disc",
+					"columns": [
+						{
+							"expression": "disc_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_date": {
+					"name": "idx_tracks_date",
+					"columns": [
+						{
+							"expression": "release_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_year": {
+					"name": "idx_tracks_year",
+					"columns": [
+						{
+							"expression": "release_year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_event": {
+					"name": "idx_tracks_event",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_event_day": {
+					"name": "idx_tracks_event_day",
+					"columns": [
+						{
+							"expression": "event_day_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_ordering": {
+					"name": "idx_tracks_ordering",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "disc_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_tracks_release_tracknumber": {
+					"name": "uq_tracks_release_tracknumber",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"tracks\".\"disc_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_tracks_disc_tracknumber": {
+					"name": "uq_tracks_disc_tracknumber",
+					"columns": [
+						{
+							"expression": "disc_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"tracks\".\"disc_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracks_release_id_releases_id_fk": {
+					"name": "tracks_release_id_releases_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracks_disc_id_discs_id_fk": {
+					"name": "tracks_disc_id_discs_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "discs",
+					"columnsFrom": ["disc_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracks_event_id_events_id_fk": {
+					"name": "tracks_event_id_events_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "events",
+					"columnsFrom": ["event_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"tracks_event_day_id_event_days_id_fk": {
+					"name": "tracks_event_day_id_event_days_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "event_days",
+					"columnsFrom": ["event_day_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_derivations": {
+			"name": "track_derivations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"child_track_id": {
+					"name": "child_track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"parent_track_id": {
+					"name": "parent_track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_derivations_child": {
+					"name": "idx_track_derivations_child",
+					"columns": [
+						{
+							"expression": "child_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_derivations_parent": {
+					"name": "idx_track_derivations_parent",
+					"columns": [
+						{
+							"expression": "parent_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_derivations": {
+					"name": "uq_track_derivations",
+					"columns": [
+						{
+							"expression": "child_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "parent_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_derivations_child_track_id_tracks_id_fk": {
+					"name": "track_derivations_child_track_id_tracks_id_fk",
+					"tableFrom": "track_derivations",
+					"tableTo": "tracks",
+					"columnsFrom": ["child_track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_derivations_parent_track_id_tracks_id_fk": {
+					"name": "track_derivations_parent_track_id_tracks_id_fk",
+					"tableFrom": "track_derivations",
+					"tableTo": "tracks",
+					"columnsFrom": ["parent_track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_official_songs": {
+			"name": "track_official_songs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"official_song_id": {
+					"name": "official_song_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"custom_song_name": {
+					"name": "custom_song_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"part_position": {
+					"name": "part_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_second": {
+					"name": "start_second",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"end_second": {
+					"name": "end_second",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_official_songs_track": {
+					"name": "idx_track_official_songs_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_official_songs_song": {
+					"name": "idx_track_official_songs_song",
+					"columns": [
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_official_songs": {
+					"name": "uq_track_official_songs",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "part_position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_official_songs_track_id_tracks_id_fk": {
+					"name": "track_official_songs_track_id_tracks_id_fk",
+					"tableFrom": "track_official_songs",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_official_songs_official_song_id_official_songs_id_fk": {
+					"name": "track_official_songs_official_song_id_official_songs_id_fk",
+					"tableFrom": "track_official_songs",
+					"tableTo": "official_songs",
+					"columnsFrom": ["official_song_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_collection_items": {
+			"name": "user_collection_items",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"collection_id": {
+					"name": "collection_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_type": {
+					"name": "target_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uq_user_collection_items_unique": {
+					"name": "uq_user_collection_items_unique",
+					"columns": [
+						{
+							"expression": "collection_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "target_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "target_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_user_collection_items_target": {
+					"name": "idx_user_collection_items_target",
+					"columns": [
+						{
+							"expression": "target_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "target_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_user_collection_items_position": {
+					"name": "idx_user_collection_items_position",
+					"columns": [
+						{
+							"expression": "collection_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"user_collection_items\".\"position\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_collection_items_collection_id_user_collections_id_fk": {
+					"name": "user_collection_items_collection_id_user_collections_id_fk",
+					"tableFrom": "user_collection_items",
+					"tableTo": "user_collections",
+					"columnsFrom": ["collection_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_user_collection_items_target_type": {
+					"name": "check_user_collection_items_target_type",
+					"value": "\"target_type\" IN ('circle','release','track')"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.user_collections": {
+			"name": "user_collections",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'collection'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"visibility": {
+					"name": "visibility",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'private'"
+				},
+				"ordered": {
+					"name": "ordered",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_default_liked": {
+					"name": "is_default_liked",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"short_id": {
+					"name": "short_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cover_image_url": {
+					"name": "cover_image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_user_collections_user_kind": {
+					"name": "idx_user_collections_user_kind",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_user_collections_default_liked": {
+					"name": "uq_user_collections_default_liked",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"user_collections\".\"is_default_liked\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_user_collections_short_id": {
+					"name": "uq_user_collections_short_id",
+					"columns": [
+						{
+							"expression": "short_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"user_collections\".\"short_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_collections_user_id_user_id_fk": {
+					"name": "user_collections_user_id_user_id_fk",
+					"tableFrom": "user_collections",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_user_collections_kind": {
+					"name": "check_user_collections_kind",
+					"value": "\"kind\" IN ('collection','playlist')"
+				},
+				"check_user_collections_visibility": {
+					"name": "check_user_collections_visibility",
+					"value": "\"visibility\" IN ('private','unlisted','public')"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/db/src/migrations/meta/0006_snapshot.json
+++ b/packages/db/src/migrations/meta/0006_snapshot.json
@@ -1,0 +1,5155 @@
+{
+	"id": "ee8035ca-e7b1-4f21-88dd-038c3c422b94",
+	"prevId": "02e480e9-dec7-4933-9307-1178921cede0",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.album_requests": {
+			"name": "album_requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_type": {
+					"name": "request_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"existing_release_id": {
+					"name": "existing_release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"circle_name": {
+					"name": "circle_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_urls": {
+					"name": "reference_urls",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"reviewed_by_user_id": {
+					"name": "reviewed_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reviewer_notes": {
+					"name": "reviewer_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reviewed_at": {
+					"name": "reviewed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_album_requests_user": {
+					"name": "idx_album_requests_user",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_existing_release": {
+					"name": "idx_album_requests_existing_release",
+					"columns": [
+						{
+							"expression": "existing_release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_status": {
+					"name": "idx_album_requests_status",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_created_at": {
+					"name": "idx_album_requests_created_at",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_status_created_at": {
+					"name": "idx_album_requests_status_created_at",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_album_requests_reviewed_by": {
+					"name": "idx_album_requests_reviewed_by",
+					"columns": [
+						{
+							"expression": "reviewed_by_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"album_requests_user_id_user_id_fk": {
+					"name": "album_requests_user_id_user_id_fk",
+					"tableFrom": "album_requests",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				},
+				"album_requests_existing_release_id_releases_id_fk": {
+					"name": "album_requests_existing_release_id_releases_id_fk",
+					"tableFrom": "album_requests",
+					"tableTo": "releases",
+					"columnsFrom": ["existing_release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"album_requests_reviewed_by_user_id_user_id_fk": {
+					"name": "album_requests_reviewed_by_user_id_user_id_fk",
+					"tableFrom": "album_requests",
+					"tableTo": "user",
+					"columnsFrom": ["reviewed_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_album_request_status": {
+					"name": "check_album_request_status",
+					"value": "status IN ('pending','approved','rejected')"
+				},
+				"check_album_request_type": {
+					"name": "check_album_request_type",
+					"value": "request_type IN ('new','existing')"
+				},
+				"check_album_request_type_consistency": {
+					"name": "check_album_request_type_consistency",
+					"value": "(request_type='existing' AND existing_release_id IS NOT NULL)\n        OR (request_type='new' AND album_name IS NOT NULL)"
+				},
+				"check_album_request_review_consistency": {
+					"name": "check_album_request_review_consistency",
+					"value": "(status='pending' AND reviewed_at IS NULL AND reviewed_by_user_id IS NULL)\n        OR (status<>'pending' AND reviewed_at IS NOT NULL AND reviewed_by_user_id IS NOT NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.artist_aliases": {
+			"name": "artist_aliases",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"alias_type_code": {
+					"name": "alias_type_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_initial": {
+					"name": "name_initial",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"initial_script": {
+					"name": "initial_script",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"period_from": {
+					"name": "period_from",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_to": {
+					"name": "period_to",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_artist_aliases_artist_id": {
+					"name": "idx_artist_aliases_artist_id",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artist_aliases_alias_type": {
+					"name": "idx_artist_aliases_alias_type",
+					"columns": [
+						{
+							"expression": "alias_type_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_artist_aliases_name": {
+					"name": "uq_artist_aliases_name",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artist_aliases_name_lower": {
+					"name": "idx_artist_aliases_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artist_aliases_name_trgm": {
+					"name": "idx_artist_aliases_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"artist_aliases_artist_id_artists_id_fk": {
+					"name": "artist_aliases_artist_id_artists_id_fk",
+					"tableFrom": "artist_aliases",
+					"tableTo": "artists",
+					"columnsFrom": ["artist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"artist_aliases_alias_type_code_alias_types_code_fk": {
+					"name": "artist_aliases_alias_type_code_alias_types_code_fk",
+					"tableFrom": "artist_aliases",
+					"tableTo": "alias_types",
+					"columnsFrom": ["alias_type_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.artists": {
+			"name": "artists",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_name": {
+					"name": "sort_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_initial": {
+					"name": "name_initial",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"initial_script": {
+					"name": "initial_script",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uq_artists_name": {
+					"name": "uq_artists_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_sort": {
+					"name": "idx_artists_sort",
+					"columns": [
+						{
+							"expression": "sort_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_initial": {
+					"name": "idx_artists_initial",
+					"columns": [
+						{
+							"expression": "name_initial",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "initial_script",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_name_lower": {
+					"name": "idx_artists_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_artists_name_trgm": {
+					"name": "idx_artists_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.circle_links": {
+			"name": "circle_links",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"circle_id": {
+					"name": "circle_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_id": {
+					"name": "platform_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"handle": {
+					"name": "handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_official": {
+					"name": "is_official",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_circle_links_circle_id": {
+					"name": "idx_circle_links_circle_id",
+					"columns": [
+						{
+							"expression": "circle_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circle_links_platform": {
+					"name": "idx_circle_links_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_circle_links_circle_url": {
+					"name": "uq_circle_links_circle_url",
+					"columns": [
+						{
+							"expression": "circle_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"circle_links_circle_id_circles_id_fk": {
+					"name": "circle_links_circle_id_circles_id_fk",
+					"tableFrom": "circle_links",
+					"tableTo": "circles",
+					"columnsFrom": ["circle_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"circle_links_platform_code_platforms_code_fk": {
+					"name": "circle_links_platform_code_platforms_code_fk",
+					"tableFrom": "circle_links",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.circles": {
+			"name": "circles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_name": {
+					"name": "sort_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_initial": {
+					"name": "name_initial",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"initial_script": {
+					"name": "initial_script",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uq_circles_name": {
+					"name": "uq_circles_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circles_initial": {
+					"name": "idx_circles_initial",
+					"columns": [
+						{
+							"expression": "name_initial",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "initial_script",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circles_name_lower": {
+					"name": "idx_circles_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_circles_name_trgm": {
+					"name": "idx_circles_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_circles_name_ja_trgm": {
+					"name": "idx_circles_name_ja_trgm",
+					"columns": [
+						{
+							"expression": "\"name_ja\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_circles_name_en_trgm": {
+					"name": "idx_circles_name_en_trgm",
+					"columns": [
+						{
+							"expression": "\"name_en\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"onboarding_completed": {
+					"name": "onboarding_completed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.event_days": {
+			"name": "event_days",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"event_id": {
+					"name": "event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"day_number": {
+					"name": "day_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_event_days_event_id": {
+					"name": "idx_event_days_event_id",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_days_date": {
+					"name": "idx_event_days_date",
+					"columns": [
+						{
+							"expression": "date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_event_days_event_day_number": {
+					"name": "uq_event_days_event_day_number",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "day_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_event_days_event_date": {
+					"name": "uq_event_days_event_date",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"event_days_event_id_events_id_fk": {
+					"name": "event_days_event_id_events_id_fk",
+					"tableFrom": "event_days",
+					"tableTo": "events",
+					"columnsFrom": ["event_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.event_series": {
+			"name": "event_series",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_event_series_name": {
+					"name": "idx_event_series_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_series_sort_order": {
+					"name": "idx_event_series_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_event_series_name": {
+					"name": "uq_event_series_name",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_series_name_lower": {
+					"name": "idx_event_series_name_lower",
+					"columns": [
+						{
+							"expression": "lower(\"name\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.events": {
+			"name": "events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"event_series_id": {
+					"name": "event_series_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"edition": {
+					"name": "edition",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_days": {
+					"name": "total_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"venue": {
+					"name": "venue",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_events_event_series_id": {
+					"name": "idx_events_event_series_id",
+					"columns": [
+						{
+							"expression": "event_series_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_events_edition": {
+					"name": "idx_events_edition",
+					"columns": [
+						{
+							"expression": "edition",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_events_start_date": {
+					"name": "idx_events_start_date",
+					"columns": [
+						{
+							"expression": "start_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_events_series_edition": {
+					"name": "uq_events_series_edition",
+					"columns": [
+						{
+							"expression": "event_series_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "edition",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"events_event_series_id_event_series_id_fk": {
+					"name": "events_event_series_id_event_series_id_fk",
+					"tableFrom": "events",
+					"tableTo": "event_series",
+					"columnsFrom": ["event_series_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.genres": {
+			"name": "genres",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"color": {
+					"name": "color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_genres_sort_order": {
+					"name": "idx_genres_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_genres": {
+			"name": "track_genres",
+			"schema": "",
+			"columns": {
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"genre_code": {
+					"name": "genre_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_genres_track": {
+					"name": "idx_track_genres_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_genres_genre": {
+					"name": "idx_track_genres_genre",
+					"columns": [
+						{
+							"expression": "genre_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_genres_track_position": {
+					"name": "idx_track_genres_track_position",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_genres_track_id_tracks_id_fk": {
+					"name": "track_genres_track_id_tracks_id_fk",
+					"tableFrom": "track_genres",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_genres_genre_code_genres_code_fk": {
+					"name": "track_genres_genre_code_genres_code_fk",
+					"tableFrom": "track_genres",
+					"tableTo": "genres",
+					"columnsFrom": ["genre_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"track_genres_track_id_genre_code_pk": {
+					"name": "track_genres_track_id_genre_code_pk",
+					"columns": ["track_id", "genre_code"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_track_genres_position": {
+					"name": "check_track_genres_position",
+					"value": "\"position\" >= 1 AND \"position\" <= 5"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.release_jan_codes": {
+			"name": "release_jan_codes",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"jan_code": {
+					"name": "jan_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"country_code": {
+					"name": "country_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_release_jan_codes_release": {
+					"name": "idx_release_jan_codes_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_release_jan_codes_jan": {
+					"name": "uq_release_jan_codes_jan",
+					"columns": [
+						{
+							"expression": "jan_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_release_jan_codes_primary": {
+					"name": "uq_release_jan_codes_primary",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"release_jan_codes\".\"is_primary\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"release_jan_codes_release_id_releases_id_fk": {
+					"name": "release_jan_codes_release_id_releases_id_fk",
+					"tableFrom": "release_jan_codes",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_isrcs": {
+			"name": "track_isrcs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"isrc": {
+					"name": "isrc",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_isrcs_track": {
+					"name": "idx_track_isrcs_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_isrcs": {
+					"name": "uq_track_isrcs",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "isrc",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_isrcs_primary": {
+					"name": "uq_track_isrcs_primary",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"track_isrcs\".\"is_primary\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_isrcs_track_id_tracks_id_fk": {
+					"name": "track_isrcs_track_id_tracks_id_fk",
+					"tableFrom": "track_isrcs",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.alias_types": {
+			"name": "alias_types",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_alias_types_sort_order": {
+					"name": "idx_alias_types_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.credit_roles": {
+			"name": "credit_roles",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_credit_roles_sort_order": {
+					"name": "idx_credit_roles_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_work_categories": {
+			"name": "official_work_categories",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_work_categories_sort_order": {
+					"name": "idx_official_work_categories_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.platforms": {
+			"name": "platforms",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url_pattern": {
+					"name": "url_pattern",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_platforms_category": {
+					"name": "idx_platforms_category",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_platforms_sort_order": {
+					"name": "idx_platforms_sort_order",
+					"columns": [
+						{
+							"expression": "sort_order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_song_links": {
+			"name": "official_song_links",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"official_song_id": {
+					"name": "official_song_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_song_links_song_id": {
+					"name": "idx_official_song_links_song_id",
+					"columns": [
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_song_links_platform": {
+					"name": "idx_official_song_links_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_official_song_links_song_url": {
+					"name": "uq_official_song_links_song_url",
+					"columns": [
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_song_links_official_song_id_official_songs_id_fk": {
+					"name": "official_song_links_official_song_id_official_songs_id_fk",
+					"tableFrom": "official_song_links",
+					"tableTo": "official_songs",
+					"columnsFrom": ["official_song_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"official_song_links_platform_code_platforms_code_fk": {
+					"name": "official_song_links_platform_code_platforms_code_fk",
+					"tableFrom": "official_song_links",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_songs": {
+			"name": "official_songs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"official_work_id": {
+					"name": "official_work_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_number": {
+					"name": "track_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"composer_name": {
+					"name": "composer_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"arranger_name": {
+					"name": "arranger_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_original": {
+					"name": "is_original",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"source_song_id": {
+					"name": "source_song_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_songs_work": {
+					"name": "idx_official_songs_work",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_songs_source": {
+					"name": "idx_official_songs_source",
+					"columns": [
+						{
+							"expression": "source_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_songs_work_original": {
+					"name": "idx_official_songs_work_original",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "is_original",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_songs_official_work_id_official_works_id_fk": {
+					"name": "official_songs_official_work_id_official_works_id_fk",
+					"tableFrom": "official_songs",
+					"tableTo": "official_works",
+					"columnsFrom": ["official_work_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_work_links": {
+			"name": "official_work_links",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"official_work_id": {
+					"name": "official_work_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_work_links_work_id": {
+					"name": "idx_official_work_links_work_id",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_work_links_platform": {
+					"name": "idx_official_work_links_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_official_work_links_work_url": {
+					"name": "uq_official_work_links_work_url",
+					"columns": [
+						{
+							"expression": "official_work_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_work_links_official_work_id_official_works_id_fk": {
+					"name": "official_work_links_official_work_id_official_works_id_fk",
+					"tableFrom": "official_work_links",
+					"tableTo": "official_works",
+					"columnsFrom": ["official_work_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"official_work_links_platform_code_platforms_code_fk": {
+					"name": "official_work_links_platform_code_platforms_code_fk",
+					"tableFrom": "official_work_links",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.official_works": {
+			"name": "official_works",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"category_code": {
+					"name": "category_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"short_name_ja": {
+					"name": "short_name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"short_name_en": {
+					"name": "short_name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"number_in_series": {
+					"name": "number_in_series",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"official_organization": {
+					"name": "official_organization",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_official_works_category": {
+					"name": "idx_official_works_category",
+					"columns": [
+						{
+							"expression": "category_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_works_release_date": {
+					"name": "idx_official_works_release_date",
+					"columns": [
+						{
+							"expression": "release_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_official_works_position": {
+					"name": "idx_official_works_position",
+					"columns": [
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"official_works_category_code_official_work_categories_code_fk": {
+					"name": "official_works_category_code_official_work_categories_code_fk",
+					"tableFrom": "official_works",
+					"tableTo": "official_work_categories",
+					"columnsFrom": ["category_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.release_publications": {
+			"name": "release_publications",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_release_publications_release": {
+					"name": "idx_release_publications_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_release_publications_platform": {
+					"name": "idx_release_publications_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_release_publications_url": {
+					"name": "uq_release_publications_url",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"release_publications_release_id_releases_id_fk": {
+					"name": "release_publications_release_id_releases_id_fk",
+					"tableFrom": "release_publications",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"release_publications_platform_code_platforms_code_fk": {
+					"name": "release_publications_platform_code_platforms_code_fk",
+					"tableFrom": "release_publications",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_publications": {
+			"name": "track_publications",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_code": {
+					"name": "platform_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_publications_track": {
+					"name": "idx_track_publications_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_publications_platform": {
+					"name": "idx_track_publications_platform",
+					"columns": [
+						{
+							"expression": "platform_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_publications_url": {
+					"name": "uq_track_publications_url",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_publications_track_id_tracks_id_fk": {
+					"name": "track_publications_track_id_tracks_id_fk",
+					"tableFrom": "track_publications",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_publications_platform_code_platforms_code_fk": {
+					"name": "track_publications_platform_code_platforms_code_fk",
+					"tableFrom": "track_publications",
+					"tableTo": "platforms",
+					"columnsFrom": ["platform_code"],
+					"columnsTo": ["code"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.discs": {
+			"name": "discs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"disc_number": {
+					"name": "disc_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"disc_name": {
+					"name": "disc_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_discs_release": {
+					"name": "idx_discs_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_discs_release_number": {
+					"name": "uq_discs_release_number",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "disc_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"discs_release_id_releases_id_fk": {
+					"name": "discs_release_id_releases_id_fk",
+					"tableFrom": "discs",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.release_circles": {
+			"name": "release_circles",
+			"schema": "",
+			"columns": {
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"circle_id": {
+					"name": "circle_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"participation_type": {
+					"name": "participation_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 1
+				}
+			},
+			"indexes": {
+				"idx_release_circles_release": {
+					"name": "idx_release_circles_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_release_circles_circle": {
+					"name": "idx_release_circles_circle",
+					"columns": [
+						{
+							"expression": "circle_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_release_circles_release_participation": {
+					"name": "idx_release_circles_release_participation",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "participation_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"release_circles_release_id_releases_id_fk": {
+					"name": "release_circles_release_id_releases_id_fk",
+					"tableFrom": "release_circles",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"release_circles_circle_id_circles_id_fk": {
+					"name": "release_circles_circle_id_circles_id_fk",
+					"tableFrom": "release_circles",
+					"tableTo": "circles",
+					"columnsFrom": ["circle_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"release_circles_release_id_circle_id_participation_type_pk": {
+					"name": "release_circles_release_id_circle_id_participation_type_pk",
+					"columns": ["release_id", "circle_id", "participation_type"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.releases": {
+			"name": "releases",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_year": {
+					"name": "release_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_month": {
+					"name": "release_month",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_day": {
+					"name": "release_day",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_type": {
+					"name": "release_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_id": {
+					"name": "event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_day_id": {
+					"name": "event_day_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_releases_date": {
+					"name": "idx_releases_date",
+					"columns": [
+						{
+							"expression": "release_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_year": {
+					"name": "idx_releases_year",
+					"columns": [
+						{
+							"expression": "release_year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_year_month": {
+					"name": "idx_releases_year_month",
+					"columns": [
+						{
+							"expression": "release_year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "release_month",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_type": {
+					"name": "idx_releases_type",
+					"columns": [
+						{
+							"expression": "release_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_event": {
+					"name": "idx_releases_event",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_event_day": {
+					"name": "idx_releases_event_day",
+					"columns": [
+						{
+							"expression": "event_day_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_releases_updated_at": {
+					"name": "idx_releases_updated_at",
+					"columns": [
+						{
+							"expression": "updated_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"releases_event_id_events_id_fk": {
+					"name": "releases_event_id_events_id_fk",
+					"tableFrom": "releases",
+					"tableTo": "events",
+					"columnsFrom": ["event_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"releases_event_day_id_event_days_id_fk": {
+					"name": "releases_event_day_id_event_days_id_fk",
+					"tableFrom": "releases",
+					"tableTo": "event_days",
+					"columnsFrom": ["event_day_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_release_year": {
+					"name": "check_release_year",
+					"value": "\"release_year\" >= 1900 AND \"release_year\" <= 2200"
+				},
+				"check_release_month": {
+					"name": "check_release_month",
+					"value": "\"release_month\" >= 1 AND \"release_month\" <= 12"
+				},
+				"check_release_day": {
+					"name": "check_release_day",
+					"value": "\"release_day\" >= 1 AND \"release_day\" <= 31"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.tags": {
+			"name": "tags",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attributes": {
+					"name": "attributes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_tags_attributes_gin": {
+					"name": "idx_tags_attributes_gin",
+					"columns": [
+						{
+							"expression": "attributes",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"tags_name_unique": {
+					"name": "tags_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_tags": {
+			"name": "track_tags",
+			"schema": "",
+			"columns": {
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tag_id": {
+					"name": "tag_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_locked": {
+					"name": "is_locked",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_tags_track": {
+					"name": "idx_track_tags_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_tags_tag": {
+					"name": "idx_track_tags_tag",
+					"columns": [
+						{
+							"expression": "tag_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_tags_track_locked_pos": {
+					"name": "idx_track_tags_track_locked_pos",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "is_locked",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_tags_track_id_tracks_id_fk": {
+					"name": "track_tags_track_id_tracks_id_fk",
+					"tableFrom": "track_tags",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_tags_tag_id_tags_id_fk": {
+					"name": "track_tags_tag_id_tags_id_fk",
+					"tableFrom": "track_tags",
+					"tableTo": "tags",
+					"columnsFrom": ["tag_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"track_tags_track_id_tag_id_pk": {
+					"name": "track_tags_track_id_tag_id_pk",
+					"columns": ["track_id", "tag_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_track_tags_position": {
+					"name": "check_track_tags_position",
+					"value": "\"position\" >= 1 AND \"position\" <= 15"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.track_credit_roles": {
+			"name": "track_credit_roles",
+			"schema": "",
+			"columns": {
+				"track_credit_id": {
+					"name": "track_credit_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role_code": {
+					"name": "role_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role_position": {
+					"name": "role_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				}
+			},
+			"indexes": {
+				"idx_track_credit_roles_credit": {
+					"name": "idx_track_credit_roles_credit",
+					"columns": [
+						{
+							"expression": "track_credit_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credit_roles_role": {
+					"name": "idx_track_credit_roles_role",
+					"columns": [
+						{
+							"expression": "role_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credit_roles_composite": {
+					"name": "idx_track_credit_roles_composite",
+					"columns": [
+						{
+							"expression": "track_credit_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "role_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_credit_roles_track_credit_id_track_credits_id_fk": {
+					"name": "track_credit_roles_track_credit_id_track_credits_id_fk",
+					"tableFrom": "track_credit_roles",
+					"tableTo": "track_credits",
+					"columnsFrom": ["track_credit_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_credit_roles_role_code_credit_roles_code_fk": {
+					"name": "track_credit_roles_role_code_credit_roles_code_fk",
+					"tableFrom": "track_credit_roles",
+					"tableTo": "credit_roles",
+					"columnsFrom": ["role_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"track_credit_roles_track_credit_id_role_code_role_position_pk": {
+					"name": "track_credit_roles_track_credit_id_role_code_role_position_pk",
+					"columns": ["track_credit_id", "role_code", "role_position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_credits": {
+			"name": "track_credits",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credit_name": {
+					"name": "credit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"alias_type_code": {
+					"name": "alias_type_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"credit_position": {
+					"name": "credit_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"artist_alias_id": {
+					"name": "artist_alias_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_credits_track": {
+					"name": "idx_track_credits_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_artist": {
+					"name": "idx_track_credits_artist",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_alias": {
+					"name": "idx_track_credits_alias",
+					"columns": [
+						{
+							"expression": "artist_alias_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_alias_type": {
+					"name": "idx_track_credits_alias_type",
+					"columns": [
+						{
+							"expression": "alias_type_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_track_artist": {
+					"name": "idx_track_credits_track_artist",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_credits_artist_track": {
+					"name": "idx_track_credits_artist_track",
+					"columns": [
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_credits_no_alias": {
+					"name": "uq_track_credits_no_alias",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"track_credits\".\"artist_alias_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_credits_with_alias": {
+					"name": "uq_track_credits_with_alias",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "artist_alias_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"track_credits\".\"artist_alias_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_credits_track_id_tracks_id_fk": {
+					"name": "track_credits_track_id_tracks_id_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_credits_artist_id_artists_id_fk": {
+					"name": "track_credits_artist_id_artists_id_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "artists",
+					"columnsFrom": ["artist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				},
+				"track_credits_alias_type_code_alias_types_code_fk": {
+					"name": "track_credits_alias_type_code_alias_types_code_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "alias_types",
+					"columnsFrom": ["alias_type_code"],
+					"columnsTo": ["code"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"track_credits_artist_alias_id_artist_aliases_id_fk": {
+					"name": "track_credits_artist_alias_id_artist_aliases_id_fk",
+					"tableFrom": "track_credits",
+					"tableTo": "artist_aliases",
+					"columnsFrom": ["artist_alias_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracks": {
+			"name": "tracks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"release_id": {
+					"name": "release_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"disc_id": {
+					"name": "disc_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_number": {
+					"name": "track_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name_ja": {
+					"name": "name_ja",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name_en": {
+					"name": "name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_year": {
+					"name": "release_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_month": {
+					"name": "release_month",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_day": {
+					"name": "release_day",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_id": {
+					"name": "event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_day_id": {
+					"name": "event_day_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_tracks_release": {
+					"name": "idx_tracks_release",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_disc": {
+					"name": "idx_tracks_disc",
+					"columns": [
+						{
+							"expression": "disc_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_date": {
+					"name": "idx_tracks_date",
+					"columns": [
+						{
+							"expression": "release_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_year": {
+					"name": "idx_tracks_year",
+					"columns": [
+						{
+							"expression": "release_year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_event": {
+					"name": "idx_tracks_event",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_event_day": {
+					"name": "idx_tracks_event_day",
+					"columns": [
+						{
+							"expression": "event_day_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_tracks_ordering": {
+					"name": "idx_tracks_ordering",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "disc_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_tracks_release_tracknumber": {
+					"name": "uq_tracks_release_tracknumber",
+					"columns": [
+						{
+							"expression": "release_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"tracks\".\"disc_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_tracks_disc_tracknumber": {
+					"name": "uq_tracks_disc_tracknumber",
+					"columns": [
+						{
+							"expression": "disc_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "track_number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"tracks\".\"disc_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracks_release_id_releases_id_fk": {
+					"name": "tracks_release_id_releases_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "releases",
+					"columnsFrom": ["release_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracks_disc_id_discs_id_fk": {
+					"name": "tracks_disc_id_discs_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "discs",
+					"columnsFrom": ["disc_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracks_event_id_events_id_fk": {
+					"name": "tracks_event_id_events_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "events",
+					"columnsFrom": ["event_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"tracks_event_day_id_event_days_id_fk": {
+					"name": "tracks_event_day_id_event_days_id_fk",
+					"tableFrom": "tracks",
+					"tableTo": "event_days",
+					"columnsFrom": ["event_day_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_derivations": {
+			"name": "track_derivations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"child_track_id": {
+					"name": "child_track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"parent_track_id": {
+					"name": "parent_track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_derivations_child": {
+					"name": "idx_track_derivations_child",
+					"columns": [
+						{
+							"expression": "child_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_derivations_parent": {
+					"name": "idx_track_derivations_parent",
+					"columns": [
+						{
+							"expression": "parent_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_derivations": {
+					"name": "uq_track_derivations",
+					"columns": [
+						{
+							"expression": "child_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "parent_track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_derivations_child_track_id_tracks_id_fk": {
+					"name": "track_derivations_child_track_id_tracks_id_fk",
+					"tableFrom": "track_derivations",
+					"tableTo": "tracks",
+					"columnsFrom": ["child_track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_derivations_parent_track_id_tracks_id_fk": {
+					"name": "track_derivations_parent_track_id_tracks_id_fk",
+					"tableFrom": "track_derivations",
+					"tableTo": "tracks",
+					"columnsFrom": ["parent_track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track_official_songs": {
+			"name": "track_official_songs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"official_song_id": {
+					"name": "official_song_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"custom_song_name": {
+					"name": "custom_song_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"part_position": {
+					"name": "part_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_second": {
+					"name": "start_second",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"end_second": {
+					"name": "end_second",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_track_official_songs_track": {
+					"name": "idx_track_official_songs_track",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_track_official_songs_song": {
+					"name": "idx_track_official_songs_song",
+					"columns": [
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_track_official_songs": {
+					"name": "uq_track_official_songs",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "official_song_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "part_position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_official_songs_track_id_tracks_id_fk": {
+					"name": "track_official_songs_track_id_tracks_id_fk",
+					"tableFrom": "track_official_songs",
+					"tableTo": "tracks",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"track_official_songs_official_song_id_official_songs_id_fk": {
+					"name": "track_official_songs_official_song_id_official_songs_id_fk",
+					"tableFrom": "track_official_songs",
+					"tableTo": "official_songs",
+					"columnsFrom": ["official_song_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_collection_items": {
+			"name": "user_collection_items",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"collection_id": {
+					"name": "collection_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_type": {
+					"name": "target_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uq_user_collection_items_unique": {
+					"name": "uq_user_collection_items_unique",
+					"columns": [
+						{
+							"expression": "collection_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "target_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "target_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_user_collection_items_target": {
+					"name": "idx_user_collection_items_target",
+					"columns": [
+						{
+							"expression": "target_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "target_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_user_collection_items_position": {
+					"name": "idx_user_collection_items_position",
+					"columns": [
+						{
+							"expression": "collection_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"user_collection_items\".\"position\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_collection_items_collection_id_user_collections_id_fk": {
+					"name": "user_collection_items_collection_id_user_collections_id_fk",
+					"tableFrom": "user_collection_items",
+					"tableTo": "user_collections",
+					"columnsFrom": ["collection_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_user_collection_items_target_type": {
+					"name": "check_user_collection_items_target_type",
+					"value": "\"target_type\" IN ('circle','release','track','artist')"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.user_collections": {
+			"name": "user_collections",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'collection'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"visibility": {
+					"name": "visibility",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'private'"
+				},
+				"ordered": {
+					"name": "ordered",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_default_liked": {
+					"name": "is_default_liked",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"item_type": {
+					"name": "item_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"short_id": {
+					"name": "short_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cover_image_url": {
+					"name": "cover_image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_user_collections_user_kind": {
+					"name": "idx_user_collections_user_kind",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_user_collections_default_liked": {
+					"name": "uq_user_collections_default_liked",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"user_collections\".\"is_default_liked\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uq_user_collections_short_id": {
+					"name": "uq_user_collections_short_id",
+					"columns": [
+						{
+							"expression": "short_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"user_collections\".\"short_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_collections_user_id_user_id_fk": {
+					"name": "user_collections_user_id_user_id_fk",
+					"tableFrom": "user_collections",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"check_user_collections_kind": {
+					"name": "check_user_collections_kind",
+					"value": "\"kind\" IN ('collection','playlist')"
+				},
+				"check_user_collections_visibility": {
+					"name": "check_user_collections_visibility",
+					"value": "\"visibility\" IN ('private','unlisted','public')"
+				},
+				"check_user_collections_item_type": {
+					"name": "check_user_collections_item_type",
+					"value": "\"item_type\" IS NULL OR \"item_type\" IN ('track','release','circle','artist')"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
 			"when": 1777256960048,
 			"tag": "0005_wakeful_clint_barton",
 			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1777470324843,
+			"tag": "0006_organic_epoch",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1777213613998,
 			"tag": "0004_great_beast",
 			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1777256960048,
+			"tag": "0005_wakeful_clint_barton",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -23,3 +23,5 @@ export * from "./track";
 export * from "./track.validation";
 export * from "./track-relations";
 export * from "./track-relations.validation";
+export * from "./user-collection";
+export * from "./user-collection.validation";

--- a/packages/db/src/schema/user-collection.ts
+++ b/packages/db/src/schema/user-collection.ts
@@ -25,9 +25,18 @@ export const COLLECTION_ITEM_TARGET_TYPES = [
 	"circle",
 	"release",
 	"track",
+	"artist",
 ] as const;
 export type CollectionItemTargetType =
 	(typeof COLLECTION_ITEM_TARGET_TYPES)[number];
+
+export const COLLECTION_ITEM_TYPES = [
+	"track",
+	"release",
+	"circle",
+	"artist",
+] as const;
+export type CollectionItemType = (typeof COLLECTION_ITEM_TYPES)[number];
 
 export const userCollections = pgTable(
 	"user_collections",
@@ -42,6 +51,7 @@ export const userCollections = pgTable(
 		visibility: text("visibility").notNull().default("private"),
 		ordered: boolean("ordered").notNull().default(false),
 		isDefaultLiked: boolean("is_default_liked").notNull().default(false),
+		itemType: text("item_type"),
 		shortId: text("short_id"),
 		coverImageUrl: text("cover_image_url"),
 		createdAt: timestamp("created_at", { withTimezone: true })
@@ -67,6 +77,10 @@ export const userCollections = pgTable(
 		check(
 			"check_user_collections_visibility",
 			sql`"visibility" IN ('private','unlisted','public')`,
+		),
+		check(
+			"check_user_collections_item_type",
+			sql`"item_type" IS NULL OR "item_type" IN ('track','release','circle','artist')`,
 		),
 	],
 );
@@ -101,7 +115,7 @@ export const userCollectionItems = pgTable(
 			.where(sql`${table.position} IS NOT NULL`),
 		check(
 			"check_user_collection_items_target_type",
-			sql`"target_type" IN ('circle','release','track')`,
+			sql`"target_type" IN ('circle','release','track','artist')`,
 		),
 	],
 );

--- a/packages/db/src/schema/user-collection.ts
+++ b/packages/db/src/schema/user-collection.ts
@@ -1,0 +1,131 @@
+import { type InferSelectModel, relations, sql } from "drizzle-orm";
+import {
+	boolean,
+	check,
+	index,
+	integer,
+	pgTable,
+	text,
+	timestamp,
+	uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const COLLECTION_KINDS = ["collection", "playlist"] as const;
+export type CollectionKind = (typeof COLLECTION_KINDS)[number];
+
+export const COLLECTION_VISIBILITIES = [
+	"private",
+	"unlisted",
+	"public",
+] as const;
+export type CollectionVisibility = (typeof COLLECTION_VISIBILITIES)[number];
+
+export const COLLECTION_ITEM_TARGET_TYPES = [
+	"circle",
+	"release",
+	"track",
+] as const;
+export type CollectionItemTargetType =
+	(typeof COLLECTION_ITEM_TARGET_TYPES)[number];
+
+export const userCollections = pgTable(
+	"user_collections",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		kind: text("kind").notNull().default("collection"),
+		name: text("name").notNull(),
+		description: text("description"),
+		visibility: text("visibility").notNull().default("private"),
+		ordered: boolean("ordered").notNull().default(false),
+		isDefaultLiked: boolean("is_default_liked").notNull().default(false),
+		shortId: text("short_id"),
+		coverImageUrl: text("cover_image_url"),
+		createdAt: timestamp("created_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.defaultNow()
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => [
+		index("idx_user_collections_user_kind").on(table.userId, table.kind),
+		uniqueIndex("uq_user_collections_default_liked")
+			.on(table.userId)
+			.where(sql`${table.isDefaultLiked} = true`),
+		uniqueIndex("uq_user_collections_short_id")
+			.on(table.shortId)
+			.where(sql`${table.shortId} IS NOT NULL`),
+		check(
+			"check_user_collections_kind",
+			sql`"kind" IN ('collection','playlist')`,
+		),
+		check(
+			"check_user_collections_visibility",
+			sql`"visibility" IN ('private','unlisted','public')`,
+		),
+	],
+);
+
+export const userCollectionItems = pgTable(
+	"user_collection_items",
+	{
+		id: text("id").primaryKey(),
+		collectionId: text("collection_id")
+			.notNull()
+			.references(() => userCollections.id, { onDelete: "cascade" }),
+		targetType: text("target_type").notNull(),
+		targetId: text("target_id").notNull(),
+		position: integer("position"),
+		note: text("note"),
+		addedAt: timestamp("added_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+	},
+	(table) => [
+		uniqueIndex("uq_user_collection_items_unique").on(
+			table.collectionId,
+			table.targetType,
+			table.targetId,
+		),
+		index("idx_user_collection_items_target").on(
+			table.targetType,
+			table.targetId,
+		),
+		index("idx_user_collection_items_position")
+			.on(table.collectionId, table.position)
+			.where(sql`${table.position} IS NOT NULL`),
+		check(
+			"check_user_collection_items_target_type",
+			sql`"target_type" IN ('circle','release','track')`,
+		),
+	],
+);
+
+export const userCollectionsRelations = relations(
+	userCollections,
+	({ one, many }) => ({
+		user: one(user, {
+			fields: [userCollections.userId],
+			references: [user.id],
+		}),
+		items: many(userCollectionItems),
+	}),
+);
+
+export const userCollectionItemsRelations = relations(
+	userCollectionItems,
+	({ one }) => ({
+		collection: one(userCollections, {
+			fields: [userCollectionItems.collectionId],
+			references: [userCollections.id],
+		}),
+	}),
+);
+
+export type UserCollection = InferSelectModel<typeof userCollections>;
+export type UserCollectionItem = InferSelectModel<typeof userCollectionItems>;

--- a/packages/db/src/schema/user-collection.validation.ts
+++ b/packages/db/src/schema/user-collection.validation.ts
@@ -1,0 +1,80 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import {
+	COLLECTION_ITEM_TARGET_TYPES,
+	COLLECTION_KINDS,
+	COLLECTION_VISIBILITIES,
+	userCollectionItems,
+	userCollections,
+} from "./user-collection";
+
+const collectionNameSchema = z
+	.string()
+	.trim()
+	.min(1, "コレクション名は必須です")
+	.max(100, "コレクション名は100文字以内で入力してください");
+
+const collectionDescriptionSchema = z
+	.string()
+	.trim()
+	.max(500, "説明は500文字以内で入力してください");
+
+const itemNoteSchema = z
+	.string()
+	.trim()
+	.max(280, "メモは280文字以内で入力してください");
+
+export const createUserCollectionSchema = z.object({
+	name: collectionNameSchema,
+	description: collectionDescriptionSchema.optional().nullable(),
+	kind: z.enum(COLLECTION_KINDS).optional().default("collection"),
+	visibility: z.enum(COLLECTION_VISIBILITIES).optional().default("private"),
+	ordered: z.boolean().optional().default(false),
+});
+
+export const updateUserCollectionSchema = z.object({
+	name: collectionNameSchema.optional(),
+	description: collectionDescriptionSchema.optional().nullable(),
+	visibility: z.enum(COLLECTION_VISIBILITIES).optional(),
+	ordered: z.boolean().optional(),
+});
+
+export const addUserCollectionItemSchema = z.object({
+	targetType: z.enum(COLLECTION_ITEM_TARGET_TYPES),
+	targetId: z.string().trim().min(1, "対象IDは必須です"),
+	note: itemNoteSchema.optional().nullable(),
+});
+
+export const reorderUserCollectionItemsSchema = z.object({
+	items: z
+		.array(
+			z.object({
+				itemId: z.string().min(1),
+				position: z.number().int().min(0),
+			}),
+		)
+		.min(1, "並び替え対象が空です"),
+});
+
+export const likeTargetSchema = z.object({
+	targetType: z.enum(COLLECTION_ITEM_TARGET_TYPES),
+	targetId: z.string().trim().min(1),
+});
+
+export const selectUserCollectionSchema = createSelectSchema(userCollections);
+export const selectUserCollectionItemSchema =
+	createSelectSchema(userCollectionItems);
+
+export type CreateUserCollectionInput = z.infer<
+	typeof createUserCollectionSchema
+>;
+export type UpdateUserCollectionInput = z.infer<
+	typeof updateUserCollectionSchema
+>;
+export type AddUserCollectionItemInput = z.infer<
+	typeof addUserCollectionItemSchema
+>;
+export type ReorderUserCollectionItemsInput = z.infer<
+	typeof reorderUserCollectionItemsSchema
+>;
+export type LikeTargetInput = z.infer<typeof likeTargetSchema>;

--- a/packages/db/src/schema/user-collection.validation.ts
+++ b/packages/db/src/schema/user-collection.validation.ts
@@ -39,6 +39,7 @@ export const updateUserCollectionSchema = z.object({
 	description: collectionDescriptionSchema.optional().nullable(),
 	visibility: z.enum(COLLECTION_VISIBILITIES).optional(),
 	ordered: z.boolean().optional(),
+	itemType: z.enum(COLLECTION_ITEM_TYPES).optional().nullable(),
 });
 
 export const addUserCollectionItemSchema = z.object({

--- a/packages/db/src/schema/user-collection.validation.ts
+++ b/packages/db/src/schema/user-collection.validation.ts
@@ -2,6 +2,7 @@ import { createSelectSchema } from "drizzle-zod";
 import { z } from "zod";
 import {
 	COLLECTION_ITEM_TARGET_TYPES,
+	COLLECTION_ITEM_TYPES,
 	COLLECTION_KINDS,
 	COLLECTION_VISIBILITIES,
 	userCollectionItems,
@@ -30,6 +31,7 @@ export const createUserCollectionSchema = z.object({
 	kind: z.enum(COLLECTION_KINDS).optional().default("collection"),
 	visibility: z.enum(COLLECTION_VISIBILITIES).optional().default("private"),
 	ordered: z.boolean().optional().default(false),
+	itemType: z.enum(COLLECTION_ITEM_TYPES).optional().nullable(),
 });
 
 export const updateUserCollectionSchema = z.object({

--- a/packages/db/src/utils/id.ts
+++ b/packages/db/src/utils/id.ts
@@ -22,4 +22,6 @@ export const createId = {
 	officialSongLink: () => typeid("sl").toString(),
 	tag: () => typeid("tag").toString(),
 	albumRequest: () => typeid("aq").toString(),
+	userCollection: () => typeid("uc").toString(),
+	userCollectionItem: () => typeid("uci").toString(),
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,9 @@ importers:
       drizzle-zod:
         specifier: ^0.8.3
         version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.5)(kysely@0.28.17)(postgres@3.4.9))(zod@4.4.3)
+      nanoid:
+        specifier: 'catalog:'
+        version: 5.1.11
       postgres:
         specifier: 'catalog:'
         version: 3.4.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,15 @@ settings:
 
 catalogs:
   default:
+    '@dnd-kit/core':
+      specifier: ^6.3.1
+      version: 6.3.1
+    '@dnd-kit/sortable':
+      specifier: ^10.0.0
+      version: 10.0.0
+    '@dnd-kit/utilities':
+      specifier: ^3.2.2
+      version: 3.2.2
     '@electric-sql/pglite':
       specifier: ^0.4.4
       version: 0.4.5
@@ -163,6 +172,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: 'catalog:'
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/sortable':
+        specifier: 'catalog:'
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities':
+        specifier: 'catalog:'
+        version: 3.2.2(react@19.2.5)
       '@nivo/bar':
         specifier: ^0.99.0
         version: 0.99.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,9 @@ catalog:
   postgres: ^3.4.9
   "@electric-sql/pglite": ^0.4.4
   nanoid: ^5.1.9
+  "@dnd-kit/core": ^6.3.1
+  "@dnd-kit/sortable": ^10.0.0
+  "@dnd-kit/utilities": ^3.2.2
 
 minimumReleaseAge: 1440
 blockExoticSubdeps: true


### PR DESCRIPTION
## 概要

`docs/specs/user-features/README.md` の Phase 1（基礎データ層）を実装。ユーザーがサークル / アルバム / 楽曲を「お気に入り」「コレクション」として保存・管理でき、コレクション内のアイテムをドラッグ&ドロップで並び替えできるようにする。

## 変更内容

### DB スキーマ
- `user_collections` テーブル新設（kind=collection|playlist の CHECK 制約、is_default_liked の部分ユニーク制約、short_id の部分ユニーク制約）
- `user_collection_items` テーブル新設（target_type=circle|release|track の論理参照、(collection_id, target_type, target_id) のユニーク制約）
- typeid: `uc` (userCollection) / `uci` (userCollectionItem) を追加
- `nanoid` を依存追加（short_id 採番用 8 文字）

### Server API（`/api/user/*` + `/api/public/*`）
- `GET/POST /api/user/collections` 一覧・新規作成（最大 100 件/ユーザーの上限チェック）
- `GET/PATCH/DELETE /api/user/collections/:id` 詳細・更新・削除（is_default_liked=true は削除禁止 / 403）
- `POST/DELETE /api/user/collections/:id/items` アイテム追加・削除（最大 1000 件/コレクション、target エンティティ存在検証）
- `PATCH /api/user/collections/:id/items/reorder` DnD 並び替え一括更新（トランザクション + 連番チェック、ordered=false なら 422）
- `POST/DELETE /api/user/likes` ♥ ショートカット（default_liked の lazy 作成 + idempotent + SELECT FOR UPDATE で同時押下耐性）
- `GET /api/user/likes/check?items=type:id,...` 一括 like チェック（一覧画面の N+1 回避、200 件上限）
- `GET /api/public/collections/:short_id` unlisted/public な公開閲覧（private は 404 で隠蔽）

### Web UI
- `/user/collections`（一覧、カード形式、Liked バッジ）
- `/user/collections/$id`（詳細・編集ダイアログ・アイテム削除・**DnD 並び替え（@dnd-kit）**）
- `/user/collections/new`（新規作成、visibility は private 固定、ordered 切替可）
- `/user/likes`（default_liked へリダイレクト、無ければ空状態表示）
- 楽曲・アルバム・サークルの公開詳細ページに `LikeActions`（♥ボタン + コレクション追加ドロップダウン）を設置
- 未ログイン時は `/login?returnTo=現在ページ` にリダイレクト
- サイドバーに「コレクション」「お気に入り」を追加

### 共通コンポーネント / ライブラリ
- `LikeButton`（楽観的更新 + 未ログイン誘導）
- `AddToCollectionDropdown`（既存コレクション選択 + 新規作成導線）
- `SortableCollectionItems`（@dnd-kit ベース、playlist でも再利用予定）
- `userCollectionsApi` / `userLikesApi`（API クライアント）
- queryOptions / mutation factory（TanStack Query）

## 影響範囲

- **既存テーブル無改変**: 新規テーブル追加のみで、既存スキーマには影響なし
- **既存 API 無改変**: `/api/user/album-requests` 等の既存エンドポイントには触れていない
- **公開詳細ページにアイコン追加**: `tracks_.$id` / `releases_.$id` / `circles_.$id` の `EntityDetailHeader` に LikeActions を 1 ノード差し込むのみ
- **依存追加**: `nanoid`（packages/db）、`@dnd-kit/core` `@dnd-kit/sortable` `@dnd-kit/utilities`（apps/web）

## 補足事項

### 仕様書からの主な実装判断

- `target_type` は仕様書の `'album'` ではなく **`'release'`** を採用（DB エンティティ名 `releases` と整合、UI ラベルは「アルバム」のまま）
- collection でも `ordered=true` を許可し、@dnd-kit による DnD 並び替えを Phase 1 で提供（仕様書では Phase 2 の playlist 機能予定だったが、ユーザー要望で前倒し）。`SortableCollectionItems` は playlist でも再利用可能な汎用設計
- Liked コレクションは初回 ♥ 押下時に lazy 作成。トランザクション内 `SELECT FOR UPDATE` + `ON CONFLICT DO NOTHING` で同時押下時の二重作成を防止
- `/api/user/likes` は idempotent（重複追加でも 201、未追加削除でも 204）。厳格な 409 重複エラーは `/api/user/collections/:id/items` 側で発生
- private コレクションへの不正アクセスは 404 で返す（情報漏洩防止）

### スコープ外（後続 PR）

仕様書の以下は本 PR には含めない:

- Phase 2: プレイリスト本格対応 / 公開プレイリスト一覧 / SNS 共有 / OG 画像 / sitemap-playlists
- Phase 3: ユーザー統計 / プレイリスト統計
- 横断: content_reports（モデレーション）/ orphan cleanup ジョブ / 通知システム

### 動作検証

- `devbox run check-types` ✅
- `devbox run check`（Biome）✅
- `make db-push` 成功（マイグレーション `0005_wakeful_clint_barton.sql`）

### テスト備考

`apps/web/src/hooks/use-unsaved-changes-guard.test.ts` 等で `ReferenceError: document is not defined` の既存失敗が 33 件あるが、本 PR では当該フックには触れていない（DOM 環境未設定の既存課題）。
